### PR TITLE
feat: upgrade GeminiRequest.inlineData to array for multi-file support

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -74,8 +74,8 @@ describe("buildGeminiPayload", () => {
     const payload = buildGeminiPayload(req);
     const parts = (payload.contents as any)[0].parts;
     expect(parts).toHaveLength(3); // 1 text + 2 inline_data
-    expect(parts[1].inline_data.mime_type).toBe("application/pdf");
-    expect(parts[2].inline_data.mime_type).toBe("image/jpeg");
+    expect(parts[1].inline_data).toEqual({ mime_type: "application/pdf", data: "file1==" });
+    expect(parts[2].inline_data).toEqual({ mime_type: "image/jpeg", data: "file2==" });
   });
 
   it("uses default system prompt when systemPrompt is omitted", () => {

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -54,12 +54,28 @@ describe("buildGeminiPayload", () => {
     const req: GeminiRequest = {
       ...baseReq,
       userTexts: ["What is this?"],
-      inlineData: { mime_type: "application/pdf", data: "base64==" },
+      inlineData: [{ mime_type: "application/pdf", data: "base64==" }],
     };
     const payload = buildGeminiPayload(req);
     const parts = (payload.contents as any)[0].parts;
     expect(parts).toHaveLength(2);
     expect(parts[1].inline_data).toEqual({ mime_type: "application/pdf", data: "base64==" });
+  });
+
+  it("appends multiple inline_data parts when inlineData has multiple items", () => {
+    const req: GeminiRequest = {
+      ...baseReq,
+      userTexts: ["Describe both files"],
+      inlineData: [
+        { mime_type: "application/pdf", data: "file1==" },
+        { mime_type: "image/jpeg", data: "file2==" },
+      ],
+    };
+    const payload = buildGeminiPayload(req);
+    const parts = (payload.contents as any)[0].parts;
+    expect(parts).toHaveLength(3); // 1 text + 2 inline_data
+    expect(parts[1].inline_data.mime_type).toBe("application/pdf");
+    expect(parts[2].inline_data.mime_type).toBe("image/jpeg");
   });
 
   it("uses default system prompt when systemPrompt is omitted", () => {

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -21,9 +21,7 @@ interface GeminiPart {
  */
 export function buildGeminiPayload(req: GeminiRequest): Record<string, unknown> {
   const parts: GeminiPart[] = req.userTexts.map((text) => ({ text }));
-  if (req.inlineData) {
-    parts.push({ inline_data: req.inlineData });
-  }
+  req.inlineData?.forEach((d) => parts.push({ inline_data: d }));
 
   const payload: Record<string, unknown> = {
     system_instruction: {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -299,7 +299,7 @@ export function runBatchAI(mode: AIMode): void {
           if (!isValidDriveLink(link)) {
             result = "[Skipped: No valid Drive Link]";
           } else {
-            const inlineData = fetchAndEncodeFile(extractId(link));
+            const inlineData = [fetchAndEncodeFile(extractId(link))];
             result = callGeminiAPI({ apiKey, systemPrompt, userTexts: [usrPrompt], inlineData });
           }
         }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -56,7 +56,7 @@ export interface GeminiRequest {
   modelName?: string; // defaults to CONFIG.MODEL_NAME if omitted
   systemPrompt?: string;
   userTexts: string[]; // assembled into parts: [{text}, {text}, ...]
-  inlineData?: GeminiInlineData; // appended as a final part if present
+  inlineData?: GeminiInlineData[]; // each item appended as an inline_data part
   tools?: GeminiFunctionDeclaration[];
   generationConfig?: GeminiGenerationConfig;
 }


### PR DESCRIPTION
## Summary

- Changes `GeminiRequest.inlineData` from `GeminiInlineData` (singular) to `GeminiInlineData[]` (plural) in `src/shared/types.ts`
- Updates `buildGeminiPayload` in `api.ts` to iterate over the array with `forEach` instead of pushing a single item
- Updates `runBatchAI` in `index.ts` to wrap its single file in an array: `inlineData: [fetchAndEncodeFile(...)]`
- Updates `api.test.ts` to cover both the single-item and multi-item cases, asserting full object shape on each `inline_data` part

## Why

The Gemini API supports multiple `inline_data` parts in a single user message. The previous singular interface couldn't represent this. This change is a prerequisite for the `SSI()` custom function, which needs to accept multiple Drive URLs.

## Test plan

- [x] `npm test` — all tests pass
- [x] `npm run typecheck` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)