### PR TITLE
feat: replace menu with persistent sidebar (feature parity)

### DIFF
--- a/.claspignore
+++ b/.claspignore
@@ -4,6 +4,7 @@
 **/**
 !appsscript.json
 !**/*.js
+!**/*.html
 
 # Exclude source maps and type declarations from the push
 **/*.js.map

--- a/__tests__/menu.test.ts
+++ b/__tests__/menu.test.ts
@@ -1,42 +1,49 @@
 /**
- * Tests for src/server/index.ts (Menu related functions)
+ * Tests for src/server/index.ts (Menu and sidebar functions)
  */
 
 // ── Mock globals BEFORE imports ────────────────────────────────
 
-const mockAddItem = jest.fn().mockReturnThis(); // This allows chaining
-const mockAddSeparator = jest.fn().mockReturnThis();
+const mockAddItem = jest.fn().mockReturnThis();
 const mockAddToUi = jest.fn();
 const mockMenu = {
   addItem: mockAddItem,
-  addSeparator: mockAddSeparator,
   addToUi: mockAddToUi,
 };
 const mockCreateMenu = jest.fn().mockReturnValue(mockMenu);
-const mockShowModalDialog = jest.fn(); // Mock for showModalDialog
+const mockShowModalDialog = jest.fn();
+const mockShowSidebarFn = jest.fn();
 const mockUi = {
   createMenu: mockCreateMenu,
-  showModalDialog: mockShowModalDialog, // Added this
+  showModalDialog: mockShowModalDialog,
+  showSidebar: mockShowSidebarFn,
 };
 const mockSpreadsheetApp = {
   getUi: jest.fn().mockReturnValue(mockUi),
 };
 
+const mockEvaluate = jest.fn().mockReturnValue({
+  setTitle: jest.fn().mockReturnThis(),
+  setWidth: jest.fn().mockReturnThis(),
+});
+const mockCreateTemplateFromFile = jest.fn().mockReturnValue({
+  evaluate: mockEvaluate,
+});
 const mockCreateHtmlOutput = jest.fn().mockReturnValue({
-  // Mock methods that return 'this' for chaining
   setWidth: jest.fn().mockReturnThis(),
   setHeight: jest.fn().mockReturnThis(),
 });
 const mockHtmlService = {
   createHtmlOutput: mockCreateHtmlOutput,
+  createTemplateFromFile: mockCreateTemplateFromFile,
 };
 
 (globalThis as any).SpreadsheetApp = mockSpreadsheetApp;
-(globalThis as any).HtmlService = mockHtmlService; // Mock HtmlService
+(globalThis as any).HtmlService = mockHtmlService;
 
 // ── Import after mocks ─────────────────────────────────────────
 
-import { onOpen, openQuickstartDoc } from "../src/server/index"; // Import openQuickstartDoc
+import { onOpen, showSidebar, runTool } from "../src/server/index";
 
 // ── Tests ──────────────────────────────────────────────────────
 
@@ -45,41 +52,47 @@ describe("onOpen", () => {
     jest.clearAllMocks();
   });
 
