### PR TITLE
feat: replace callGeminiAPI with GeminiRequest options object interface

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -1,7 +1,8 @@
 /**
  * Tests for src/server/api.ts
  *
- * Requires mocking UrlFetchApp, DriveApp, and Utilities globals.
+ * Only UrlFetchApp needs mocking — DriveApp and Utilities are no longer
+ * used in this module.
  */
 
 // ── Mock globals BEFORE imports ────────────────────────────────
@@ -10,120 +11,119 @@
   fetch: jest.fn(),
 };
 
-(globalThis as any).DriveApp = {
-  getFileById: jest.fn(),
-};
-
-(globalThis as any).Utilities = {
-  base64Encode: jest.fn().mockReturnValue("base64data=="),
-};
-
-(globalThis as any).PropertiesService = {
-  getScriptProperties: jest.fn().mockReturnValue({
-    getProperty: jest.fn(),
-  }),
-};
-
 // ── Import after mocks ─────────────────────────────────────────
 
-import { callGeminiAPI } from "../src/server/api";
+import { buildGeminiPayload, callGeminiAPI } from "../src/server/api";
+import type { GeminiRequest } from "../src/shared/types";
 
 // ── Helpers ────────────────────────────────────────────────────
 
-function mockFetchResponse(body: unknown, code = 200) {
+function mockFetchResponse(body: unknown) {
   (UrlFetchApp.fetch as jest.Mock).mockReturnValue({
-    getResponseCode: () => code,
     getContentText: () => JSON.stringify(body),
   });
 }
 
-// ── Tests ──────────────────────────────────────────────────────
+const baseReq: GeminiRequest = {
+  apiKey: "key123",
+  systemPrompt: "Be helpful",
+  userTexts: ["Summarize this"],
+};
+
+// ── buildGeminiPayload tests ───────────────────────────────────
+
+describe("buildGeminiPayload", () => {
+  it("assembles a single text part", () => {
+    const payload = buildGeminiPayload(baseReq);
+    const parts = (payload.contents as any)[0].parts;
+    expect(parts).toHaveLength(1);
+    expect(parts[0].text).toBe("Summarize this");
+  });
+
+  it("assembles multiple text parts in order", () => {
+    const req: GeminiRequest = { ...baseReq, userTexts: ["Prompt", "Context"] };
+    const payload = buildGeminiPayload(req);
+    const parts = (payload.contents as any)[0].parts;
+    expect(parts).toHaveLength(2);
+    expect(parts[0].text).toBe("Prompt");
+    expect(parts[1].text).toBe("Context");
+  });
+
+  it("appends inline_data as the final part when provided", () => {
+    const req: GeminiRequest = {
+      ...baseReq,
+      userTexts: ["What is this?"],
+      inlineData: { mime_type: "application/pdf", data: "base64==" },
+    };
+    const payload = buildGeminiPayload(req);
+    const parts = (payload.contents as any)[0].parts;
+    expect(parts).toHaveLength(2);
+    expect(parts[1].inline_data).toEqual({ mime_type: "application/pdf", data: "base64==" });
+  });
+
+  it("uses default system prompt when systemPrompt is omitted", () => {
+    const req: GeminiRequest = { apiKey: "k", userTexts: ["hi"] };
+    const payload = buildGeminiPayload(req);
+    expect((payload.system_instruction as any).parts[0].text).toBe("You are a helpful assistant.");
+  });
+
+  it("includes tools when provided", () => {
+    const req: GeminiRequest = {
+      ...baseReq,
+      tools: [{ name: "myFn", description: "does stuff" }],
+    };
+    const payload = buildGeminiPayload(req);
+    expect((payload.tools as any)[0].function_declarations[0].name).toBe("myFn");
+  });
+
+  it("omits tools key when tools array is empty or absent", () => {
+    const payload = buildGeminiPayload(baseReq);
+    expect(payload.tools).toBeUndefined();
+  });
+
+  it("passes through generationConfig when provided", () => {
+    const req: GeminiRequest = {
+      ...baseReq,
+      generationConfig: { temperature: 0.5, maxOutputTokens: 1024 },
+    };
+    const payload = buildGeminiPayload(req);
+    expect((payload.generationConfig as any).temperature).toBe(0.5);
+  });
+});
+
+// ── callGeminiAPI tests ────────────────────────────────────────
 
 describe("callGeminiAPI", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("sends text context appended to the user prompt", () => {
+  it("returns the text from the first candidate", () => {
     mockFetchResponse({
       candidates: [{ content: { parts: [{ text: "AI says hello" }] } }],
     });
-
-    const result = callGeminiAPI("key123", "Be helpful", "Summarize this", {
-      textContext: "Some document text here",
-    });
-
-    expect(result).toBe("AI says hello");
-
-    // Verify the payload sent to UrlFetchApp
-    const callArgs = (UrlFetchApp.fetch as jest.Mock).mock.calls[0];
-    const payload = JSON.parse(callArgs[1].payload);
-
-    expect(payload.system_instruction.parts[0].text).toBe("Be helpful");
-    expect(payload.contents[0].parts[0].text).toContain("Summarize this");
-    expect(payload.contents[0].parts[0].text).toContain("--- CONTEXT ---");
-    expect(payload.contents[0].parts[0].text).toContain("Some document text here");
-  });
-
-  it("sends file as inline_data for FILE mode", () => {
-    const mockFile = {
-      getMimeType: () => "application/pdf",
-      getSize: () => 1024,
-      getBlob: () => ({ getBytes: () => [1, 2, 3] }),
-    };
-    (DriveApp.getFileById as jest.Mock).mockReturnValue(mockFile);
-
-    mockFetchResponse({
-      candidates: [{ content: { parts: [{ text: "Analyzed your PDF" }] } }],
-    });
-
-    const result = callGeminiAPI("key123", "Be helpful", "What is this?", {
-      fileId: "file123abc",
-    });
-
-    expect(result).toBe("Analyzed your PDF");
-
-    const callArgs = (UrlFetchApp.fetch as jest.Mock).mock.calls[0];
-    const payload = JSON.parse(callArgs[1].payload);
-    expect(payload.contents[0].parts).toHaveLength(2);
-    expect(payload.contents[0].parts[1].inline_data.mime_type).toBe("application/pdf");
-  });
-
-  it("throws on file size exceeding 25MB", () => {
-    const mockFile = {
-      getMimeType: () => "application/pdf",
-      getSize: () => 30 * 1024 * 1024, // 30MB
-      getBlob: () => ({ getBytes: () => [] }),
-    };
-    (DriveApp.getFileById as jest.Mock).mockReturnValue(mockFile);
-
-    expect(() =>
-      callGeminiAPI("key123", "", "analyze", { fileId: "bigfile" }),
-    ).toThrow("File too large");
-  });
-
-  it("throws on API error response", () => {
-    mockFetchResponse({ error: { message: "Invalid API key" } });
-
-    expect(() =>
-      callGeminiAPI("badkey", "", "test", { textContext: "ctx" }),
-    ).toThrow("Invalid API key");
+    expect(callGeminiAPI(baseReq)).toBe("AI says hello");
   });
 
   it("returns 'No response.' when candidates are empty", () => {
     mockFetchResponse({ candidates: [] });
-
-    const result = callGeminiAPI("key123", "", "test", { textContext: "ctx" });
-    expect(result).toBe("No response.");
+    expect(callGeminiAPI(baseReq)).toBe("No response.");
   });
 
-  it("uses default system prompt when none provided", () => {
-    mockFetchResponse({
-      candidates: [{ content: { parts: [{ text: "ok" }] } }],
-    });
+  it("throws on API error response", () => {
+    mockFetchResponse({ error: { message: "Invalid API key" } });
+    expect(() => callGeminiAPI({ ...baseReq, apiKey: "bad" })).toThrow("Invalid API key");
+  });
 
-    callGeminiAPI("key123", "", "test", { textContext: "ctx" });
+  it("uses modelName from request when provided", () => {
+    mockFetchResponse({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
+    callGeminiAPI({ ...baseReq, modelName: "gemini-1.5-pro" });
+    const url = (UrlFetchApp.fetch as jest.Mock).mock.calls[0][0];
+    expect(url).toContain("gemini-1.5-pro");
+  });
 
-    const callArgs = (UrlFetchApp.fetch as jest.Mock).mock.calls[0];
-    const payload = JSON.parse(callArgs[1].payload);
-    expect(payload.system_instruction.parts[0].text).toBe("You are a helpful assistant.");
+  it("falls back to CONFIG.MODEL_NAME when modelName is omitted", () => {
+    mockFetchResponse({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
+    callGeminiAPI(baseReq);
+    const url = (UrlFetchApp.fetch as jest.Mock).mock.calls[0][0];
+    expect(url).toContain("gemini-2.0-flash");
   });
 });

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -14,6 +14,7 @@
 // ── Import after mocks ─────────────────────────────────────────
 
 import { buildGeminiPayload, callGeminiAPI } from "../src/server/api";
+import { CONFIG } from "../src/server/config";
 import type { GeminiRequest } from "../src/shared/types";
 
 // ── Helpers ────────────────────────────────────────────────────
@@ -124,6 +125,6 @@ describe("callGeminiAPI", () => {
     mockFetchResponse({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
     callGeminiAPI(baseReq);
     const url = (UrlFetchApp.fetch as jest.Mock).mock.calls[0][0];
-    expect(url).toContain("gemini-2.0-flash");
+    expect(url).toContain(CONFIG.MODEL_NAME);
   });
 });

--- a/__tests__/drive.test.ts
+++ b/__tests__/drive.test.ts
@@ -22,6 +22,10 @@ const mockUi = {
   openById: jest.fn(),
 };
 
+(globalThis as any).Utilities = {
+  base64Encode: jest.fn().mockReturnValue("base64data=="),
+};
+
 (globalThis as any).MimeType = {
   GOOGLE_DOCS: "application/vnd.google-apps.document",
   PDF: "application/pdf",
@@ -29,7 +33,7 @@ const mockUi = {
 
 // ── Import after mocks ─────────────────────────────────────────
 
-import { checkDriveService, extractTextUniversal } from "../src/server/drive";
+import { checkDriveService, extractTextUniversal, fetchAndEncodeFile } from "../src/server/drive";
 
 // ── Tests ──────────────────────────────────────────────────────
 
@@ -129,5 +133,33 @@ describe("extractTextUniversal", () => {
 
     expect(extractTextUniversal("imgId123")).toBe("ocr text from image");
     expect((Drive.Files as any).remove).toHaveBeenCalledWith("tempImgDocId");
+  });
+});
+
+describe("fetchAndEncodeFile", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns mime_type and base64-encoded data for a valid file", () => {
+    const mockFile = {
+      getMimeType: () => "application/pdf",
+      getSize: () => 1024,
+      getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+    };
+    (DriveApp.getFileById as jest.Mock).mockReturnValue(mockFile);
+
+    const result = fetchAndEncodeFile("file123");
+    expect(result.mime_type).toBe("application/pdf");
+    expect(result.data).toBe("base64data=="); // matches Utilities mock in this file
+  });
+
+  it("throws when file exceeds 25MB", () => {
+    const mockFile = {
+      getMimeType: () => "application/pdf",
+      getSize: () => 30 * 1024 * 1024,
+      getBlob: () => ({ getBytes: () => [] }),
+    };
+    (DriveApp.getFileById as jest.Mock).mockReturnValue(mockFile);
+
+    expect(() => fetchAndEncodeFile("bigfile")).toThrow("File too large");
   });
 });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -89,6 +89,13 @@ describe("createSeededRandom", () => {
       expect(val).toBeLessThan(1);
     }
   });
+
+  it("produces values in [0, 1) when called without a seed", () => {
+    const rng = createSeededRandom();
+    const val = rng();
+    expect(val).toBeGreaterThanOrEqual(0);
+    expect(val).toBeLessThan(1);
+  });
 });
 
 describe("sampleRows", () => {

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -13,9 +13,8 @@ import {
   getAllFilesRecursive,
   sampleRows,
   truncateText,
-  getAIContext,
 } from "../src/server/utils";
-import type { ColumnMap, DriveFileInfo } from "../src/shared/types";
+import type { DriveFileInfo } from "../src/shared/types";
 
 describe("extractId", () => {
   it("extracts ID from a standard Drive file URL", () => {
@@ -132,60 +131,6 @@ describe("truncateText", () => {
     const text = "a".repeat(101);
     const result = truncateText(text, 100);
     expect(result).toBe("a".repeat(100) + "... [TRUNCATED]");
-  });
-});
-
-describe("getAIContext", () => {
-  const baseMap: ColumnMap = {
-    source_drive: 0,
-    source_text: 1,
-    sys_prompt: 2,
-    user_prompt: 3,
-    output: 4,
-  };
-
-  describe("TEXT mode", () => {
-    it("returns textContext when source text is valid", () => {
-      const row = [
-        "https://drive.google.com/file/d/abc",
-        "This is valid text for the AI",
-        "",
-        "",
-        "",
-      ];
-      expect(getAIContext(row, baseMap, "TEXT")).toEqual({
-        textContext: "This is valid text for the AI",
-      });
-    });
-
-    it("returns null when source text is too short (5 chars or fewer)", () => {
-      const row = ["", "hi", "", "", ""];
-      expect(getAIContext(row, baseMap, "TEXT")).toBeNull();
-    });
-
-    it("returns null when source text contains 'Error'", () => {
-      const row = ["", "[Error: something went wrong]", "", "", ""];
-      expect(getAIContext(row, baseMap, "TEXT")).toBeNull();
-    });
-
-    it("returns null when source_text column is missing (index -1)", () => {
-      const mapNoText = { ...baseMap, source_text: -1 };
-      const row = ["", "some text", "", "", ""];
-      expect(getAIContext(row, mapNoText, "TEXT")).toBeNull();
-    });
-  });
-
-  describe("FILE mode", () => {
-    it("returns fileId when a valid Drive link is present", () => {
-      const row = ["https://drive.google.com/file/d/abc123defgh456ijklm789nop", "", "", "", ""];
-      const result = getAIContext(row, baseMap, "FILE");
-      expect(result).toEqual({ fileId: "abc123defgh456ijklm789nop" });
-    });
-
-    it("returns null when Drive link is invalid", () => {
-      const row = ["not-a-drive-link", "", "", "", ""];
-      expect(getAIContext(row, baseMap, "FILE")).toBeNull();
-    });
   });
 });
 

--- a/docs/plans/2026-02-20-gemini-api-interface-design.md
+++ b/docs/plans/2026-02-20-gemini-api-interface-design.md
@@ -1,0 +1,116 @@
+# Gemini API Interface Design
+
+**Date:** 2026-02-20
+**Status:** Approved
+
+## Context
+
+`src/server/api.ts` currently exports a single function `callGeminiAPI(apiKey, systemPrompt, userPrompt, context)`. It has two responsibilities that should be separated:
+
+1. Drive file I/O — fetching a file by ID, checking its size, and base64-encoding it via `DriveApp` and `Utilities`
+2. HTTP call to the Gemini `generateContent` endpoint via `UrlFetchApp`
+
+`AIContext` (a discriminated union of `TextContext | FileContext`) encodes both the text-append and file-attach paths inside the API function. This couples Drive logic to the HTTP adapter and requires tests to mock `DriveApp` and `Utilities` alongside `UrlFetchApp`.
+
+The refactor replaces `callGeminiAPI` entirely with a cleaner interface that:
+- Accepts fully preprocessed inputs (all encoding and text assembly done by the caller)
+- Removes all `DriveApp` and `Utilities` dependencies from `api.ts`
+- Supports multiple text parts per user message
+- Provides a hook for function calling (tools)
+- Exposes `buildGeminiPayload` as a pure, independently testable function
+
+## Design
+
+### 1. New types in `src/shared/types.ts`
+
+Add Gemini API primitives and a unified request interface. Remove `AIContext`, `TextContext`, and `FileContext`.
+
+```typescript
+export interface GeminiInlineData {
+  mime_type: string;
+  data: string; // base64-encoded bytes
+}
+
+export interface GeminiFunctionDeclaration {
+  name: string;
+  description: string;
+  parameters?: Record<string, unknown>; // JSON Schema object
+}
+
+export interface GeminiGenerationConfig {
+  temperature?: number;
+  maxOutputTokens?: number;
+  responseMimeType?: string;
+}
+
+export interface GeminiRequest {
+  apiKey: string;
+  modelName?: string;              // defaults to CONFIG.MODEL_NAME if omitted
+  systemPrompt?: string;
+  userTexts: string[];             // assembled into parts: [{text}, {text}, ...]
+  inlineData?: GeminiInlineData;  // appended as a final part if present
+  tools?: GeminiFunctionDeclaration[];
+  generationConfig?: GeminiGenerationConfig;
+}
+```
+
+### 2. `src/server/api.ts` — two exported functions
+
+```typescript
+export function buildGeminiPayload(req: GeminiRequest): Record<string, unknown>
+export function callGeminiAPI(req: GeminiRequest): string
+```
+
+**`buildGeminiPayload`** — pure function, no GAS globals:
+- Assembles `system_instruction` from `req.systemPrompt` (defaults to `"You are a helpful assistant."`)
+- Builds `parts` array: one `{ text }` per entry in `req.userTexts`, then appends `{ inline_data }` if `req.inlineData` is present
+- Merges `generationConfig` and `tools` if provided
+- Returns the full payload object
+
+**`callGeminiAPI`** — calls `buildGeminiPayload`, then `UrlFetchApp.fetch`. Only GAS global needed is `UrlFetchApp`. Returns the text of `candidates[0].content.parts[0].text` or `"No response."`.
+
+### 3. Call-site changes in `src/server/index.ts`
+
+`runBatchAI` pre-assembles the `GeminiRequest` before calling the API. Drive fetching and encoding moves out of `api.ts`:
+
+```typescript
+// TEXT mode
+const result = callGeminiAPI({
+  apiKey,
+  systemPrompt: row[map.sys_prompt],
+  userTexts: [row[map.user_prompt], row[map.source_text]].filter(Boolean),
+});
+
+// FILE mode
+const encoded = fetchAndEncodeFile(fileId); // Drive fetch + base64, returns GeminiInlineData
+const result = callGeminiAPI({
+  apiKey,
+  systemPrompt: row[map.sys_prompt],
+  userTexts: [row[map.user_prompt]],
+  inlineData: encoded,
+});
+```
+
+The Drive fetch + encode helper (`fetchAndEncodeFile`) belongs in `src/server/drive.ts` alongside the existing Drive logic.
+
+### 4. Test changes in `__tests__/api.test.ts`
+
+- Remove all `DriveApp` and `Utilities` mocks
+- Add direct tests for `buildGeminiPayload` covering: single text part, multiple text parts, inline data appended as final part, system prompt default, tools field, generationConfig passthrough
+- Update `callGeminiAPI` tests to use the new `GeminiRequest` shape
+- Add a test for the Drive helper in `__tests__/drive.test.ts`
+
+## What This Does Not Include
+
+- Multi-turn conversation support (the `contents` array remains a single user turn)
+- Agentic function calling execution loop — `tools` is wired to the payload but the response parsing for `functionCall` candidates is not implemented; that is deferred until a concrete use case is designed
+- Changes to `src/server/config.ts` or `appsscript.json`
+
+## Separation of Concerns After Refactor
+
+| Responsibility | Location |
+|---|---|
+| Gemini HTTP call + payload assembly | `src/server/api.ts` |
+| Drive file fetch + base64 encode | `src/server/drive.ts` |
+| Text context assembly, column mapping | `src/server/index.ts` (`runBatchAI`) |
+| Gemini API types | `src/shared/types.ts` |

--- a/docs/plans/2026-02-20-gemini-api-interface.md
+++ b/docs/plans/2026-02-20-gemini-api-interface.md
@@ -1,0 +1,595 @@
+# Gemini API Interface Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace `callGeminiAPI(apiKey, systemPrompt, userPrompt, context)` with a `GeminiRequest` options object interface that separates Drive I/O from the HTTP adapter, supports multiple text parts per message, and hooks for function calling.
+
+**Architecture:** New `GeminiRequest` interface in `types.ts` carries all preprocessed inputs. `api.ts` becomes a pure HTTP adapter with a separately testable `buildGeminiPayload`. Drive fetch + base64 encode moves to `drive.ts` as `fetchAndEncodeFile`. `getAIContext` in `utils.ts` is deleted — its skip logic moves inline to `runBatchAI`.
+
+**Tech Stack:** TypeScript, Jest + ts-jest, Google Apps Script globals (UrlFetchApp, DriveApp, Utilities)
+
+---
+
+### Task 1: Update shared types
+
+**Files:**
+- Modify: `src/shared/types.ts`
+
+**Step 1: Remove old AI context types and add Gemini API types**
+
+Replace the `// ── AI Context` section (lines 33–46) with the following. Keep `AIMode` — it is still used by `runBatchAI`.
+
+```typescript
+// ── AI Mode ────────────────────────────────────────────────────
+export type AIMode = "TEXT" | "FILE";
+
+// ── Gemini API ─────────────────────────────────────────────────
+
+export interface GeminiInlineData {
+  mime_type: string;
+  data: string; // base64-encoded bytes
+}
+
+export interface GeminiFunctionDeclaration {
+  name: string;
+  description: string;
+  parameters?: Record<string, unknown>; // JSON Schema object
+}
+
+export interface GeminiGenerationConfig {
+  temperature?: number;
+  maxOutputTokens?: number;
+  responseMimeType?: string;
+}
+
+export interface GeminiRequest {
+  apiKey: string;
+  modelName?: string; // defaults to CONFIG.MODEL_NAME if omitted
+  systemPrompt?: string;
+  userTexts: string[]; // assembled into parts: [{text}, {text}, ...]
+  inlineData?: GeminiInlineData; // appended as a final part if present
+  tools?: GeminiFunctionDeclaration[];
+  generationConfig?: GeminiGenerationConfig;
+}
+```
+
+The deleted types are: `TextContext`, `FileContext`, `AIContext`.
+
+**Step 2: Run typecheck to see all breakage sites**
+
+```bash
+npm run typecheck
+```
+
+Expected: errors in `api.ts`, `utils.ts`, `index.ts` — these will be fixed in subsequent tasks.
+
+**Step 3: Commit types**
+
+```bash
+git add src/shared/types.ts
+git commit -m "feat: add GeminiRequest interface, remove AIContext types"
+```
+
+---
+
+### Task 2: Rewrite api.ts tests (TDD — write tests before implementation)
+
+**Files:**
+- Modify: `__tests__/api.test.ts`
+
+**Step 1: Replace the test file with the new test suite**
+
+The new test file removes `DriveApp` and `Utilities` mocks entirely (those globals are no longer used in `api.ts`). It adds direct tests for `buildGeminiPayload` and updates `callGeminiAPI` tests to use `GeminiRequest`.
+
+```typescript
+/**
+ * Tests for src/server/api.ts
+ *
+ * Only UrlFetchApp needs mocking — DriveApp and Utilities are no longer
+ * used in this module.
+ */
+
+// ── Mock globals BEFORE imports ────────────────────────────────
+
+(globalThis as any).UrlFetchApp = {
+  fetch: jest.fn(),
+};
+
+// ── Import after mocks ─────────────────────────────────────────
+
+import { buildGeminiPayload, callGeminiAPI } from "../src/server/api";
+import type { GeminiRequest } from "../src/shared/types";
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function mockFetchResponse(body: unknown) {
+  (UrlFetchApp.fetch as jest.Mock).mockReturnValue({
+    getContentText: () => JSON.stringify(body),
+  });
+}
+
+const baseReq: GeminiRequest = {
+  apiKey: "key123",
+  systemPrompt: "Be helpful",
+  userTexts: ["Summarize this"],
+};
+
+// ── buildGeminiPayload tests ───────────────────────────────────
+
+describe("buildGeminiPayload", () => {
+  it("assembles a single text part", () => {
+    const payload = buildGeminiPayload(baseReq);
+    const parts = (payload.contents as any)[0].parts;
+    expect(parts).toHaveLength(1);
+    expect(parts[0].text).toBe("Summarize this");
+  });
+
+  it("assembles multiple text parts in order", () => {
+    const req: GeminiRequest = { ...baseReq, userTexts: ["Prompt", "Context"] };
+    const payload = buildGeminiPayload(req);
+    const parts = (payload.contents as any)[0].parts;
+    expect(parts).toHaveLength(2);
+    expect(parts[0].text).toBe("Prompt");
+    expect(parts[1].text).toBe("Context");
+  });
+
+  it("appends inline_data as the final part when provided", () => {
+    const req: GeminiRequest = {
+      ...baseReq,
+      userTexts: ["What is this?"],
+      inlineData: { mime_type: "application/pdf", data: "base64==" },
+    };
+    const payload = buildGeminiPayload(req);
+    const parts = (payload.contents as any)[0].parts;
+    expect(parts).toHaveLength(2);
+    expect(parts[1].inline_data).toEqual({ mime_type: "application/pdf", data: "base64==" });
+  });
+
+  it("uses default system prompt when systemPrompt is omitted", () => {
+    const req: GeminiRequest = { apiKey: "k", userTexts: ["hi"] };
+    const payload = buildGeminiPayload(req);
+    expect((payload.system_instruction as any).parts[0].text).toBe("You are a helpful assistant.");
+  });
+
+  it("includes tools when provided", () => {
+    const req: GeminiRequest = {
+      ...baseReq,
+      tools: [{ name: "myFn", description: "does stuff" }],
+    };
+    const payload = buildGeminiPayload(req);
+    expect((payload.tools as any)[0].function_declarations[0].name).toBe("myFn");
+  });
+
+  it("omits tools key when tools array is empty or absent", () => {
+    const payload = buildGeminiPayload(baseReq);
+    expect(payload.tools).toBeUndefined();
+  });
+
+  it("passes through generationConfig when provided", () => {
+    const req: GeminiRequest = {
+      ...baseReq,
+      generationConfig: { temperature: 0.5, maxOutputTokens: 1024 },
+    };
+    const payload = buildGeminiPayload(req);
+    expect((payload.generationConfig as any).temperature).toBe(0.5);
+  });
+});
+
+// ── callGeminiAPI tests ────────────────────────────────────────
+
+describe("callGeminiAPI", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns the text from the first candidate", () => {
+    mockFetchResponse({
+      candidates: [{ content: { parts: [{ text: "AI says hello" }] } }],
+    });
+    expect(callGeminiAPI(baseReq)).toBe("AI says hello");
+  });
+
+  it("returns 'No response.' when candidates are empty", () => {
+    mockFetchResponse({ candidates: [] });
+    expect(callGeminiAPI(baseReq)).toBe("No response.");
+  });
+
+  it("throws on API error response", () => {
+    mockFetchResponse({ error: { message: "Invalid API key" } });
+    expect(() => callGeminiAPI({ ...baseReq, apiKey: "bad" })).toThrow("Invalid API key");
+  });
+
+  it("uses modelName from request when provided", () => {
+    mockFetchResponse({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
+    callGeminiAPI({ ...baseReq, modelName: "gemini-1.5-pro" });
+    const url = (UrlFetchApp.fetch as jest.Mock).mock.calls[0][0];
+    expect(url).toContain("gemini-1.5-pro");
+  });
+
+  it("falls back to CONFIG.MODEL_NAME when modelName is omitted", () => {
+    mockFetchResponse({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
+    callGeminiAPI(baseReq);
+    const url = (UrlFetchApp.fetch as jest.Mock).mock.calls[0][0];
+    expect(url).toContain("gemini-2.0-flash");
+  });
+});
+```
+
+**Step 2: Run the new tests — expect them to fail**
+
+```bash
+npx jest __tests__/api.test.ts
+```
+
+Expected: FAIL — `buildGeminiPayload` is not exported from `api.ts` yet, and `callGeminiAPI` has the wrong signature.
+
+**Step 3: Commit the failing tests**
+
+```bash
+git add __tests__/api.test.ts
+git commit -m "test: rewrite api tests for GeminiRequest interface (failing)"
+```
+
+---
+
+### Task 3: Rewrite api.ts implementation
+
+**Files:**
+- Modify: `src/server/api.ts`
+
+**Step 1: Replace the file contents**
+
+```typescript
+/**
+ * api.ts — Gemini API interaction via UrlFetchApp.
+ *
+ * Pure HTTP adapter. All preprocessing (Drive file fetching, base64 encoding,
+ * text assembly) is the caller's responsibility.
+ *
+ * Requires oauth scope: https://www.googleapis.com/auth/script.external_request
+ */
+
+import { CONFIG } from "./config";
+import type { GeminiInlineData, GeminiRequest } from "../shared/types";
+
+interface GeminiPart {
+  text?: string;
+  inline_data?: GeminiInlineData;
+}
+
+/**
+ * Assemble the Gemini generateContent request payload from a GeminiRequest.
+ * Pure function — no GAS globals. Independently testable.
+ */
+export function buildGeminiPayload(req: GeminiRequest): Record<string, unknown> {
+  const parts: GeminiPart[] = req.userTexts.map((text) => ({ text }));
+  if (req.inlineData) {
+    parts.push({ inline_data: req.inlineData });
+  }
+
+  const payload: Record<string, unknown> = {
+    system_instruction: {
+      parts: [{ text: req.systemPrompt || "You are a helpful assistant." }],
+    },
+    contents: [{ role: "user", parts }],
+  };
+
+  if (req.generationConfig) {
+    payload.generationConfig = req.generationConfig;
+  }
+
+  if (req.tools && req.tools.length > 0) {
+    payload.tools = [{ function_declarations: req.tools }];
+  }
+
+  return payload;
+}
+
+/**
+ * Call the Gemini generateContent endpoint and return the response text.
+ */
+export function callGeminiAPI(req: GeminiRequest): string {
+  const modelName = req.modelName ?? CONFIG.MODEL_NAME;
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent?key=${req.apiKey}`;
+
+  const options: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
+    method: "post",
+    contentType: "application/json",
+    payload: JSON.stringify(buildGeminiPayload(req)),
+    muteHttpExceptions: true,
+  };
+
+  const response = UrlFetchApp.fetch(url, options);
+  const json = JSON.parse(response.getContentText()) as Record<string, unknown>;
+
+  if (json.error) throw new Error((json.error as { message: string }).message);
+  return (json.candidates as any)?.[0]?.content?.parts?.[0]?.text ?? "No response.";
+}
+```
+
+**Step 2: Run the api tests — expect them to pass**
+
+```bash
+npx jest __tests__/api.test.ts
+```
+
+Expected: all tests PASS.
+
+**Step 3: Commit**
+
+```bash
+git add src/server/api.ts
+git commit -m "feat: rewrite api.ts with GeminiRequest options object and buildGeminiPayload"
+```
+
+---
+
+### Task 4: Add fetchAndEncodeFile to drive.ts (TDD)
+
+**Files:**
+- Modify: `__tests__/drive.test.ts`
+- Modify: `src/server/drive.ts`
+
+**Step 1: Add failing tests for fetchAndEncodeFile in drive.test.ts**
+
+Open `__tests__/drive.test.ts`. The file already mocks `DriveApp` and `Utilities` globally at the top. Add this `describe` block after the existing tests:
+
+```typescript
+describe("fetchAndEncodeFile", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns mime_type and base64-encoded data for a valid file", () => {
+    const mockFile = {
+      getMimeType: () => "application/pdf",
+      getSize: () => 1024,
+      getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+    };
+    (DriveApp.getFileById as jest.Mock).mockReturnValue(mockFile);
+
+    const result = fetchAndEncodeFile("file123");
+    expect(result.mime_type).toBe("application/pdf");
+    expect(result.data).toBe("base64data=="); // matches mock in Utilities
+  });
+
+  it("throws when file exceeds 25MB", () => {
+    const mockFile = {
+      getMimeType: () => "application/pdf",
+      getSize: () => 30 * 1024 * 1024,
+      getBlob: () => ({ getBytes: () => [] }),
+    };
+    (DriveApp.getFileById as jest.Mock).mockReturnValue(mockFile);
+
+    expect(() => fetchAndEncodeFile("bigfile")).toThrow("File too large");
+  });
+});
+```
+
+Also add `fetchAndEncodeFile` to the import line at the top of the file:
+
+```typescript
+import { checkDriveService, extractTextUniversal, fetchAndEncodeFile } from "../src/server/drive";
+```
+
+**Step 2: Run drive tests — expect new tests to fail**
+
+```bash
+npx jest __tests__/drive.test.ts
+```
+
+Expected: FAIL — `fetchAndEncodeFile` is not exported yet.
+
+**Step 3: Add fetchAndEncodeFile to drive.ts**
+
+Add this import at the top of `src/server/drive.ts` (after the JSDoc comment block):
+
+```typescript
+import { CONFIG } from "./config";
+import type { GeminiInlineData } from "../shared/types";
+```
+
+Add this function at the end of `src/server/drive.ts`:
+
+```typescript
+/**
+ * Fetch a Drive file by ID and return it as base64-encoded inline data
+ * ready for the Gemini API. Throws if the file exceeds the 25MB limit.
+ */
+export function fetchAndEncodeFile(fileId: string): GeminiInlineData {
+  const file = DriveApp.getFileById(fileId);
+  if (file.getSize() > CONFIG.MAX_FILE_SIZE_BYTES) {
+    throw new Error("File too large (>25MB).");
+  }
+  return {
+    mime_type: file.getMimeType(),
+    data: Utilities.base64Encode(file.getBlob().getBytes()),
+  };
+}
+```
+
+**Step 4: Run drive tests — expect all to pass**
+
+```bash
+npx jest __tests__/drive.test.ts
+```
+
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/server/drive.ts __tests__/drive.test.ts
+git commit -m "feat: add fetchAndEncodeFile to drive.ts"
+```
+
+---
+
+### Task 5: Remove getAIContext from utils.ts and its tests
+
+**Files:**
+- Modify: `src/server/utils.ts`
+- Modify: `__tests__/utils.test.ts`
+
+**Step 1: Remove getAIContext from utils.ts**
+
+In `src/server/utils.ts`:
+
+1. Change the import on line 8 from:
+   ```typescript
+   import type { AIContext, AIMode, ColumnMap, DriveFileInfo } from "../shared/types";
+   ```
+   to:
+   ```typescript
+   import type { ColumnMap, DriveFileInfo } from "../shared/types";
+   ```
+
+2. Delete the entire `getAIContext` function (lines 82–102).
+
+**Step 2: Remove getAIContext from utils.test.ts**
+
+In `__tests__/utils.test.ts`:
+
+1. Remove `getAIContext` from the import list (line 16).
+2. Delete the entire `describe("getAIContext", ...)` block (lines 138–190).
+
+**Step 3: Run utils tests — expect all to pass**
+
+```bash
+npx jest __tests__/utils.test.ts
+```
+
+Expected: all PASS.
+
+**Step 4: Commit**
+
+```bash
+git add src/server/utils.ts __tests__/utils.test.ts
+git commit -m "refactor: remove getAIContext (logic moved inline to runBatchAI)"
+```
+
+---
+
+### Task 6: Update runBatchAI in index.ts
+
+**Files:**
+- Modify: `src/server/index.ts`
+
+**Step 1: Update imports**
+
+Change the import from `./utils` to remove `getAIContext`:
+
+```typescript
+import {
+  extractId,
+  getAIContext,   // ← remove this line
+  isValidDriveLink,
+  getAllFilesRecursive,
+  sampleRows,
+  truncateText,
+} from "./utils";
+```
+
+Add `fetchAndEncodeFile` to the `./drive` import:
+
+```typescript
+import { checkDriveService, extractTextUniversal, fetchAndEncodeFile } from "./drive";
+```
+
+Remove `AIMode` from the `../shared/types` import if it is no longer needed after this change — check whether `AIMode` is still used in the file (it is, in the `runBatchAI` signature and `handleDialogSelection`), so keep it.
+
+**Step 2: Replace the try block inside runBatchAI**
+
+Find this block inside the `for` loop in `runBatchAI` (around line 288):
+
+```typescript
+try {
+  const context = getAIContext(row, map, mode);
+  if (context) {
+    result = callGeminiAPI(apiKey, row[map.sys_prompt] as string, usrPrompt, context);
+  } else {
+    result = mode === "TEXT" ? "[Skipped: No valid text]" : "[Skipped: No valid Drive Link]";
+  }
+  sheet.getRange(realRowIndex, map.output + 1).setValue(result);
+  processed++;
+} catch (e) {
+  sheet.getRange(realRowIndex, map.output + 1).setValue("Error: " + (e as Error).message);
+}
+```
+
+Replace it with:
+
+```typescript
+try {
+  const systemPrompt = row[map.sys_prompt] as string;
+
+  if (mode === "TEXT") {
+    const sourceText = map.source_text > -1 ? (row[map.source_text] as string) : "";
+    if (!sourceText || sourceText.length <= 5 || sourceText.includes("Error")) {
+      result = "[Skipped: No valid text]";
+    } else {
+      result = callGeminiAPI({ apiKey, systemPrompt, userTexts: [usrPrompt, sourceText] });
+    }
+  } else {
+    const link = row[map.source_drive] as string;
+    if (!isValidDriveLink(link)) {
+      result = "[Skipped: No valid Drive Link]";
+    } else {
+      const inlineData = fetchAndEncodeFile(extractId(link));
+      result = callGeminiAPI({ apiKey, systemPrompt, userTexts: [usrPrompt], inlineData });
+    }
+  }
+
+  sheet.getRange(realRowIndex, map.output + 1).setValue(result);
+  processed++;
+} catch (e) {
+  sheet.getRange(realRowIndex, map.output + 1).setValue("Error: " + (e as Error).message);
+}
+```
+
+**Step 3: Run typecheck — expect zero errors**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors.
+
+**Step 4: Run full test suite**
+
+```bash
+npm test
+```
+
+Expected: all suites PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/server/index.ts
+git commit -m "feat: update runBatchAI to use GeminiRequest interface"
+```
+
+---
+
+### Task 7: Final verification
+
+**Step 1: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: no errors or warnings.
+
+**Step 2: Run full test suite with coverage**
+
+```bash
+npm run test:coverage
+```
+
+Expected: all thresholds met.
+
+**Step 3: Build**
+
+```bash
+npm run build
+```
+
+Expected: clean build, no errors in `dist/`.

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -61,5 +61,8 @@ export function callGeminiAPI(req: GeminiRequest): string {
   const json = JSON.parse(response.getContentText()) as Record<string, unknown>;
 
   if (json.error) throw new Error((json.error as { message: string }).message);
-  return (json.candidates as any)?.[0]?.content?.parts?.[0]?.text ?? "No response.";
+  const candidates = json.candidates as
+    | Array<{ content: { parts: Array<{ text: string }> } }>
+    | undefined;
+  return candidates?.[0]?.content?.parts?.[0]?.text ?? "No response.";
 }

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -1,69 +1,65 @@
 /**
- * api.ts — Gemini API interaction via UrlFetchApp. test change
+ * api.ts — Gemini API interaction via UrlFetchApp.
+ *
+ * Pure HTTP adapter. All preprocessing (Drive file fetching, base64 encoding,
+ * text assembly) is the caller's responsibility.
  *
  * Requires oauth scope: https://www.googleapis.com/auth/script.external_request
  */
 
 import { CONFIG } from "./config";
-import type { AIContext } from "../shared/types";
+import type { GeminiInlineData, GeminiRequest } from "../shared/types";
+
+interface GeminiPart {
+  text?: string;
+  inline_data?: GeminiInlineData;
+}
 
 /**
- * Call the Gemini generateContent endpoint.
- *
- * Supports two context modes:
- * - textContext: appends text to the user prompt (fast, text-only)
- * - fileId: base64-encodes the Drive file as inline_data (multimodal)
+ * Assemble the Gemini generateContent request payload from a GeminiRequest.
+ * Pure function — no GAS globals. Independently testable.
  */
-export function callGeminiAPI(
-  apiKey: string,
-  systemPrompt: string,
-  userPrompt: string,
-  context: AIContext,
-): string {
-  const url = `https://generativelanguage.googleapis.com/v1beta/models/${CONFIG.MODEL_NAME}:generateContent?key=${apiKey}`;
+export function buildGeminiPayload(req: GeminiRequest): Record<string, unknown> {
+  const parts: GeminiPart[] = req.userTexts.map((text) => ({ text }));
+  if (req.inlineData) {
+    parts.push({ inline_data: req.inlineData });
+  }
 
   const payload: Record<string, unknown> = {
     system_instruction: {
-      parts: [{ text: systemPrompt || "You are a helpful assistant." }],
+      parts: [{ text: req.systemPrompt || "You are a helpful assistant." }],
     },
-    contents: [
-      {
-        role: "user",
-        parts: [{ text: userPrompt }],
-      },
-    ],
+    contents: [{ role: "user", parts }],
   };
 
-  // Branch on context type
-  const parts = (payload.contents as { parts: Record<string, unknown>[] }[])[0].parts;
-
-  if (context.textContext) {
-    // Append text context to the user prompt part
-    parts[parts.length - 1].text += `\n\n--- CONTEXT ---\n${context.textContext}`;
-  } else if (context.fileId) {
-    // Base64-encode the file and attach as inline_data
-    const file = DriveApp.getFileById(context.fileId);
-    if (file.getSize() > CONFIG.MAX_FILE_SIZE_BYTES) {
-      throw new Error("File too large (>25MB).");
-    }
-    parts.push({
-      inline_data: {
-        mime_type: file.getMimeType(),
-        data: Utilities.base64Encode(file.getBlob().getBytes()),
-      },
-    });
+  if (req.generationConfig) {
+    payload.generationConfig = req.generationConfig;
   }
+
+  if (req.tools && req.tools.length > 0) {
+    payload.tools = [{ function_declarations: req.tools }];
+  }
+
+  return payload;
+}
+
+/**
+ * Call the Gemini generateContent endpoint and return the response text.
+ */
+export function callGeminiAPI(req: GeminiRequest): string {
+  const modelName = req.modelName ?? CONFIG.MODEL_NAME;
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent?key=${req.apiKey}`;
 
   const options: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
     method: "post",
     contentType: "application/json",
-    payload: JSON.stringify(payload),
+    payload: JSON.stringify(buildGeminiPayload(req)),
     muteHttpExceptions: true,
   };
 
   const response = UrlFetchApp.fetch(url, options);
-  const json = JSON.parse(response.getContentText());
+  const json = JSON.parse(response.getContentText()) as Record<string, unknown>;
 
-  if (json.error) throw new Error(json.error.message);
-  return json.candidates?.[0]?.content?.parts?.[0]?.text || "No response.";
+  if (json.error) throw new Error((json.error as { message: string }).message);
+  return (json.candidates as any)?.[0]?.content?.parts?.[0]?.text ?? "No response.";
 }

--- a/src/server/drive.ts
+++ b/src/server/drive.ts
@@ -6,6 +6,9 @@
  * editor (Services > + > Drive API v3) and declared in appsscript.json.
  */
 
+import { CONFIG } from "./config";
+import type { GeminiInlineData } from "../shared/types";
+
 /**
  * Check that the Drive Advanced Service is available.
  * Returns truthy if available, false (and shows alert) if not.
@@ -60,4 +63,19 @@ export function extractTextUniversal(fileId: string): string {
   } catch (e) {
     return `[Error: ${(e as Error).message}]`;
   }
+}
+
+/**
+ * Fetch a Drive file by ID and return it as base64-encoded inline data
+ * ready for the Gemini API. Throws if the file exceeds the 25MB limit.
+ */
+export function fetchAndEncodeFile(fileId: string): GeminiInlineData {
+  const file = DriveApp.getFileById(fileId);
+  if (file.getSize() > CONFIG.MAX_FILE_SIZE_BYTES) {
+    throw new Error("File too large (>25MB).");
+  }
+  return {
+    mime_type: file.getMimeType(),
+    data: Utilities.base64Encode(file.getBlob().getBytes()),
+  };
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,10 +10,9 @@
 
 import { CONFIG } from "./config";
 import { callGeminiAPI } from "./api";
-import { checkDriveService, extractTextUniversal } from "./drive";
+import { checkDriveService, extractTextUniversal, fetchAndEncodeFile } from "./drive";
 import {
   extractId,
-  getAIContext,
   isValidDriveLink,
   getAllFilesRecursive,
   sampleRows,
@@ -286,12 +285,25 @@ export function runBatchAI(mode: AIMode): void {
       let result = "";
 
       try {
-        const context = getAIContext(row, map, mode);
-        if (context) {
-          result = callGeminiAPI(apiKey, row[map.sys_prompt] as string, usrPrompt, context);
+        const systemPrompt = row[map.sys_prompt] as string;
+
+        if (mode === "TEXT") {
+          const sourceText = map.source_text > -1 ? (row[map.source_text] as string) : "";
+          if (!sourceText || sourceText.length <= 5 || sourceText.includes("Error")) {
+            result = "[Skipped: No valid text]";
+          } else {
+            result = callGeminiAPI({ apiKey, systemPrompt, userTexts: [usrPrompt, sourceText] });
+          }
         } else {
-          result = mode === "TEXT" ? "[Skipped: No valid text]" : "[Skipped: No valid Drive Link]";
+          const link = row[map.source_drive] as string;
+          if (!isValidDriveLink(link)) {
+            result = "[Skipped: No valid Drive Link]";
+          } else {
+            const inlineData = fetchAndEncodeFile(extractId(link));
+            result = callGeminiAPI({ apiKey, systemPrompt, userTexts: [usrPrompt], inlineData });
+          }
         }
+
         sheet.getRange(realRowIndex, map.output + 1).setValue(result);
         processed++;
       } catch (e) {

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -5,7 +5,7 @@
  * trivially testable without mocking.
  */
 
-import type { AIContext, AIMode, ColumnMap, DriveFileInfo } from "../shared/types";
+import type { DriveFileInfo } from "../shared/types";
 
 /**
  * Extract a Google Drive file/folder ID from a URL or raw ID string.
@@ -77,26 +77,4 @@ export function sampleRows(data: unknown[][], sampleSize: number, seed: number):
 export function truncateText(text: string, maxLength: number): string {
   if (text.length <= maxLength) return text;
   return text.substring(0, maxLength) + "... [TRUNCATED]";
-}
-
-/**
- * Determine the AI context for a row, or return null to skip it.
- * Pure function — no GAS dependencies.
- */
-export function getAIContext(row: unknown[], map: ColumnMap, mode: AIMode): AIContext | null {
-  if (mode === "TEXT") {
-    const txt = map.source_text > -1 ? (row[map.source_text] as string) : "";
-    if (txt && txt.length > 5 && !txt.includes("Error")) {
-      return { textContext: txt };
-    }
-    return null;
-  }
-  if (mode === "FILE") {
-    const link = row[map.source_drive] as string;
-    if (isValidDriveLink(link)) {
-      return { fileId: extractId(link) };
-    }
-    return null;
-  }
-  return null;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -29,21 +29,37 @@ export interface ColumnMap {
   output: number;
 }
 
-// ── AI Context ─────────────────────────────────────────────────
-
+// ── AI Mode ────────────────────────────────────────────────────
 export type AIMode = "TEXT" | "FILE";
 
-export interface TextContext {
-  textContext: string;
-  fileId?: never;
+// ── Gemini API ─────────────────────────────────────────────────
+
+export interface GeminiInlineData {
+  mime_type: string;
+  data: string; // base64-encoded bytes
 }
 
-export interface FileContext {
-  fileId: string;
-  textContext?: never;
+export interface GeminiFunctionDeclaration {
+  name: string;
+  description: string;
+  parameters?: Record<string, unknown>; // JSON Schema object
 }
 
-export type AIContext = TextContext | FileContext;
+export interface GeminiGenerationConfig {
+  temperature?: number;
+  maxOutputTokens?: number;
+  responseMimeType?: string;
+}
+
+export interface GeminiRequest {
+  apiKey: string;
+  modelName?: string; // defaults to CONFIG.MODEL_NAME if omitted
+  systemPrompt?: string;
+  userTexts: string[]; // assembled into parts: [{text}, {text}, ...]
+  inlineData?: GeminiInlineData; // appended as a final part if present
+  tools?: GeminiFunctionDeclaration[];
+  generationConfig?: GeminiGenerationConfig;
+}
 
 // ── Drive ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Replaces the 4-arg `callGeminiAPI(apiKey, systemPrompt, userPrompt, context)` with a typed `GeminiRequest` options object
- Splits `api.ts` into `buildGeminiPayload` (pure, no GAS globals) + `callGeminiAPI(req)` — independently testable
- Moves Drive fetch + base64 encode out of `api.ts` into `fetchAndEncodeFile` in `drive.ts`
- Removes `AIContext`/`TextContext`/`FileContext` discriminated union; inlines skip logic in `runBatchAI`
- Adds `tools?: GeminiFunctionDeclaration[]` hook for future function calling support

## Test plan

- [ ] `npm run typecheck` — zero errors
- [ ] `npm test` — 51 tests, all passing
- [ ] `npm run test:coverage` — all per-file thresholds met (utils.ts branches now 100%)
- [ ] `npm run build` — clean build, no errors in `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)