-  it("should create an 'SSI Toolkit' menu", () => {
+  it("creates a menu named '⚡ SSI Toolkit'", () => {
     onOpen();
-    expect(mockSpreadsheetApp.getUi).toHaveBeenCalledTimes(1);
-    expect(mockCreateMenu).toHaveBeenCalledWith("⚡ SSI Tools");
+    expect(mockCreateMenu).toHaveBeenCalledWith("⚡ SSI Toolkit");
   });
 
-  it("should add '0. Quickstart' as the first menu item", () => {
+  it("adds a single item that opens the sidebar", () => {
     onOpen();
-    expect(mockAddItem).toHaveBeenNthCalledWith(1, "0. Quickstart", "openQuickstartDoc");
+    expect(mockAddItem).toHaveBeenCalledTimes(1);
+    expect(mockAddItem).toHaveBeenCalledWith("🚀 Open SSI Sidebar", "showSidebar");
   });
 
-  it("should add the menu to the UI", () => {
+  it("adds the menu to the UI", () => {
     onOpen();
     expect(mockAddToUi).toHaveBeenCalledTimes(1);
   });
 });
 
-describe("openQuickstartDoc", () => {
+describe("showSidebar", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("should open the quickstart document in a new tab", () => {
-    openQuickstartDoc();
+  it("loads the sidebar from the 'Sidebar' template file", () => {
+    showSidebar();
+    expect(mockCreateTemplateFromFile).toHaveBeenCalledWith("Sidebar");
+  });
 
-    // Expect HtmlService.createHtmlOutput to be called with specific content
-    expect(mockCreateHtmlOutput).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "window.open('https://docs.google.com/document/d/1BQJzBHiE6L0hvU6NMD0jaQE71VWRpWH-vNQu3UtGjBA/edit?usp=sharing', '_blank');google.script.host.close();",
-      ),
-    );
+  it("evaluates the template and shows the sidebar", () => {
+    showSidebar();
+    expect(mockEvaluate).toHaveBeenCalledTimes(1);
+    expect(mockShowSidebarFn).toHaveBeenCalledTimes(1);
+  });
+});
 
-    // Expect showModalDialog to be called
-    expect(mockShowModalDialog).toHaveBeenCalledTimes(1);
-    expect(mockCreateHtmlOutput().setWidth).toHaveBeenCalledWith(10); // Check for arbitrary width
-    expect(mockCreateHtmlOutput().setHeight).toHaveBeenCalledWith(10); // Check for arbitrary height
+describe("runTool", () => {
+  it("dispatches 'importDriveLinks' without throwing", () => {
+    // importDriveLinks calls SpreadsheetApp.getUi() — already mocked above
+    expect(() => runTool("importDriveLinks")).not.toThrow();
+  });
+
+  it("throws for an unknown function name", () => {
+    expect(() => runTool("doesNotExist")).toThrow("Function not found: doesNotExist");
   });
 });

--- a/__tests__/menu.test.ts
+++ b/__tests__/menu.test.ts
@@ -111,6 +111,10 @@ describe("showSidebar", () => {
 });
 
 describe("runTool", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("dispatches 'importDriveLinks' without throwing", () => {
     // importDriveLinks calls ui.prompt() which is mocked to return CANCEL (early exit)
     expect(() => runTool("importDriveLinks")).not.toThrow();

--- a/__tests__/menu.test.ts
+++ b/__tests__/menu.test.ts
@@ -13,13 +13,37 @@ const mockMenu = {
 const mockCreateMenu = jest.fn().mockReturnValue(mockMenu);
 const mockShowModalDialog = jest.fn();
 const mockShowSidebarFn = jest.fn();
+const mockPromptResponse = {
+  getSelectedButton: jest.fn().mockReturnValue("CANCEL"),
+  getResponseText: jest.fn().mockReturnValue(""),
+};
 const mockUi = {
   createMenu: mockCreateMenu,
   showModalDialog: mockShowModalDialog,
   showSidebar: mockShowSidebarFn,
+  Button: { OK: "OK", YES: "YES", NO: "NO", CANCEL: "CANCEL" },
+  ButtonSet: { OK_CANCEL: "OK_CANCEL", YES_NO: "YES_NO", OK: "OK" },
+  prompt: jest.fn().mockReturnValue(mockPromptResponse),
+  alert: jest.fn(),
+};
+const mockActiveSheet = {
+  getActiveCell: jest.fn().mockReturnValue({ getA1Notation: jest.fn().mockReturnValue("A1") }),
+  getActiveRange: jest.fn(),
+  getLastRow: jest.fn().mockReturnValue(0),
+  getLastColumn: jest.fn().mockReturnValue(0),
+  getRange: jest.fn(),
+  getName: jest.fn().mockReturnValue("Sheet1"),
 };
 const mockSpreadsheetApp = {
   getUi: jest.fn().mockReturnValue(mockUi),
+  getActiveSpreadsheet: jest.fn().mockReturnValue({
+    getActiveSheet: jest.fn().mockReturnValue(mockActiveSheet),
+    getSheetByName: jest.fn().mockReturnValue(null),
+    insertSheet: jest.fn().mockReturnValue(mockActiveSheet),
+    setActiveSheet: jest.fn(),
+    toast: jest.fn(),
+  }),
+  getActive: jest.fn().mockReturnValue({ toast: jest.fn() }),
 };
 
 const mockEvaluate = jest.fn().mockReturnValue({
@@ -88,7 +112,7 @@ describe("showSidebar", () => {
 
 describe("runTool", () => {
   it("dispatches 'importDriveLinks' without throwing", () => {
-    // importDriveLinks calls SpreadsheetApp.getUi() — already mocked above
+    // importDriveLinks calls ui.prompt() which is mocked to return CANCEL (early exit)
     expect(() => runTool("importDriveLinks")).not.toThrow();
   });
 

--- a/docs/plans/2026-02-18-sidebar-feature-parity-design.md
+++ b/docs/plans/2026-02-18-sidebar-feature-parity-design.md
@@ -1,0 +1,102 @@
+# Design: Sidebar Feature Parity
+
+**Date:** 2026-02-18
+**Status:** Approved
+
+## Background
+
+The Apps Script web IDE source (`updated_code.gs` + `updated_sidebar.html`) has diverged ahead of the TypeScript source in `src/`. The primary UX change is replacing the multi-item custom menu with a single persistent sidebar that surfaces all four tools. All four tool implementations and all helper logic are behaviorally identical between the two sources.
+
+## User-Facing Changes
+
+| Before | After |
+|--------|-------|
+| `⚡ SSI Tools` menu with 5 items (Quickstart, 4 tools) | `⚡ SSI Toolkit` menu with 1 item: `🚀 Open SSI Sidebar` |
+| Quickstart opens a redirect modal | User Guide link lives in sidebar as a plain `<a>` tag |
+| Tools triggered from menu items | Tools triggered from sidebar buttons with loading state |
+| No persistent UI panel | Sidebar stays open while user works |
+
+## Components
+
+### `src/server/index.ts`
+
+**`onOpen()`** — rewritten to a single menu item:
+```typescript
+SpreadsheetApp.getUi()
+  .createMenu("⚡ SSI Toolkit")
+  .addItem("🚀 Open SSI Sidebar", "showSidebar")
+  .addToUi();
+```
+
+**`openQuickstartDoc()`** — removed. The user guide URL is a plain anchor in the sidebar HTML; no server round-trip needed.
+
+**`showSidebar()`** — new function:
+```typescript
+export function showSidebar(): void {
+  const html = HtmlService.createTemplateFromFile("Sidebar");
+  const output = html.evaluate().setTitle("SSI Toolkit").setWidth(300);
+  SpreadsheetApp.getUi().showSidebar(output);
+}
+```
+
+**`runTool()`** — new dispatcher used by sidebar buttons:
+```typescript
+const TOOLS: Record<string, () => void> = {
+  importDriveLinks,
+  showSourceDialog,
+  sampleRowsToEvaluation,
+  extractTextFromSelection,
+};
+
+export function runTool(functionName: string): void {
+  const fn = TOOLS[functionName];
+  if (!fn) throw new Error("Function not found: " + functionName);
+  fn();
+}
+```
+
+### `src/Sidebar.html` (new file)
+
+Standalone HTML file for the sidebar UI. Must be a separate file (not an inlined string) because `HtmlService.createTemplateFromFile('Sidebar')` resolves by filename in the deployed Apps Script project.
+
+Sections:
+- User Guide link card (direct `<a href>` — no server call)
+- Main Tools: Import Drive Links, Run AI Inference
+- Extras: Sample Rows, Extract Text
+- Footer: version/branding string
+- Client-side `run(fn)` JS: calls `google.script.run.runTool(fn)` with loading state and error handling
+
+### `rollup.config.js`
+
+Footer stubs delta:
+- Add: `function showSidebar()`, `function runTool(fn)`
+- Remove: `function openQuickstartDoc()`
+
+### Build scripts (`package.json`)
+
+Extend `build` and `build:watch` to copy `src/Sidebar.html` to `dist/` alongside `appsscript.json`:
+```
+"build": "rimraf dist && rollup -c && cp appsscript.json dist/ && cp src/Sidebar.html dist/"
+"build:watch": "mkdir -p dist && cp appsscript.json dist/ && cp src/Sidebar.html dist/ && rollup -c --watch"
+```
+
+### `__tests__/menu.test.ts`
+
+- Update `onOpen` tests: new menu label `⚡ SSI Toolkit`, single `addItem` call for `showSidebar`
+- Remove `openQuickstartDoc` describe block
+- Add `showSidebar` tests: mock `HtmlService.createTemplateFromFile`, assert `showSidebar` called on UI
+- Add `runTool` tests: assert known function names dispatch correctly, assert unknown name throws
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/server/index.ts` | Update `onOpen`; remove `openQuickstartDoc`; add `showSidebar`, `runTool` |
+| `src/Sidebar.html` | New file |
+| `rollup.config.js` | Update footer stubs |
+| `package.json` | Update `build` and `build:watch` scripts |
+| `__tests__/menu.test.ts` | Update/replace menu and quickstart tests |
+
+## Files Unchanged
+
+`config.ts`, `api.ts`, `drive.ts`, `utils.ts`, `dialog.ts`, `types.ts`, all other tests — no behavioral changes to the four tools or any helpers.

--- a/docs/plans/2026-02-18-sidebar-feature-parity.md
+++ b/docs/plans/2026-02-18-sidebar-feature-parity.md
@@ -1,0 +1,574 @@
+# Sidebar Feature Parity Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the 5-item custom menu with a single persistent sidebar that exposes all four tools, matching the UX of `updated_code.gs` + `updated_sidebar.html`.
+
+**Architecture:** `showSidebar()` loads `Sidebar.html` (a standalone file in `dist/`) via `HtmlService.createTemplateFromFile`. The sidebar calls `google.script.run.runTool(fn)` to dispatch to any tool by name; `runTool` resolves the name against an explicit typed map in `index.ts`. `openQuickstartDoc` is removed — the user guide link lives as a plain `<a>` in the sidebar.
+
+**Tech Stack:** TypeScript, Rollup (IIFE), clasp, Jest/ts-jest, Google Apps Script V8 runtime
+
+**Design doc:** `docs/plans/2026-02-18-sidebar-feature-parity-design.md`
+
+---
+
+### Task 1: Update build scripts to copy `Sidebar.html` to `dist/`
+
+**Files:**
+- Modify: `package.json`
+
+No test needed — the build either succeeds or fails. We verify by running the build at the end.
+
+**Step 1: Edit `package.json` build scripts**
+
+In `package.json`, the `"build"` and `"build:watch"` scripts currently only copy `appsscript.json`. Extend both to also copy `src/Sidebar.html`:
+
+```json
+"build": "rimraf dist && rollup -c && cp appsscript.json dist/ && cp src/Sidebar.html dist/",
+"build:watch": "mkdir -p dist && cp appsscript.json dist/ && cp src/Sidebar.html dist/ && rollup -c --watch",
+```
+
+**Step 2: Commit**
+
+```bash
+git add package.json
+git commit -m "build: copy Sidebar.html to dist/ alongside appsscript.json"
+```
+
+---
+
+### Task 2: Create `src/Sidebar.html`
+
+**Files:**
+- Create: `src/Sidebar.html`
+
+This file is a static HTML artifact — no unit test. Visual correctness is verified by deploying to dev.
+
+**Step 1: Create the file**
+
+Create `src/Sidebar.html` with the following content (adapted directly from `updated_sidebar.html`):
+
+```html
+<!DOCTYPE html>
+<html>
+
+<head>
+    <base target="_top">
+    <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --primary-blue: #1a73e8;
+            --hover-blue: #f1f3f4;
+            --border-color: #dadce0;
+            --text-main: #3c4043;
+            --text-secondary: #5f6368;
+        }
+
+        body {
+            padding: 0;
+            margin: 0;
+            font-family: 'Google Sans', Roboto, Arial, sans-serif;
+            background-color: #ffffff;
+            color: var(--text-main);
+        }
+
+        .container {
+            padding: 16px;
+        }
+
+        .guide-card {
+            background-color: #f8f9fa;
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 24px;
+            text-align: center;
+            transition: background-color 0.2s;
+        }
+
+        .guide-card:hover {
+            background-color: #f1f3f4;
+        }
+
+        .guide-link {
+            color: var(--primary-blue);
+            font-weight: 500;
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            font-size: 14px;
+        }
+
+        .section {
+            margin-bottom: 28px;
+        }
+
+        h3 {
+            font-size: 11px;
+            font-weight: 500;
+            color: var(--text-secondary);
+            text-transform: uppercase;
+            letter-spacing: 0.8px;
+            margin: 0 0 12px 4px;
+        }
+
+        .tool-btn {
+            width: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: flex-start;
+            padding: 12px 16px;
+            margin-bottom: 8px;
+            border-radius: 24px;
+            border: 1px solid var(--border-color);
+            background: white;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            font-family: 'Google Sans', sans-serif;
+            font-size: 14px;
+            font-weight: 500;
+            color: var(--text-main);
+        }
+
+        .tool-btn:hover {
+            background-color: var(--hover-blue);
+            border-color: transparent;
+            color: var(--primary-blue);
+        }
+
+        .tool-btn:active {
+            background-color: #e8eaed;
+            transform: scale(0.98);
+        }
+
+        .icon {
+            margin-right: 12px;
+            font-size: 18px;
+            width: 24px;
+            text-align: center;
+        }
+
+        .status-footer {
+            margin-top: 40px;
+            padding: 16px;
+            border-top: 1px solid #eee;
+            font-size: 11px;
+            color: var(--text-secondary);
+            text-align: center;
+            line-height: 1.5;
+        }
+
+        .loading {
+            opacity: 0.5;
+            pointer-events: none;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <div class="guide-card">
+            <a href="https://docs.google.com/document/d/1BQJzBHiE6L0hvU6NMD0jaQE71VWRpWH-vNQu3UtGjBA/edit?tab=t.66jobsqlduah#heading=h.h5k0s81xpiiq"
+                target="_blank" class="guide-link">
+                <span>📖</span> View User Guide ↗
+            </a>
+        </div>
+
+        <div class="section">
+            <h3>Main Tools</h3>
+            <button class="tool-btn" onclick="run('importDriveLinks')">
+                <span class="icon">📂</span> Import Drive Links
+            </button>
+            <button class="tool-btn" onclick="run('showSourceDialog')">
+                <span class="icon">▶️</span> Run AI Inference
+            </button>
+        </div>
+
+        <div class="section">
+            <h3>Extras</h3>
+            <button class="tool-btn" onclick="run('sampleRowsToEvaluation')">
+                <span class="icon">🎲</span> Sample Rows
+            </button>
+            <button class="tool-btn" onclick="run('extractTextFromSelection')">
+                <span class="icon">📜</span> Extract Text
+            </button>
+        </div>
+    </div>
+
+    <div class="status-footer">
+        <strong>SSI Tools v2.0</strong><br>
+        Powered by Gemini 2.0 Flash<br>
+        Evaluation Unrestricted Mode
+    </div>
+
+    <script>
+        function run(fn) {
+            const btn = event.currentTarget;
+            const originalContent = btn.innerHTML;
+
+            btn.classList.add('loading');
+            btn.innerHTML = '<span class="icon">⏳</span> Working...';
+
+            google.script.run
+                .withSuccessHandler(() => {
+                    btn.classList.remove('loading');
+                    btn.innerHTML = originalContent;
+                })
+                .withFailureHandler(msg => {
+                    alert('Error: ' + msg);
+                    btn.classList.remove('loading');
+                    btn.innerHTML = originalContent;
+                })
+                .runTool(fn);
+        }
+    </script>
+</body>
+
+</html>
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/Sidebar.html
+git commit -m "feat: add Sidebar.html for persistent sidebar UI"
+```
+
+---
+
+### Task 3: Update `rollup.config.js` footer stubs
+
+**Files:**
+- Modify: `rollup.config.js`
+
+**Step 1: Update the footer**
+
+The footer currently has stubs for `onOpen`, `showSourceDialog`, `handleDialogSelection`, `importDriveLinks`, `extractTextFromSelection`, `sampleRowsToEvaluation`, and `openQuickstartDoc`.
+
+Replace the `footer` value with:
+
+```js
+footer: `
+/**
+ * Global Handshake — Explicit function stubs for Google Apps Script discovery.
+ */
+function onOpen(e) { _GASEntry.onOpen(e); }
+function showSidebar() { _GASEntry.showSidebar(); }
+function runTool(fn) { _GASEntry.runTool(fn); }
+function showSourceDialog() { _GASEntry.showSourceDialog(); }
+function handleDialogSelection(mode) { _GASEntry.handleDialogSelection(mode); }
+function importDriveLinks() { _GASEntry.importDriveLinks(); }
+function extractTextFromSelection() { _GASEntry.extractTextFromSelection(); }
+function sampleRowsToEvaluation() { _GASEntry.sampleRowsToEvaluation(); }
+`,
+```
+
+Note: `openQuickstartDoc` is removed. `showSidebar` and `runTool` are added.
+
+**Step 2: Commit**
+
+```bash
+git add rollup.config.js
+git commit -m "build: update rollup footer stubs for showSidebar and runTool"
+```
+
+---
+
+### Task 4: Update `__tests__/menu.test.ts` (write failing tests first)
+
+**Files:**
+- Modify: `__tests__/menu.test.ts`
+
+This task replaces the entire test file. Read `__tests__/menu.test.ts` before editing.
+
+**Step 1: Replace the file contents**
+
+The new file must:
+- Add mocks for `createTemplateFromFile`, `evaluate()`, and `showSidebar` on the UI
+- Update `onOpen` tests: single `addItem` call, new menu name `⚡ SSI Toolkit`
+- Remove the `openQuickstartDoc` describe block entirely
+- Add `showSidebar` describe block
+- Add `runTool` describe block
+
+```typescript
+/**
+ * Tests for src/server/index.ts (Menu and sidebar functions)
+ */
+
+// ── Mock globals BEFORE imports ────────────────────────────────
+
+const mockAddItem = jest.fn().mockReturnThis();
+const mockAddToUi = jest.fn();
+const mockMenu = {
+  addItem: mockAddItem,
+  addToUi: mockAddToUi,
+};
+const mockCreateMenu = jest.fn().mockReturnValue(mockMenu);
+const mockShowModalDialog = jest.fn();
+const mockShowSidebarFn = jest.fn();
+const mockUi = {
+  createMenu: mockCreateMenu,
+  showModalDialog: mockShowModalDialog,
+  showSidebar: mockShowSidebarFn,
+};
+const mockSpreadsheetApp = {
+  getUi: jest.fn().mockReturnValue(mockUi),
+};
+
+const mockEvaluate = jest.fn().mockReturnValue({
+  setTitle: jest.fn().mockReturnThis(),
+  setWidth: jest.fn().mockReturnThis(),
+});
+const mockCreateTemplateFromFile = jest.fn().mockReturnValue({
+  evaluate: mockEvaluate,
+});
+const mockCreateHtmlOutput = jest.fn().mockReturnValue({
+  setWidth: jest.fn().mockReturnThis(),
+  setHeight: jest.fn().mockReturnThis(),
+});
+const mockHtmlService = {
+  createHtmlOutput: mockCreateHtmlOutput,
+  createTemplateFromFile: mockCreateTemplateFromFile,
+};
+
+(globalThis as any).SpreadsheetApp = mockSpreadsheetApp;
+(globalThis as any).HtmlService = mockHtmlService;
+
+// ── Import after mocks ─────────────────────────────────────────
+
+import { onOpen, showSidebar, runTool } from "../src/server/index";
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe("onOpen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates a menu named '⚡ SSI Toolkit'", () => {
+    onOpen();
+    expect(mockCreateMenu).toHaveBeenCalledWith("⚡ SSI Toolkit");
+  });
+
+  it("adds a single item that opens the sidebar", () => {
+    onOpen();
+    expect(mockAddItem).toHaveBeenCalledTimes(1);
+    expect(mockAddItem).toHaveBeenCalledWith("🚀 Open SSI Sidebar", "showSidebar");
+  });
+
+  it("adds the menu to the UI", () => {
+    onOpen();
+    expect(mockAddToUi).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("showSidebar", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("loads the sidebar from the 'Sidebar' template file", () => {
+    showSidebar();
+    expect(mockCreateTemplateFromFile).toHaveBeenCalledWith("Sidebar");
+  });
+
+  it("evaluates the template and shows the sidebar", () => {
+    showSidebar();
+    expect(mockEvaluate).toHaveBeenCalledTimes(1);
+    expect(mockShowSidebarFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runTool", () => {
+  it("dispatches 'importDriveLinks' without throwing", () => {
+    // importDriveLinks calls SpreadsheetApp.getUi() — already mocked
+    // We just need it not to throw on dispatch itself
+    expect(() => runTool("importDriveLinks")).not.toThrow();
+  });
+
+  it("throws for an unknown function name", () => {
+    expect(() => runTool("doesNotExist")).toThrow("Function not found: doesNotExist");
+  });
+});
+```
+
+**Step 2: Run the tests and confirm they fail**
+
+```bash
+npx jest __tests__/menu.test.ts
+```
+
+Expected: FAIL — `showSidebar` and `runTool` are not yet exported from `index.ts`, and `onOpen` still creates the old menu.
+
+**Step 3: Commit the failing tests**
+
+```bash
+git add __tests__/menu.test.ts
+git commit -m "test: update menu tests for sidebar UX (failing)"
+```
+
+---
+
+### Task 5: Update `src/server/index.ts` to make tests pass
+
+**Files:**
+- Modify: `src/server/index.ts`
+
+Read `src/server/index.ts` before editing. Make these changes:
+
+**Step 1: Update `onOpen()`**
+
+Replace the existing `onOpen` body:
+
+```typescript
+export function onOpen(): void {
+  SpreadsheetApp.getUi()
+    .createMenu("⚡ SSI Toolkit")
+    .addItem("🚀 Open SSI Sidebar", "showSidebar")
+    .addToUi();
+}
+```
+
+**Step 2: Remove `openQuickstartDoc()`**
+
+Delete the entire `openQuickstartDoc` function and its section comment.
+
+**Step 3: Add `showSidebar()` after the UI handlers section**
+
+```typescript
+export function showSidebar(): void {
+  const html = HtmlService.createTemplateFromFile("Sidebar");
+  const output = html.evaluate().setTitle("SSI Toolkit").setWidth(300);
+  SpreadsheetApp.getUi().showSidebar(output);
+}
+```
+
+**Step 4: Add `runTool()` and the dispatch map**
+
+Add this immediately after `showSidebar`. The dispatch map must reference the four tool functions that are defined later in the same file. Since JavaScript hoists function declarations but not `const`, define the map as a `function` or place it after the tool definitions. The simplest approach: put the map and `runTool` at the bottom of the file, after all four tool functions are defined.
+
+```typescript
+// ==========================================
+// 🔀 SIDEBAR DISPATCHER
+// ==========================================
+
+const TOOLS: Record<string, () => void> = {
+  importDriveLinks,
+  showSourceDialog,
+  sampleRowsToEvaluation,
+  extractTextFromSelection,
+};
+
+export function runTool(functionName: string): void {
+  const fn = TOOLS[functionName];
+  if (!fn) throw new Error("Function not found: " + functionName);
+  fn();
+}
+```
+
+**Step 5: Run the tests and confirm they pass**
+
+```bash
+npx jest __tests__/menu.test.ts
+```
+
+Expected: all tests PASS.
+
+**Step 6: Run the full test suite to confirm no regressions**
+
+```bash
+npm test
+```
+
+Expected: all 4 suites pass.
+
+**Step 7: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors.
+
+**Step 8: Commit**
+
+```bash
+git add src/server/index.ts
+git commit -m "feat: replace menu with sidebar — add showSidebar and runTool"
+```
+
+---
+
+### Task 6: Verify the build end-to-end
+
+**Step 1: Run the full build**
+
+```bash
+npm run build
+```
+
+Expected: exits 0. `dist/` should contain `index.js`, `appsscript.json`, and `Sidebar.html`.
+
+**Step 2: Confirm `dist/Sidebar.html` exists**
+
+```bash
+ls dist/
+```
+
+Expected output includes `Sidebar.html`.
+
+**Step 3: Confirm the footer stubs are in the bundle**
+
+```bash
+grep -E "showSidebar|runTool|openQuickstartDoc" dist/index.js
+```
+
+Expected: lines for `showSidebar` and `runTool`; no line for `openQuickstartDoc`.
+
+**Step 4: Commit if anything was adjusted; otherwise proceed to deploy**
+
+```bash
+git add -A
+git status
+# If clean, no commit needed. If any tweaks were made, commit them.
+```
+
+---
+
+### Task 7: Deploy to dev and smoke-test
+
+**Step 1: Deploy to dev**
+
+```bash
+npm run deploy:dev
+```
+
+Expected: build succeeds, clasp pushes `dist/` (3 files: `index.js`, `appsscript.json`, `Sidebar.html`).
+
+**Step 2: Open the Apps Script editor to confirm the files are present**
+
+```bash
+npm run clasp:open
+```
+
+Confirm `Sidebar.html` appears in the file list alongside `Code.gs` / `index.gs`.
+
+**Step 3: Open the spreadsheet and smoke-test**
+
+- Reload the Google Sheets document
+- The `⚡ SSI Toolkit` menu should appear with a single item: `🚀 Open SSI Sidebar`
+- Click it — the sidebar should open on the right
+- Click "View User Guide ↗" — should open the doc in a new tab
+- Click "Import Drive Links" — should trigger the folder prompt
+- Click "Run AI Inference" — should open the AI mode selection dialog
+- Click "Sample Rows" — should trigger the sample size prompt
+- Click "Extract Text" — should trigger the Drive service check
+
+**Step 4: Final commit (if any fixes made during smoke test)**
+
+```bash
+git add -A
+git commit -m "fix: <describe any smoke-test fix>"
+```

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "rimraf dist && rollup -c && cp appsscript.json dist/",
-    "build:watch": "mkdir -p dist && cp appsscript.json dist/ && rollup -c --watch",
+    "build": "rimraf dist && rollup -c && cp appsscript.json dist/ && cp src/Sidebar.html dist/",
+    "build:watch": "mkdir -p dist && cp appsscript.json dist/ && cp src/Sidebar.html dist/ && rollup -c --watch",
     "deploy:dev": "npm run build && cp .clasp.dev.json .clasp.json && clasp push",
     "deploy:prod": "npm run build && cp .clasp.prod.json .clasp.json && clasp push",
     "deploy:watch:dev": "cp .clasp.dev.json .clasp.json && npm-run-all --parallel build:watch push:watch",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,12 +36,13 @@ export default {
  * Global Handshake — Explicit function stubs for Google Apps Script discovery.
  */
 function onOpen(e) { _GASEntry.onOpen(e); }
+function showSidebar() { _GASEntry.showSidebar(); }
+function runTool(fn) { _GASEntry.runTool(fn); }
 function showSourceDialog() { _GASEntry.showSourceDialog(); }
 function handleDialogSelection(mode) { _GASEntry.handleDialogSelection(mode); }
 function importDriveLinks() { _GASEntry.importDriveLinks(); }
 function extractTextFromSelection() { _GASEntry.extractTextFromSelection(); }
 function sampleRowsToEvaluation() { _GASEntry.sampleRowsToEvaluation(); }
-function openQuickstartDoc() { _GASEntry.openQuickstartDoc(); }
 `,
   },
   plugins: [

--- a/src/Sidebar.html
+++ b/src/Sidebar.html
@@ -127,20 +127,20 @@
 
         <div class="section">
             <h3>Main Tools</h3>
-            <button class="tool-btn" onclick="run('importDriveLinks')">
+            <button class="tool-btn" onclick="run(event, 'importDriveLinks')">
                 <span class="icon">📂</span> Import Drive Links
             </button>
-            <button class="tool-btn" onclick="run('showSourceDialog')">
+            <button class="tool-btn" onclick="run(event, 'showSourceDialog')">
                 <span class="icon">▶️</span> Run AI Inference
             </button>
         </div>
 
         <div class="section">
             <h3>Extras</h3>
-            <button class="tool-btn" onclick="run('sampleRowsToEvaluation')">
+            <button class="tool-btn" onclick="run(event, 'sampleRowsToEvaluation')">
                 <span class="icon">🎲</span> Sample Rows
             </button>
-            <button class="tool-btn" onclick="run('extractTextFromSelection')">
+            <button class="tool-btn" onclick="run(event, 'extractTextFromSelection')">
                 <span class="icon">📜</span> Extract Text
             </button>
         </div>
@@ -153,8 +153,8 @@
     </div>
 
     <script>
-        function run(fn) {
-            const btn = event.currentTarget;
+        function run(e, fn) {
+            const btn = e.currentTarget;
             const originalContent = btn.innerHTML;
 
             btn.classList.add('loading');

--- a/src/Sidebar.html
+++ b/src/Sidebar.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <base target="_top">
+    <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --primary-blue: #1a73e8;
+            --hover-blue: #f1f3f4;
+            --border-color: #dadce0;
+            --text-main: #3c4043;
+            --text-secondary: #5f6368;
+        }
+
+        body {
+            padding: 0;
+            margin: 0;
+            font-family: 'Google Sans', Roboto, Arial, sans-serif;
+            background-color: #ffffff;
+            color: var(--text-main);
+        }
+
+        .container {
+            padding: 16px;
+        }
+
+        .guide-card {
+            background-color: #f8f9fa;
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 24px;
+            text-align: center;
+            transition: background-color 0.2s;
+        }
+
+        .guide-card:hover {
+            background-color: #f1f3f4;
+        }
+
+        .guide-link {
+            color: var(--primary-blue);
+            font-weight: 500;
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            font-size: 14px;
+        }
+
+        .section {
+            margin-bottom: 28px;
+        }
+
+        h3 {
+            font-size: 11px;
+            font-weight: 500;
+            color: var(--text-secondary);
+            text-transform: uppercase;
+            letter-spacing: 0.8px;
+            margin: 0 0 12px 4px;
+        }
+
+        .tool-btn {
+            width: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: flex-start;
+            padding: 12px 16px;
+            margin-bottom: 8px;
+            border-radius: 24px;
+            border: 1px solid var(--border-color);
+            background: white;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            font-family: 'Google Sans', sans-serif;
+            font-size: 14px;
+            font-weight: 500;
+            color: var(--text-main);
+        }
+
+        .tool-btn:hover {
+            background-color: var(--hover-blue);
+            border-color: transparent;
+            color: var(--primary-blue);
+        }
+
+        .tool-btn:active {
+            background-color: #e8eaed;
+            transform: scale(0.98);
+        }
+
+        .icon {
+            margin-right: 12px;
+            font-size: 18px;
+            width: 24px;
+            text-align: center;
+        }
+
+        .status-footer {
+            margin-top: 40px;
+            padding: 16px;
+            border-top: 1px solid #eee;
+            font-size: 11px;
+            color: var(--text-secondary);
+            text-align: center;
+            line-height: 1.5;
+        }
+
+        .loading {
+            opacity: 0.5;
+            pointer-events: none;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <div class="guide-card">
+            <a href="https://docs.google.com/document/d/1BQJzBHiE6L0hvU6NMD0jaQE71VWRpWH-vNQu3UtGjBA/edit?tab=t.66jobsqlduah#heading=h.h5k0s81xpiiq"
+                target="_blank" class="guide-link">
+                <span>📖</span> View User Guide ↗
+            </a>
+        </div>
+
+        <div class="section">
+            <h3>Main Tools</h3>
+            <button class="tool-btn" onclick="run('importDriveLinks')">
+                <span class="icon">📂</span> Import Drive Links
+            </button>
+            <button class="tool-btn" onclick="run('showSourceDialog')">
+                <span class="icon">▶️</span> Run AI Inference
+            </button>
+        </div>
+
+        <div class="section">
+            <h3>Extras</h3>
+            <button class="tool-btn" onclick="run('sampleRowsToEvaluation')">
+                <span class="icon">🎲</span> Sample Rows
+            </button>
+            <button class="tool-btn" onclick="run('extractTextFromSelection')">
+                <span class="icon">📜</span> Extract Text
+            </button>
+        </div>
+    </div>
+
+    <div class="status-footer">
+        <strong>SSI Tools v2.0</strong><br>
+        Powered by Gemini 2.0 Flash<br>
+        Evaluation Unrestricted Mode
+    </div>
+
+    <script>
+        function run(fn) {
+            const btn = event.currentTarget;
+            const originalContent = btn.innerHTML;
+
+            btn.classList.add('loading');
+            btn.innerHTML = '<span class="icon">⏳</span> Working...';
+
+            google.script.run
+                .withSuccessHandler(() => {
+                    btn.classList.remove('loading');
+                    btn.innerHTML = originalContent;
+                })
+                .withFailureHandler(msg => {
+                    alert('Error: ' + msg);
+                    btn.classList.remove('loading');
+                    btn.innerHTML = originalContent;
+                })
+                .runTool(fn);
+        }
+    </script>
+</body>
+
+</html>

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -56,33 +56,28 @@ export function showSidebar(): void {
 // 📂 TOOL 1: IMPORT DRIVE LINKS
 // ==========================================
 
-/**
- * Entry point invoked from the sidebar. Opens a modal dialog where the user
- * enters a Drive folder URL; the dialog's submit handler calls
- * runImportDriveLinks() via google.script.run.
- */
 export function importDriveLinks(): void {
   const ui = SpreadsheetApp.getUi();
-  const html = HtmlService.createHtmlOutput(
-    `<p>Paste a Google Drive Folder link below:</p>
-     <input id="url" type="text" style="width:100%">
-     <button onclick="google.script.run.runImportDriveLinks(document.getElementById('url').value);google.script.host.close();">Import</button>`,
-  )
-    .setWidth(400)
-    .setHeight(120);
-  ui.showModalDialog(html, "Import Drive Links");
-}
-
-/**
- * Performs the actual folder scan and writes file URLs to the active sheet.
- * Called by the Import Drive Links dialog via google.script.run.
- */
-export function runImportDriveLinks(folderUrl: string): void {
-  const ui = SpreadsheetApp.getUi();
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
-  const startCell = sheet.getActiveCell().getA1Notation();
 
-  const folderId = extractId(folderUrl.trim());
+  // 1. Get Folder
+  const folderResponse = ui.prompt(
+    "Step 1/2: Select Folder",
+    "Paste the Google Drive Folder Link or ID:",
+    ui.ButtonSet.OK_CANCEL,
+  );
+  if (folderResponse.getSelectedButton() !== ui.Button.OK) return;
+  const folderId = extractId(folderResponse.getResponseText().trim());
+
+  // 2. Get Location
+  const activeA1 = sheet.getActiveCell().getA1Notation();
+  const cellResponse = ui.prompt(
+    "Step 2/2: Confirm Location",
+    `Importing links starting at cell ${activeA1}.\nClick OK to proceed or type a new cell below:`,
+    ui.ButtonSet.OK_CANCEL,
+  );
+  if (cellResponse.getSelectedButton() !== ui.Button.OK) return;
+  const startCell = cellResponse.getResponseText().trim() || activeA1;
 
   try {
     const parentFolder = DriveApp.getFolderById(folderId);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -28,29 +28,9 @@ import type { AIMode, ColumnMap } from "../shared/types";
 
 export function onOpen(): void {
   SpreadsheetApp.getUi()
-    .createMenu("⚡ SSI Tools")
-    .addItem("0. Quickstart", "openQuickstartDoc")
-    .addItem("1. Import Drive Links (Folder)", "importDriveLinks")
-    .addItem("2. Extract Text from Selected Cells", "extractTextFromSelection")
-    .addSeparator()
-    .addItem("3. 🎲 Sample Rows for Evaluation", "sampleRowsToEvaluation")
-    .addItem("4. ▶️ Run AI on Selected Rows", "showSourceDialog")
+    .createMenu("⚡ SSI Toolkit")
+    .addItem("🚀 Open SSI Sidebar", "showSidebar")
     .addToUi();
-}
-
-// ==========================================
-// 🚀 QUICKSTART
-// ==========================================
-
-export function openQuickstartDoc(): void {
-  const url =
-    "https://docs.google.com/document/d/1BQJzBHiE6L0hvU6NMD0jaQE71VWRpWH-vNQu3UtGjBA/edit?usp=sharing";
-  const htmlOutput = HtmlService.createHtmlOutput(
-    `<script>window.open('${url}', '_blank');google.script.host.close();</script>`,
-  )
-    .setWidth(10)
-    .setHeight(10);
-  SpreadsheetApp.getUi().showModalDialog(htmlOutput, "Opening Quickstart Guide");
 }
 
 // ==========================================
@@ -66,32 +46,43 @@ export function handleDialogSelection(mode: string): void {
   runBatchAI(mode as AIMode);
 }
 
+export function showSidebar(): void {
+  const html = HtmlService.createTemplateFromFile("Sidebar");
+  const output = html.evaluate().setTitle("SSI Toolkit").setWidth(300);
+  SpreadsheetApp.getUi().showSidebar(output);
+}
+
 // ==========================================
 // 📂 TOOL 1: IMPORT DRIVE LINKS
 // ==========================================
 
+/**
+ * Entry point invoked from the sidebar. Opens a modal dialog where the user
+ * enters a Drive folder URL; the dialog's submit handler calls
+ * runImportDriveLinks() via google.script.run.
+ */
 export function importDriveLinks(): void {
   const ui = SpreadsheetApp.getUi();
+  const html = HtmlService.createHtmlOutput(
+    `<p>Paste a Google Drive Folder link below:</p>
+     <input id="url" type="text" style="width:100%">
+     <button onclick="google.script.run.runImportDriveLinks(document.getElementById('url').value);google.script.host.close();">Import</button>`,
+  )
+    .setWidth(400)
+    .setHeight(120);
+  ui.showModalDialog(html, "Import Drive Links");
+}
+
+/**
+ * Performs the actual folder scan and writes file URLs to the active sheet.
+ * Called by the Import Drive Links dialog via google.script.run.
+ */
+export function runImportDriveLinks(folderUrl: string): void {
+  const ui = SpreadsheetApp.getUi();
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+  const startCell = sheet.getActiveCell().getA1Notation();
 
-  // 1. Get Folder
-  const folderResponse = ui.prompt(
-    "Step 1/2: Select Folder",
-    "Paste the Google Drive Folder Link or ID:",
-    ui.ButtonSet.OK_CANCEL,
-  );
-  if (folderResponse.getSelectedButton() !== ui.Button.OK) return;
-  const folderId = extractId(folderResponse.getResponseText().trim());
-
-  // 2. Get Location
-  const activeA1 = sheet.getActiveCell().getA1Notation();
-  const cellResponse = ui.prompt(
-    "Step 2/2: Confirm Location",
-    `Importing links starting at cell ${activeA1}.\nClick OK to proceed or type a new cell below:`,
-    ui.ButtonSet.OK_CANCEL,
-  );
-  if (cellResponse.getSelectedButton() !== ui.Button.OK) return;
-  const startCell = cellResponse.getResponseText().trim() || activeA1;
+  const folderId = extractId(folderUrl.trim());
 
   try {
     const parentFolder = DriveApp.getFolderById(folderId);
@@ -315,4 +306,21 @@ export function runBatchAI(mode: AIMode): void {
     }
   }
   SpreadsheetApp.getActive().toast(`Complete! Processed ${processed} rows.`, "Success", 5);
+}
+
+// ==========================================
+// 🔀 SIDEBAR DISPATCHER
+// ==========================================
+
+const TOOLS: Record<string, () => void> = {
+  importDriveLinks,
+  showSourceDialog,
+  sampleRowsToEvaluation,
+  extractTextFromSelection,
+};
+
+export function runTool(functionName: string): void {
+  const fn = TOOLS[functionName];
+  if (!fn) throw new Error("Function not found: " + functionName);
+  fn();
 }


### PR DESCRIPTION
## Summary

- Replaces the 5-item custom menu with a single entry point (`🚀 Open SSI Sidebar`) that opens a persistent docked sidebar
- Adds `src/Sidebar.html` — Google-style sidebar UI with all four tools, a User Guide link card, and button loading states
- Adds `showSidebar()` and `runTool()` to `index.ts`; removes `openQuickstartDoc()` (user guide link now lives in the sidebar as a plain anchor)
- Updates build scripts to copy `Sidebar.html` to `dist/` so clasp deploys it alongside the bundle

## Test Plan

- [ ] All 48 unit tests pass (`npm test`)
- [ ] `npm run build` completes cleanly; `dist/` contains `index.js`, `appsscript.json`, `Sidebar.html`
- [ ] Deploy to dev (`npm run deploy:dev`); reload the sheet and confirm `⚡ SSI Toolkit` menu has one item
- [ ] Click `🚀 Open SSI Sidebar` — sidebar opens on the right
- [ ] Click "View User Guide ↗" — opens the doc in a new tab
- [ ] Click each tool button — confirms correct tool triggers and button shows loading state while running
- [ ] Unknown function name passed to `runTool` throws `"Function not found: <name>"`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)