### PR TITLE
feat: add SSI Sheets custom function (text-only)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,16 +57,22 @@ function showSourceDialog() { _GASEntry.showSourceDialog(); }
 
 If you skip step 2, the function will exist in the bundle but Apps Script won't be able to discover or call it.
 
+**Custom functions (callable from spreadsheet cells) require one extra step:**
+3. Add a JSDoc comment with `@customfunction` directly on the stub in `rollup.config.js`
+
+The TypeScript-level JSDoc is compiled away by Rollup and does not appear on the global stub. Google Sheets only registers a function as a custom function when `@customfunction` is present in a JSDoc comment on the **global** declaration — the one in the footer. Without it the function executes correctly when called explicitly but does not appear in autocomplete and is not recognized as a custom function by Sheets.
+
 ### Module Dependency Graph
 
 ```
-src/server/index.ts   (entry point — menu, 4 tool orchestrators, UI handlers)
-├── src/server/config.ts   (CONFIG object: API key property name, model, column names, limits)
-├── src/server/api.ts      (callGeminiAPI — text or multimodal via UrlFetchApp + base64)
-├── src/server/drive.ts    (extractTextUniversal, checkDriveService — OCR via Drive Advanced Service)
-├── src/server/dialog.ts   (HTML_TEMPLATE string for AI mode selection modal)
-├── src/server/utils.ts    (extractId, isValidDriveLink, createSeededRandom, getAllFilesRecursive, sampleRows, truncateText, getAIContext)
-└── src/shared/types.ts    (shared interfaces: AppConfig, AIMode, ColumnMap, AIContext variants)
+src/server/index.ts          (entry point — menu, 4 tool orchestrators, UI handlers, re-exports custom functions)
+├── src/server/config.ts         (CONFIG object: API key property name, model, column names, limits)
+├── src/server/api.ts            (callGeminiAPI, buildGeminiPayload — pure HTTP adapter via UrlFetchApp)
+├── src/server/drive.ts          (extractTextUniversal, fetchAndEncodeFile, checkDriveService)
+├── src/server/dialog.ts         (HTML_TEMPLATE string for AI mode selection modal)
+├── src/server/utils.ts          (extractId, isValidDriveLink, createSeededRandom, getAllFilesRecursive, sampleRows, truncateText)
+├── src/server/customFunctions.ts  (SSI — Sheets custom function; TOOL_REGISTRY for named tool declarations)
+└── src/shared/types.ts          (shared interfaces: AppConfig, AIMode, ColumnMap, GeminiRequest, etc.)
 ```
 
 Source files use relative imports (e.g. `../shared/types`). The `@server/*` and `@shared/*` aliases are **Jest-only** (mapped in `jest.config.cjs`) and are not available in TypeScript source.
@@ -103,7 +109,7 @@ The Gemini API key must be set as a Script Property (`GEMINI_API_KEY`) in Apps S
 - **No Node.js built-ins** — everything runs on Google's servers
 - `appsscript.json` must be in `dist/` for clasp push (the build script copies it)
 - Drive Advanced Service must be enabled in the Apps Script editor AND declared in `appsscript.json`
-- `PropertiesService` is not available in custom functions (only in menu-triggered functions)
+- `PropertiesService.getScriptProperties()` is available in custom functions once the add-on has been authorized by the user (opening the menu triggers authorization)
 - `.clasp.json` is generated at deploy time by copying `.clasp.dev.json` or `.clasp.prod.json`
 
 ## Code Style

--- a/__tests__/customFunctions.test.ts
+++ b/__tests__/customFunctions.test.ts
@@ -27,7 +27,7 @@
 
 // ── Import after mocks ─────────────────────────────────────────
 
-import { GEMINI, TOOL_REGISTRY } from "../src/server/customFunctions";
+import { SSI, TOOL_REGISTRY } from "../src/server/customFunctions";
 
 // ── Helpers ────────────────────────────────────────────────────
 
@@ -51,7 +51,7 @@ function mockDriveFile(): void {
 
 // ── Tests ──────────────────────────────────────────────────────
 
-describe("GEMINI", () => {
+describe("SSI", () => {
   beforeEach(() => jest.clearAllMocks());
 
   // ── userTexts normalization ──────────────────────────────────
@@ -59,7 +59,7 @@ describe("GEMINI", () => {
   describe("userTexts normalization", () => {
     it("accepts a single string", () => {
       mockOkResponse("ok");
-      GEMINI("hello");
+      SSI("hello");
       const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
       expect(payload.contents[0].parts).toHaveLength(1);
       expect(payload.contents[0].parts[0].text).toBe("hello");
@@ -67,7 +67,7 @@ describe("GEMINI", () => {
 
     it("flattens a vertical range (multiple rows, one column)", () => {
       mockOkResponse("ok");
-      GEMINI([["row1"], ["row2"], ["row3"]]);
+      SSI([["row1"], ["row2"], ["row3"]]);
       const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
       expect(payload.contents[0].parts).toHaveLength(3);
       expect(payload.contents[0].parts[0].text).toBe("row1");
@@ -76,14 +76,14 @@ describe("GEMINI", () => {
 
     it("flattens a horizontal range (one row, multiple columns)", () => {
       mockOkResponse("ok");
-      GEMINI([["col1", "col2", "col3"]]);
+      SSI([["col1", "col2", "col3"]]);
       const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
       expect(payload.contents[0].parts).toHaveLength(3);
     });
 
     it("filters empty strings from ranges", () => {
       mockOkResponse("ok");
-      GEMINI([["text", "", "more text"]]);
+      SSI([["text", "", "more text"]]);
       const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
       expect(payload.contents[0].parts).toHaveLength(2);
     });
@@ -98,7 +98,7 @@ describe("GEMINI", () => {
     it("attaches a single Drive URL as one inline_data part", () => {
       mockOkResponse("ok");
       mockDriveFile();
-      GEMINI("prompt", driveUrl);
+      SSI("prompt", driveUrl);
       const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
       expect(payload.contents[0].parts).toHaveLength(2); // text + inline_data
       expect(payload.contents[0].parts[1].inline_data.mime_type).toBe("application/pdf");
@@ -107,14 +107,14 @@ describe("GEMINI", () => {
     it("attaches multiple Drive URLs as multiple inline_data parts", () => {
       mockOkResponse("ok");
       mockDriveFile();
-      GEMINI("prompt", [[driveUrl, driveUrl2]]);
+      SSI("prompt", [[driveUrl, driveUrl2]]);
       const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
       expect(payload.contents[0].parts).toHaveLength(3); // text + 2 inline_data
     });
 
     it("omits inline_data parts when inlineData is not provided", () => {
       mockOkResponse("ok");
-      GEMINI("prompt");
+      SSI("prompt");
       const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
       expect(payload.contents[0].parts).toHaveLength(1);
       expect(payload.contents[0].parts[0].inline_data).toBeUndefined();
@@ -126,14 +126,14 @@ describe("GEMINI", () => {
   describe("systemPrompt", () => {
     it("sets system_instruction when provided", () => {
       mockOkResponse("ok");
-      GEMINI("prompt", undefined, "Be concise");
+      SSI("prompt", undefined, "Be concise");
       const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
       expect(payload.system_instruction.parts[0].text).toBe("Be concise");
     });
 
     it("uses default system prompt when omitted", () => {
       mockOkResponse("ok");
-      GEMINI("prompt");
+      SSI("prompt");
       const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
       expect(payload.system_instruction.parts[0].text).toBe("You are a helpful assistant.");
     });
@@ -143,14 +143,14 @@ describe("GEMINI", () => {
 
   describe("toolNames", () => {
     it("returns an error string for an unknown tool name", () => {
-      const result = GEMINI("prompt", undefined, undefined, "nonExistentTool");
-      expect(result).toMatch(/\[GEMINI Error:.*nonExistentTool/);
+      const result = SSI("prompt", undefined, undefined, "nonExistentTool");
+      expect(result).toMatch(/\[SSI Error:.*nonExistentTool/);
     });
 
     it("includes a known tool declaration in the API payload", () => {
       mockOkResponse("ok");
       TOOL_REGISTRY["testTool"] = { name: "testTool", description: "A test tool" };
-      GEMINI("prompt", undefined, undefined, "testTool");
+      SSI("prompt", undefined, undefined, "testTool");
       delete TOOL_REGISTRY["testTool"];
       const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
       expect(payload.tools[0].function_declarations[0].name).toBe("testTool");
@@ -162,8 +162,8 @@ describe("GEMINI", () => {
   describe("API key", () => {
     it("returns an error string when GEMINI_API_KEY is not set", () => {
       (PropertiesService.getScriptProperties().getProperty as jest.Mock).mockReturnValueOnce(null);
-      const result = GEMINI("prompt");
-      expect(result).toMatch(/\[GEMINI Error:.*GEMINI_API_KEY/);
+      const result = SSI("prompt");
+      expect(result).toMatch(/\[SSI Error:.*GEMINI_API_KEY/);
     });
   });
 
@@ -172,13 +172,13 @@ describe("GEMINI", () => {
   describe("error handling", () => {
     it("returns an error string on API error response", () => {
       mockFetchResponse({ error: { message: "quota exceeded" } });
-      const result = GEMINI("prompt");
-      expect(result).toMatch(/\[GEMINI Error:.*quota exceeded/);
+      const result = SSI("prompt");
+      expect(result).toMatch(/\[SSI Error:.*quota exceeded/);
     });
 
     it("returns the model text on success", () => {
       mockOkResponse("The answer is 42");
-      const result = GEMINI("What is the answer?");
+      const result = SSI("What is the answer?");
       expect(result).toBe("The answer is 42");
     });
   });

--- a/__tests__/customFunctions.test.ts
+++ b/__tests__/customFunctions.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for src/server/customFunctions.ts
  *
- * Mocks UrlFetchApp, DriveApp, Utilities, and PropertiesService globally
+ * Mocks UrlFetchApp and PropertiesService globally
  * before importing, per the GAS globals pattern used across this test suite.
  */
 
@@ -9,14 +9,6 @@
 
 (globalThis as any).UrlFetchApp = {
   fetch: jest.fn(),
-};
-
-(globalThis as any).DriveApp = {
-  getFileById: jest.fn(),
-};
-
-(globalThis as any).Utilities = {
-  base64Encode: jest.fn().mockReturnValue("base64data=="),
 };
 
 (globalThis as any).PropertiesService = {
@@ -39,14 +31,6 @@ function mockFetchResponse(body: unknown): void {
 
 function mockOkResponse(text: string): void {
   mockFetchResponse({ candidates: [{ content: { parts: [{ text }] } }] });
-}
-
-function mockDriveFile(): void {
-  (DriveApp.getFileById as jest.Mock).mockReturnValue({
-    getMimeType: () => "application/pdf",
-    getSize: () => 1024,
-    getBlob: () => ({ getBytes: () => [1, 2, 3] }),
-  });
 }
 
 // ── Tests ──────────────────────────────────────────────────────
@@ -89,44 +73,12 @@ describe("SSI", () => {
     });
   });
 
-  // ── inlineData normalization ─────────────────────────────────
-
-  describe("inlineData normalization", () => {
-    const driveUrl = "https://drive.google.com/file/d/abc123defgh456ijklm789nop/view";
-    const driveUrl2 = "https://drive.google.com/file/d/xyz789defgh456ijklm012abc/view";
-
-    it("attaches a single Drive URL as one inline_data part", () => {
-      mockOkResponse("ok");
-      mockDriveFile();
-      SSI("prompt", driveUrl);
-      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
-      expect(payload.contents[0].parts).toHaveLength(2); // text + inline_data
-      expect(payload.contents[0].parts[1].inline_data.mime_type).toBe("application/pdf");
-    });
-
-    it("attaches multiple Drive URLs as multiple inline_data parts", () => {
-      mockOkResponse("ok");
-      mockDriveFile();
-      SSI("prompt", [[driveUrl, driveUrl2]]);
-      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
-      expect(payload.contents[0].parts).toHaveLength(3); // text + 2 inline_data
-    });
-
-    it("omits inline_data parts when inlineData is not provided", () => {
-      mockOkResponse("ok");
-      SSI("prompt");
-      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
-      expect(payload.contents[0].parts).toHaveLength(1);
-      expect(payload.contents[0].parts[0].inline_data).toBeUndefined();
-    });
-  });
-
   // ── systemPrompt ─────────────────────────────────────────────
 
   describe("systemPrompt", () => {
     it("sets system_instruction when provided", () => {
       mockOkResponse("ok");
-      SSI("prompt", undefined, "Be concise");
+      SSI("prompt", "Be concise");
       const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
       expect(payload.system_instruction.parts[0].text).toBe("Be concise");
     });
@@ -143,14 +95,14 @@ describe("SSI", () => {
 
   describe("toolNames", () => {
     it("returns an error string for an unknown tool name", () => {
-      const result = SSI("prompt", undefined, undefined, "nonExistentTool");
+      const result = SSI("prompt", undefined, "nonExistentTool");
       expect(result).toMatch(/\[SSI Error:.*nonExistentTool/);
     });
 
     it("includes a known tool declaration in the API payload", () => {
       mockOkResponse("ok");
       TOOL_REGISTRY["testTool"] = { name: "testTool", description: "A test tool" };
-      SSI("prompt", undefined, undefined, "testTool");
+      SSI("prompt", undefined, "testTool");
       delete TOOL_REGISTRY["testTool"];
       const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
       expect(payload.tools[0].function_declarations[0].name).toBe("testTool");

--- a/__tests__/customFunctions.test.ts
+++ b/__tests__/customFunctions.test.ts
@@ -27,7 +27,7 @@
 
 // ── Import after mocks ─────────────────────────────────────────
 
-import { GEMINI } from "../src/server/customFunctions";
+import { GEMINI, TOOL_REGISTRY } from "../src/server/customFunctions";
 
 // ── Helpers ────────────────────────────────────────────────────
 
@@ -145,6 +145,15 @@ describe("GEMINI", () => {
     it("returns an error string for an unknown tool name", () => {
       const result = GEMINI("prompt", undefined, undefined, "nonExistentTool");
       expect(result).toMatch(/\[GEMINI Error:.*nonExistentTool/);
+    });
+
+    it("includes a known tool declaration in the API payload", () => {
+      mockOkResponse("ok");
+      TOOL_REGISTRY["testTool"] = { name: "testTool", description: "A test tool" };
+      GEMINI("prompt", undefined, undefined, "testTool");
+      delete TOOL_REGISTRY["testTool"];
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.tools[0].function_declarations[0].name).toBe("testTool");
     });
   });
 

--- a/__tests__/customFunctions.test.ts
+++ b/__tests__/customFunctions.test.ts
@@ -71,6 +71,14 @@ describe("SSI", () => {
       const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
       expect(payload.contents[0].parts).toHaveLength(2);
     });
+
+    it("passes empty parts when userTexts is null", () => {
+      mockOkResponse("ok");
+      const result = SSI(null);
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.contents[0].parts).toEqual([]);
+      expect(result).toBe("ok");
+    });
   });
 
   // ── systemPrompt ─────────────────────────────────────────────

--- a/__tests__/customFunctions.test.ts
+++ b/__tests__/customFunctions.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for src/server/customFunctions.ts
+ *
+ * Mocks UrlFetchApp, DriveApp, Utilities, and PropertiesService globally
+ * before importing, per the GAS globals pattern used across this test suite.
+ */
+
+// ── Mock globals BEFORE imports ────────────────────────────────
+
+(globalThis as any).UrlFetchApp = {
+  fetch: jest.fn(),
+};
+
+(globalThis as any).DriveApp = {
+  getFileById: jest.fn(),
+};
+
+(globalThis as any).Utilities = {
+  base64Encode: jest.fn().mockReturnValue("base64data=="),
+};
+
+(globalThis as any).PropertiesService = {
+  getScriptProperties: jest.fn().mockReturnValue({
+    getProperty: jest.fn().mockReturnValue("test-api-key"),
+  }),
+};
+
+// ── Import after mocks ─────────────────────────────────────────
+
+import { GEMINI } from "../src/server/customFunctions";
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function mockFetchResponse(body: unknown): void {
+  (UrlFetchApp.fetch as jest.Mock).mockReturnValue({
+    getContentText: () => JSON.stringify(body),
+  });
+}
+
+function mockOkResponse(text: string): void {
+  mockFetchResponse({ candidates: [{ content: { parts: [{ text }] } }] });
+}
+
+function mockDriveFile(): void {
+  (DriveApp.getFileById as jest.Mock).mockReturnValue({
+    getMimeType: () => "application/pdf",
+    getSize: () => 1024,
+    getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe("GEMINI", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // ── userTexts normalization ──────────────────────────────────
+
+  describe("userTexts normalization", () => {
+    it("accepts a single string", () => {
+      mockOkResponse("ok");
+      GEMINI("hello");
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.contents[0].parts).toHaveLength(1);
+      expect(payload.contents[0].parts[0].text).toBe("hello");
+    });
+
+    it("flattens a vertical range (multiple rows, one column)", () => {
+      mockOkResponse("ok");
+      GEMINI([["row1"], ["row2"], ["row3"]]);
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.contents[0].parts).toHaveLength(3);
+      expect(payload.contents[0].parts[0].text).toBe("row1");
+      expect(payload.contents[0].parts[2].text).toBe("row3");
+    });
+
+    it("flattens a horizontal range (one row, multiple columns)", () => {
+      mockOkResponse("ok");
+      GEMINI([["col1", "col2", "col3"]]);
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.contents[0].parts).toHaveLength(3);
+    });
+
+    it("filters empty strings from ranges", () => {
+      mockOkResponse("ok");
+      GEMINI([["text", "", "more text"]]);
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.contents[0].parts).toHaveLength(2);
+    });
+  });
+
+  // ── inlineData normalization ─────────────────────────────────
+
+  describe("inlineData normalization", () => {
+    const driveUrl = "https://drive.google.com/file/d/abc123defgh456ijklm789nop/view";
+    const driveUrl2 = "https://drive.google.com/file/d/xyz789defgh456ijklm012abc/view";
+
+    it("attaches a single Drive URL as one inline_data part", () => {
+      mockOkResponse("ok");
+      mockDriveFile();
+      GEMINI("prompt", driveUrl);
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.contents[0].parts).toHaveLength(2); // text + inline_data
+      expect(payload.contents[0].parts[1].inline_data.mime_type).toBe("application/pdf");
+    });
+
+    it("attaches multiple Drive URLs as multiple inline_data parts", () => {
+      mockOkResponse("ok");
+      mockDriveFile();
+      GEMINI("prompt", [[driveUrl, driveUrl2]]);
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.contents[0].parts).toHaveLength(3); // text + 2 inline_data
+    });
+
+    it("omits inline_data parts when inlineData is not provided", () => {
+      mockOkResponse("ok");
+      GEMINI("prompt");
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.contents[0].parts).toHaveLength(1);
+      expect(payload.contents[0].parts[0].inline_data).toBeUndefined();
+    });
+  });
+
+  // ── systemPrompt ─────────────────────────────────────────────
+
+  describe("systemPrompt", () => {
+    it("sets system_instruction when provided", () => {
+      mockOkResponse("ok");
+      GEMINI("prompt", undefined, "Be concise");
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.system_instruction.parts[0].text).toBe("Be concise");
+    });
+
+    it("uses default system prompt when omitted", () => {
+      mockOkResponse("ok");
+      GEMINI("prompt");
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.system_instruction.parts[0].text).toBe("You are a helpful assistant.");
+    });
+  });
+
+  // ── toolNames ────────────────────────────────────────────────
+
+  describe("toolNames", () => {
+    it("returns an error string for an unknown tool name", () => {
+      const result = GEMINI("prompt", undefined, undefined, "nonExistentTool");
+      expect(result).toMatch(/\[GEMINI Error:.*nonExistentTool/);
+    });
+  });
+
+  // ── API key ──────────────────────────────────────────────────
+
+  describe("API key", () => {
+    it("returns an error string when GEMINI_API_KEY is not set", () => {
+      (PropertiesService.getScriptProperties().getProperty as jest.Mock).mockReturnValueOnce(null);
+      const result = GEMINI("prompt");
+      expect(result).toMatch(/\[GEMINI Error:.*GEMINI_API_KEY/);
+    });
+  });
+
+  // ── error handling ───────────────────────────────────────────
+
+  describe("error handling", () => {
+    it("returns an error string on API error response", () => {
+      mockFetchResponse({ error: { message: "quota exceeded" } });
+      const result = GEMINI("prompt");
+      expect(result).toMatch(/\[GEMINI Error:.*quota exceeded/);
+    });
+
+    it("returns the model text on success", () => {
+      mockOkResponse("The answer is 42");
+      const result = GEMINI("What is the answer?");
+      expect(result).toBe("The answer is 42");
+    });
+  });
+});

--- a/docs/plans/2026-02-21-gemini-custom-function-design.md
+++ b/docs/plans/2026-02-21-gemini-custom-function-design.md
@@ -1,0 +1,159 @@
+# GEMINI Custom Function Design
+
+**Date:** 2026-02-21
+**Status:** Approved
+
+## Context
+
+The existing Tool 4 (`runBatchAI`) calls `callGeminiAPI` from a menu-triggered function with full access to `PropertiesService`. This design adds a `GEMINI` Sheets custom function that exposes the same API capability directly from a cell formula, mirroring the `GeminiRequest` interface as closely as makes sense from a spreadsheet user's perspective.
+
+Key constraints for custom functions:
+- Cannot display UI (no `SpreadsheetApp.getUi()`, no dialogs)
+- `PropertiesService.getScriptProperties()` is available when the add-on has been authorized — the existing `GEMINI_API_KEY` script property is reused
+- Errors must be returned as strings rather than thrown (thrown exceptions show as generic script errors in the cell)
+- Range arguments arrive as 2D arrays; single-cell arguments arrive as raw scalars
+
+## Design
+
+### 1. `GeminiRequest.inlineData` — upgrade to array
+
+`inlineData` changes from `GeminiInlineData` (singular) to `GeminiInlineData[]` (plural). The Gemini API supports multiple `inline_data` parts in a single user message; the interface should reflect this.
+
+```typescript
+// src/shared/types.ts
+export interface GeminiRequest {
+  apiKey: string;
+  modelName?: string;
+  systemPrompt?: string;
+  userTexts: string[];
+  inlineData?: GeminiInlineData[];  // was: GeminiInlineData
+  tools?: GeminiFunctionDeclaration[];
+  generationConfig?: GeminiGenerationConfig;
+}
+```
+
+`buildGeminiPayload` loops over the array:
+```typescript
+req.inlineData?.forEach((d) => parts.push({ inline_data: d }));
+```
+
+`runBatchAI` wraps its single file in an array:
+```typescript
+inlineData: [fetchAndEncodeFile(extractId(link))]
+```
+
+### 2. `src/server/customFunctions.ts` — new module
+
+**Function signature:**
+
+```typescript
+/**
+ * Call the Gemini API from a spreadsheet cell.
+ *
+ * @param {string|Array} userTexts  One or more text parts for the user message.
+ *   Pass a single string, a cell reference, or a range/array literal.
+ * @param {string|Array?} inlineData  Drive URL(s) or file ID(s) to attach as
+ *   inline data. Pass a single URL, a cell reference, or a range/array literal.
+ * @param {string?} systemPrompt  System-level instruction for the model.
+ * @param {string|Array?} toolNames  Names of pre-registered tools to enable.
+ * @return {string} The model's text response, or an error string on failure.
+ * @customfunction
+ */
+export function GEMINI(
+  userTexts: unknown,
+  inlineData?: unknown,
+  systemPrompt?: string,
+  toolNames?: unknown,
+): string
+```
+
+**Input normalization:**
+
+GAS passes single-cell references as raw scalars and ranges as 2D arrays. A shared helper normalizes both:
+
+```typescript
+function flattenArg(val: unknown): string[] {
+  if (!Array.isArray(val)) return val != null ? [String(val)] : [];
+  return (val as unknown[][]).flat()
+    .filter((v) => v !== "" && v != null)
+    .map(String);
+}
+```
+
+Array literals (`{A1,B1,C1}`) are expected to arrive as `[[v1, v2, v3]]` (matching horizontal range behavior) and are handled by the same helper. This should be verified manually after deployment.
+
+**Tool registry:**
+
+```typescript
+const TOOL_REGISTRY: Record<string, GeminiFunctionDeclaration> = {
+  // Populated as concrete tool use cases are designed.
+};
+```
+
+Unknown tool names cause the function to return `"[GEMINI Error: unknown tool 'name']"` rather than silently dropping them.
+
+**API key:**
+
+```typescript
+const apiKey = PropertiesService.getScriptProperties().getProperty("GEMINI_API_KEY");
+if (!apiKey) return "[GEMINI Error: GEMINI_API_KEY script property not set]";
+```
+
+Reuses the same script property as Tool 4. If the property is missing, an actionable error string is returned.
+
+**Error handling:**
+
+All errors are caught and returned as `"[GEMINI Error: ...]"` strings. Custom functions display return values in the cell — thrown exceptions produce unhelpful generic error messages.
+
+### 3. Wiring
+
+Per CLAUDE.md's two-step rule for exposing functions to Apps Script:
+
+1. Re-export `GEMINI` from `src/server/index.ts`:
+   ```typescript
+   export { GEMINI } from "./customFunctions";
+   ```
+
+2. Add a global stub to the `footer` in `rollup.config.js`:
+   ```js
+   function GEMINI(userTexts, inlineData, systemPrompt, toolNames) {
+     return _GASEntry.GEMINI(userTexts, inlineData, systemPrompt, toolNames);
+   }
+   ```
+
+### 4. Tests — `__tests__/customFunctions.test.ts`
+
+All GAS globals (`UrlFetchApp`, `DriveApp`, `Utilities`, `PropertiesService`) are mocked before imports, following the existing pattern in `api.test.ts` and `drive.test.ts`.
+
+Test cases:
+- Single string `userTexts` → flattened to `["text"]`, correct payload
+- Vertical range `userTexts` (`[[v1],[v2]]`) → flattened to `[v1, v2]`
+- Horizontal range `userTexts` (`[[v1, v2]]`) → flattened to `[v1, v2]`
+- Empty cells filtered from ranges
+- `inlineData` with two Drive URLs → two `inline_data` parts in payload
+- `inlineData` omitted → no `inline_data` parts
+- `systemPrompt` passed → correct `system_instruction` in payload
+- `systemPrompt` omitted → default system prompt used
+- Known tool name → `tools` present in payload
+- Unknown tool name → returns `"[GEMINI Error: unknown tool ...]"`
+- Missing API key → returns `"[GEMINI Error: GEMINI_API_KEY ...]"`
+- `UrlFetchApp` error → returns `"[GEMINI Error: ...]"`
+- Happy path → correct text response
+
+### 5. Updated coverage thresholds
+
+`jest.config.cjs` gains a threshold entry for `src/server/customFunctions.ts`:
+```js
+"./src/server/customFunctions.ts": {
+  statements: 90,
+  branches: 85,
+  functions: 100,
+},
+```
+
+## What This Does Not Include
+
+- Caching via `CacheService` — Sheets caches custom function results automatically for identical inputs; explicit caching is deferred unless quota issues arise in practice
+- Array literal `{...}` argument behavior — must be verified manually after deployment; the implementation handles the expected shape but GAS docs don't officially specify this case
+- Tool implementations — the registry is empty at launch; tools are added as concrete use cases are designed
+- `modelName` and `generationConfig` parameters — omitted from the custom function signature for simplicity; the function uses `CONFIG.MODEL_NAME` and default generation config

--- a/docs/plans/2026-02-21-gemini-custom-function.md
+++ b/docs/plans/2026-02-21-gemini-custom-function.md
@@ -1,0 +1,581 @@
+# GEMINI Custom Function Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `=GEMINI(userTexts, inlineData?, systemPrompt?, toolNames?)` custom function that calls the Gemini API directly from a spreadsheet cell.
+
+**Architecture:** Four independent changes bundled into four commits: (1) upgrade `GeminiRequest.inlineData` to an array, (2) add `src/server/customFunctions.ts` with tests, (3) wire the function into the Rollup bundle, (4) add the coverage threshold. Tests and implementation are bundled in one commit because the pre-commit hook (Jest) requires a green suite at every commit.
+
+**Tech Stack:** TypeScript, Google Apps Script globals (UrlFetchApp, DriveApp, Utilities, PropertiesService), Jest + ts-jest, Rollup IIFE bundle
+
+---
+
+### Task 1: Upgrade `GeminiRequest.inlineData` to an array
+
+The Gemini API supports multiple `inline_data` parts per message. The interface should reflect this. All four changes below must land in one commit — they are tightly coupled through the type system.
+
+**Files:**
+- Modify: `src/shared/types.ts:59`
+- Modify: `src/server/api.ts:23-26`
+- Modify: `src/server/index.ts:302-303`
+- Modify: `__tests__/api.test.ts` (update inlineData test + add multi-file test)
+
+---
+
+**Step 1: Update `GeminiRequest.inlineData` in `src/shared/types.ts`**
+
+Find line 59:
+```typescript
+inlineData?: GeminiInlineData; // appended as a final part if present
+```
+Replace with:
+```typescript
+inlineData?: GeminiInlineData[]; // each item appended as an inline_data part
+```
+
+---
+
+**Step 2: Update `buildGeminiPayload` in `src/server/api.ts`**
+
+Find lines 24-26:
+```typescript
+  if (req.inlineData) {
+    parts.push({ inline_data: req.inlineData });
+  }
+```
+Replace with:
+```typescript
+  req.inlineData?.forEach((d) => parts.push({ inline_data: d }));
+```
+
+---
+
+**Step 3: Update `runBatchAI` in `src/server/index.ts`**
+
+Find line 302-303:
+```typescript
+            const inlineData = fetchAndEncodeFile(extractId(link));
+            result = callGeminiAPI({ apiKey, systemPrompt, userTexts: [usrPrompt], inlineData });
+```
+Replace with:
+```typescript
+            const inlineData = [fetchAndEncodeFile(extractId(link))];
+            result = callGeminiAPI({ apiKey, systemPrompt, userTexts: [usrPrompt], inlineData });
+```
+
+---
+
+**Step 4: Update `__tests__/api.test.ts`**
+
+Find the existing `buildGeminiPayload` test named `"appends inline_data as the final part when provided"`. Change the `inlineData` value from a single object to a single-element array:
+
+```typescript
+// Before:
+inlineData: { mime_type: "application/pdf", data: "base64==" },
+// After:
+inlineData: [{ mime_type: "application/pdf", data: "base64==" }],
+```
+
+Then add a new test immediately after it inside the same `describe("buildGeminiPayload")` block:
+
+```typescript
+  it("appends multiple inline_data parts when inlineData has multiple items", () => {
+    const req: GeminiRequest = {
+      ...baseReq,
+      userTexts: ["Describe both files"],
+      inlineData: [
+        { mime_type: "application/pdf", data: "file1==" },
+        { mime_type: "image/jpeg", data: "file2==" },
+      ],
+    };
+    const payload = buildGeminiPayload(req);
+    const parts = (payload.contents as any)[0].parts;
+    expect(parts).toHaveLength(3); // 1 text + 2 inline_data
+    expect(parts[1].inline_data.mime_type).toBe("application/pdf");
+    expect(parts[2].inline_data.mime_type).toBe("image/jpeg");
+  });
+```
+
+---
+
+**Step 5: Run tests — expect all to pass**
+
+```bash
+npm test
+```
+
+Expected: all 52 tests PASS (one new test added).
+
+---
+
+**Step 6: Commit**
+
+```bash
+git add src/shared/types.ts src/server/api.ts src/server/index.ts __tests__/api.test.ts
+git commit -m "feat: upgrade GeminiRequest.inlineData to array for multi-file support"
+```
+
+---
+
+### Task 2: Add GEMINI custom function with tests
+
+Tests and implementation must land in one commit — the pre-commit hook runs Jest, so the test file cannot exist without a passing implementation.
+
+**Files:**
+- Create: `__tests__/customFunctions.test.ts`
+- Create: `src/server/customFunctions.ts`
+
+---
+
+**Step 1: Create `__tests__/customFunctions.test.ts`**
+
+```typescript
+/**
+ * Tests for src/server/customFunctions.ts
+ *
+ * Mocks UrlFetchApp, DriveApp, Utilities, and PropertiesService globally
+ * before importing, per the GAS globals pattern used across this test suite.
+ */
+
+// ── Mock globals BEFORE imports ────────────────────────────────
+
+(globalThis as any).UrlFetchApp = {
+  fetch: jest.fn(),
+};
+
+(globalThis as any).DriveApp = {
+  getFileById: jest.fn(),
+};
+
+(globalThis as any).Utilities = {
+  base64Encode: jest.fn().mockReturnValue("base64data=="),
+};
+
+(globalThis as any).PropertiesService = {
+  getScriptProperties: jest.fn().mockReturnValue({
+    getProperty: jest.fn().mockReturnValue("test-api-key"),
+  }),
+};
+
+// ── Import after mocks ─────────────────────────────────────────
+
+import { GEMINI } from "../src/server/customFunctions";
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function mockFetchResponse(body: unknown): void {
+  (UrlFetchApp.fetch as jest.Mock).mockReturnValue({
+    getContentText: () => JSON.stringify(body),
+  });
+}
+
+function mockOkResponse(text: string): void {
+  mockFetchResponse({ candidates: [{ content: { parts: [{ text }] } }] });
+}
+
+function mockDriveFile(): void {
+  (DriveApp.getFileById as jest.Mock).mockReturnValue({
+    getMimeType: () => "application/pdf",
+    getSize: () => 1024,
+    getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe("GEMINI", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // ── userTexts normalization ──────────────────────────────────
+
+  describe("userTexts normalization", () => {
+    it("accepts a single string", () => {
+      mockOkResponse("ok");
+      GEMINI("hello");
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.contents[0].parts).toHaveLength(1);
+      expect(payload.contents[0].parts[0].text).toBe("hello");
+    });
+
+    it("flattens a vertical range (multiple rows, one column)", () => {
+      mockOkResponse("ok");
+      GEMINI([["row1"], ["row2"], ["row3"]]);
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.contents[0].parts).toHaveLength(3);
+      expect(payload.contents[0].parts[0].text).toBe("row1");
+      expect(payload.contents[0].parts[2].text).toBe("row3");
+    });
+
+    it("flattens a horizontal range (one row, multiple columns)", () => {
+      mockOkResponse("ok");
+      GEMINI([["col1", "col2", "col3"]]);
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.contents[0].parts).toHaveLength(3);
+    });
+
+    it("filters empty strings from ranges", () => {
+      mockOkResponse("ok");
+      GEMINI([["text", "", "more text"]]);
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.contents[0].parts).toHaveLength(2);
+    });
+  });
+
+  // ── inlineData normalization ─────────────────────────────────
+
+  describe("inlineData normalization", () => {
+    const driveUrl = "https://drive.google.com/file/d/abc123defgh456ijklm789nop/view";
+    const driveUrl2 = "https://drive.google.com/file/d/xyz789defgh456ijklm012abc/view";
+
+    it("attaches a single Drive URL as one inline_data part", () => {
+      mockOkResponse("ok");
+      mockDriveFile();
+      GEMINI("prompt", driveUrl);
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.contents[0].parts).toHaveLength(2); // text + inline_data
+      expect(payload.contents[0].parts[1].inline_data.mime_type).toBe("application/pdf");
+    });
+
+    it("attaches multiple Drive URLs as multiple inline_data parts", () => {
+      mockOkResponse("ok");
+      mockDriveFile();
+      GEMINI("prompt", [[driveUrl, driveUrl2]]);
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.contents[0].parts).toHaveLength(3); // text + 2 inline_data
+    });
+
+    it("omits inline_data parts when inlineData is not provided", () => {
+      mockOkResponse("ok");
+      GEMINI("prompt");
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.contents[0].parts).toHaveLength(1);
+      expect(payload.contents[0].parts[0].inline_data).toBeUndefined();
+    });
+  });
+
+  // ── systemPrompt ─────────────────────────────────────────────
+
+  describe("systemPrompt", () => {
+    it("sets system_instruction when provided", () => {
+      mockOkResponse("ok");
+      GEMINI("prompt", undefined, "Be concise");
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.system_instruction.parts[0].text).toBe("Be concise");
+    });
+
+    it("uses default system prompt when omitted", () => {
+      mockOkResponse("ok");
+      GEMINI("prompt");
+      const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+      expect(payload.system_instruction.parts[0].text).toBe("You are a helpful assistant.");
+    });
+  });
+
+  // ── toolNames ────────────────────────────────────────────────
+
+  describe("toolNames", () => {
+    it("returns an error string for an unknown tool name", () => {
+      const result = GEMINI("prompt", undefined, undefined, "nonExistentTool");
+      expect(result).toMatch(/\[GEMINI Error:.*nonExistentTool/);
+    });
+  });
+
+  // ── API key ──────────────────────────────────────────────────
+
+  describe("API key", () => {
+    it("returns an error string when GEMINI_API_KEY is not set", () => {
+      (PropertiesService.getScriptProperties().getProperty as jest.Mock).mockReturnValueOnce(null);
+      const result = GEMINI("prompt");
+      expect(result).toMatch(/\[GEMINI Error:.*GEMINI_API_KEY/);
+    });
+  });
+
+  // ── error handling ───────────────────────────────────────────
+
+  describe("error handling", () => {
+    it("returns an error string on API error response", () => {
+      mockFetchResponse({ error: { message: "quota exceeded" } });
+      const result = GEMINI("prompt");
+      expect(result).toMatch(/\[GEMINI Error:.*quota exceeded/);
+    });
+
+    it("returns the model text on success", () => {
+      mockOkResponse("The answer is 42");
+      const result = GEMINI("What is the answer?");
+      expect(result).toBe("The answer is 42");
+    });
+  });
+});
+```
+
+---
+
+**Step 2: Run `__tests__/customFunctions.test.ts` — expect it to fail**
+
+```bash
+npx jest __tests__/customFunctions.test.ts
+```
+
+Expected: FAIL — `GEMINI` not exported yet.
+
+---
+
+**Step 3: Create `src/server/customFunctions.ts`**
+
+```typescript
+/**
+ * customFunctions.ts — Google Sheets custom functions.
+ *
+ * Functions here are callable directly from spreadsheet cells via the
+ * @customfunction JSDoc tag. Key constraints vs. menu-triggered functions:
+ * - Cannot display UI (no dialogs, no prompts, no alerts)
+ * - Errors must be returned as strings — thrown exceptions show as generic
+ *   script errors in the cell with no useful message
+ * - PropertiesService.getScriptProperties() is available after the add-on
+ *   has been authorized by the user
+ * - Range arguments arrive as unknown[][], single cells as raw scalars
+ */
+
+import { CONFIG } from "./config";
+import { callGeminiAPI } from "./api";
+import { fetchAndEncodeFile } from "./drive";
+import { extractId } from "./utils";
+import type { GeminiFunctionDeclaration } from "../shared/types";
+
+// ── Tool Registry ────────────────────────────────────────────────────────────
+//
+// Map tool names to GeminiFunctionDeclaration objects.
+// Add entries here as concrete tool use cases are designed.
+
+const TOOL_REGISTRY: Record<string, GeminiFunctionDeclaration> = {};
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Normalize a custom function argument to a flat array of non-empty strings.
+ * GAS passes single-cell references as raw scalars and ranges as 2D arrays.
+ */
+function flattenArg(val: unknown): string[] {
+  if (!Array.isArray(val)) return val != null ? [String(val)] : [];
+  return (val as unknown[][])
+    .flat()
+    .filter((v) => v !== "" && v != null)
+    .map(String);
+}
+
+// ── Custom Functions ─────────────────────────────────────────────────────────
+
+/**
+ * Call the Gemini API from a spreadsheet cell.
+ *
+ * @param {string|Array} userTexts One or more text parts for the user message.
+ *   Pass a single string, a cell reference, or a range / array literal.
+ *   Example: "Summarize this" or A1 or A1:A3 or {A1,B4,B10}
+ * @param {string|Array} inlineData Drive URL(s) or file ID(s) to attach as
+ *   inline data. Pass a single URL, a cell reference, or a range / array literal.
+ *   Example: A2 or {A2,A3}
+ * @param {string} systemPrompt System-level instruction for the model.
+ *   Example: "You are a concise summarizer."
+ * @param {string|Array} toolNames Names of pre-registered tools to enable.
+ *   Example: "myTool" or {A5,A6}
+ * @return {string} The model's text response, or "[GEMINI Error: ...]" on failure.
+ * @customfunction
+ */
+export function GEMINI(
+  userTexts: unknown,
+  inlineData?: unknown,
+  systemPrompt?: string,
+  toolNames?: unknown,
+): string {
+  try {
+    // Resolve API key from Script Properties (set via Project Settings)
+    const apiKey = PropertiesService.getScriptProperties().getProperty(CONFIG.API_KEY_PROPERTY);
+    if (!apiKey) {
+      return `[GEMINI Error: ${CONFIG.API_KEY_PROPERTY} script property not set. Go to Project Settings > Script Properties to add it.]`;
+    }
+
+    // Normalize and validate tool names
+    const resolvedTools = flattenArg(toolNames).map((name) => {
+      const decl = TOOL_REGISTRY[name];
+      if (!decl) throw new Error(`unknown tool '${name}'`);
+      return decl;
+    });
+
+    // Normalize inlineData: fetch and encode each Drive URL / file ID
+    const resolvedInlineData = inlineData != null
+      ? flattenArg(inlineData).map((url) => fetchAndEncodeFile(extractId(url)))
+      : undefined;
+
+    return callGeminiAPI({
+      apiKey,
+      systemPrompt: systemPrompt || undefined,
+      userTexts: flattenArg(userTexts),
+      inlineData: resolvedInlineData?.length ? resolvedInlineData : undefined,
+      tools: resolvedTools.length ? resolvedTools : undefined,
+    });
+  } catch (e) {
+    return `[GEMINI Error: ${(e as Error).message}]`;
+  }
+}
+```
+
+---
+
+**Step 4: Run tests — expect all to pass**
+
+```bash
+npm test
+```
+
+Expected: all tests PASS (new suite included).
+
+---
+
+**Step 5: Commit**
+
+```bash
+git add src/server/customFunctions.ts __tests__/customFunctions.test.ts
+git commit -m "feat: add GEMINI custom function with tests"
+```
+
+---
+
+### Task 3: Wire the function into the bundle
+
+Per CLAUDE.md: to expose a function to Apps Script, you must (1) export it from `index.ts` and (2) add a global stub to the Rollup footer.
+
+**Files:**
+- Modify: `src/server/index.ts` (add re-export)
+- Modify: `rollup.config.js:45` (add footer stub)
+
+---
+
+**Step 1: Add re-export to `src/server/index.ts`**
+
+Add this line at the top of `src/server/index.ts`, after the existing imports block (after line 23 `import type { AIMode, ColumnMap } from "../shared/types";`):
+
+```typescript
+export { GEMINI } from "./customFunctions";
+```
+
+---
+
+**Step 2: Add global stub to `rollup.config.js`**
+
+Find the footer string (line 34–46). Add the `GEMINI` stub before the closing backtick:
+
+```js
+function GEMINI(userTexts, inlineData, systemPrompt, toolNames) { return _GASEntry.GEMINI(userTexts, inlineData, systemPrompt, toolNames); }
+```
+
+The footer section should look like this after the edit:
+
+```js
+    footer: `
+/**
+ * Global Handshake — Explicit function stubs for Google Apps Script discovery.
+ */
+function onOpen(e) { _GASEntry.onOpen(e); }
+function showSidebar() { _GASEntry.showSidebar(); }
+function runTool(fn) { _GASEntry.runTool(fn); }
+function showSourceDialog() { _GASEntry.showSourceDialog(); }
+function handleDialogSelection(mode) { _GASEntry.handleDialogSelection(mode); }
+function importDriveLinks() { _GASEntry.importDriveLinks(); }
+function extractTextFromSelection() { _GASEntry.extractTextFromSelection(); }
+function sampleRowsToEvaluation() { _GASEntry.sampleRowsToEvaluation(); }
+function GEMINI(userTexts, inlineData, systemPrompt, toolNames) { return _GASEntry.GEMINI(userTexts, inlineData, systemPrompt, toolNames); }
+`,
+```
+
+---
+
+**Step 3: Run tests and typecheck**
+
+```bash
+npm test && npm run typecheck
+```
+
+Expected: all tests PASS, zero type errors.
+
+---
+
+**Step 4: Commit**
+
+```bash
+git add src/server/index.ts rollup.config.js
+git commit -m "feat: wire GEMINI custom function into Apps Script bundle"
+```
+
+---
+
+### Task 4: Add coverage threshold for customFunctions.ts
+
+**Files:**
+- Modify: `jest.config.cjs:41` (add threshold entry before closing `}`)
+
+---
+
+**Step 1: Add threshold to `jest.config.cjs`**
+
+Find the `coverageThreshold` block. Add a new entry for `customFunctions.ts` after the existing `drive.ts` entry:
+
+```js
+    "./src/server/customFunctions.ts": {
+      statements: 90,
+      branches: 85,
+      functions: 100,
+    },
+```
+
+---
+
+**Step 2: Run coverage — verify threshold is met**
+
+```bash
+npm run test:coverage
+```
+
+Expected: all thresholds met. If `customFunctions.ts` is below 85% branches, check which branches are uncovered and add a targeted test in `__tests__/customFunctions.test.ts`.
+
+---
+
+**Step 3: Commit**
+
+```bash
+git add jest.config.cjs
+git commit -m "test: add coverage threshold for customFunctions.ts"
+```
+
+---
+
+### Task 5: Final verification
+
+**Step 1: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: no errors or warnings.
+
+**Step 2: Run full coverage suite**
+
+```bash
+npm run test:coverage
+```
+
+Expected: all per-file thresholds met.
+
+**Step 3: Build**
+
+```bash
+npm run build
+```
+
+Expected: clean build. Verify `dist/index.js` contains the `GEMINI` global stub by running:
+
+```bash
+grep "function GEMINI" dist/index.js
+```
+
+Expected: one matching line.

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -39,5 +39,10 @@ module.exports = {
       branches: 95,
       functions: 100,
     },
+    "./src/server/customFunctions.ts": {
+      statements: 90,
+      branches: 85,
+      functions: 100,
+    },
   },
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -58,14 +58,12 @@ function sampleRowsToEvaluation() { _GASEntry.sampleRowsToEvaluation(); }
  * Call the Gemini API from a spreadsheet cell.
  * @param {string|Array} userTexts One or more text parts for the user message.
  *   Pass a single string, a cell reference, or a range / array literal.
- * @param {string|Array} inlineData Drive URL(s) or file ID(s) to attach as inline data.
- *   Pass a single URL, a cell reference, or a range / array literal.
  * @param {string} systemPrompt System-level instruction for the model.
  * @param {string|Array} toolNames Names of pre-registered tools to enable.
  * @return {string} The model's text response, or "[SSI Error: ...]" on failure.
  * @customfunction
  */
-function SSI(userTexts, inlineData, systemPrompt, toolNames) { return _GASEntry.SSI(userTexts, inlineData, systemPrompt, toolNames); }
+function SSI(userTexts, systemPrompt, toolNames) { return _GASEntry.SSI(userTexts, systemPrompt, toolNames); }
 `,
   },
   plugins: [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,6 +34,17 @@ export default {
     footer: `
 /**
  * Global Handshake — Explicit function stubs for Google Apps Script discovery.
+ *
+ * Every export from index.ts that Apps Script needs to call must have a
+ * matching one-line stub here. Rollup's IIFE wrapper scopes everything inside
+ * _GASEntry; these stubs re-expose the relevant functions in the global scope.
+ *
+ * CUSTOM FUNCTIONS: If the stub is for a Sheets custom function (callable from
+ * a cell formula), you MUST add a JSDoc comment with @customfunction directly
+ * on the stub below. The TypeScript-level JSDoc is compiled away by Rollup and
+ * does NOT appear on the global stub. Google Sheets only recognises a function
+ * as a custom function when @customfunction is present on the global declaration
+ * — without it the function will not appear in autocomplete or parameter hints.
  */
 function onOpen(e) { _GASEntry.onOpen(e); }
 function showSidebar() { _GASEntry.showSidebar(); }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -43,6 +43,17 @@ function handleDialogSelection(mode) { _GASEntry.handleDialogSelection(mode); }
 function importDriveLinks() { _GASEntry.importDriveLinks(); }
 function extractTextFromSelection() { _GASEntry.extractTextFromSelection(); }
 function sampleRowsToEvaluation() { _GASEntry.sampleRowsToEvaluation(); }
+/**
+ * Call the Gemini API from a spreadsheet cell.
+ * @param {string|Array} userTexts One or more text parts for the user message.
+ *   Pass a single string, a cell reference, or a range / array literal.
+ * @param {string|Array} inlineData Drive URL(s) or file ID(s) to attach as inline data.
+ *   Pass a single URL, a cell reference, or a range / array literal.
+ * @param {string} systemPrompt System-level instruction for the model.
+ * @param {string|Array} toolNames Names of pre-registered tools to enable.
+ * @return {string} The model's text response, or "[SSI Error: ...]" on failure.
+ * @customfunction
+ */
 function SSI(userTexts, inlineData, systemPrompt, toolNames) { return _GASEntry.SSI(userTexts, inlineData, systemPrompt, toolNames); }
 `,
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -43,7 +43,7 @@ function handleDialogSelection(mode) { _GASEntry.handleDialogSelection(mode); }
 function importDriveLinks() { _GASEntry.importDriveLinks(); }
 function extractTextFromSelection() { _GASEntry.extractTextFromSelection(); }
 function sampleRowsToEvaluation() { _GASEntry.sampleRowsToEvaluation(); }
-function GEMINI(userTexts, inlineData, systemPrompt, toolNames) { return _GASEntry.GEMINI(userTexts, inlineData, systemPrompt, toolNames); }
+function SSI(userTexts, inlineData, systemPrompt, toolNames) { return _GASEntry.SSI(userTexts, inlineData, systemPrompt, toolNames); }
 `,
   },
   plugins: [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -43,6 +43,7 @@ function handleDialogSelection(mode) { _GASEntry.handleDialogSelection(mode); }
 function importDriveLinks() { _GASEntry.importDriveLinks(); }
 function extractTextFromSelection() { _GASEntry.extractTextFromSelection(); }
 function sampleRowsToEvaluation() { _GASEntry.sampleRowsToEvaluation(); }
+function GEMINI(userTexts, inlineData, systemPrompt, toolNames) { return _GASEntry.GEMINI(userTexts, inlineData, systemPrompt, toolNames); }
 `,
   },
   plugins: [

--- a/src/server/customFunctions.ts
+++ b/src/server/customFunctions.ts
@@ -53,10 +53,10 @@ function flattenArg(val: unknown): string[] {
  *   Example: "You are a concise summarizer."
  * @param {string|Array} toolNames Names of pre-registered tools to enable.
  *   Example: "myTool" or {A5,A6}
- * @return {string} The model's text response, or "[GEMINI Error: ...]" on failure.
+ * @return {string} The model's text response, or "[SSI Error: ...]" on failure.
  * @customfunction
  */
-export function GEMINI(
+export function SSI(
   userTexts: unknown,
   inlineData?: unknown,
   systemPrompt?: string,
@@ -66,7 +66,7 @@ export function GEMINI(
     // Resolve API key from Script Properties (set via Project Settings)
     const apiKey = PropertiesService.getScriptProperties().getProperty(CONFIG.API_KEY_PROPERTY);
     if (!apiKey) {
-      return `[GEMINI Error: ${CONFIG.API_KEY_PROPERTY} script property not set. Go to Project Settings > Script Properties to add it.]`;
+      return `[SSI Error: ${CONFIG.API_KEY_PROPERTY} script property not set. Go to Project Settings > Script Properties to add it.]`;
     }
 
     // Normalize and validate tool names
@@ -95,6 +95,6 @@ export function GEMINI(
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    return `[GEMINI Error: ${msg}]`;
+    return `[SSI Error: ${msg}]`;
   }
 }

--- a/src/server/customFunctions.ts
+++ b/src/server/customFunctions.ts
@@ -22,7 +22,7 @@ import type { GeminiFunctionDeclaration } from "../shared/types";
 // Map tool names to GeminiFunctionDeclaration objects.
 // Add entries here as concrete tool use cases are designed.
 
-const TOOL_REGISTRY: Record<string, GeminiFunctionDeclaration> = {};
+export const TOOL_REGISTRY: Record<string, GeminiFunctionDeclaration> = {};
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
 
@@ -79,7 +79,11 @@ export function GEMINI(
     // Normalize inlineData: fetch and encode each Drive URL / file ID
     const resolvedInlineData =
       inlineData != null
-        ? flattenArg(inlineData).map((url) => fetchAndEncodeFile(extractId(url)))
+        ? flattenArg(inlineData).map((url) => {
+            const id = extractId(url);
+            if (!id) throw new Error(`Could not extract a Drive file ID from: "${url}"`);
+            return fetchAndEncodeFile(id);
+          })
         : undefined;
 
     return callGeminiAPI({
@@ -90,6 +94,7 @@ export function GEMINI(
       tools: resolvedTools.length ? resolvedTools : undefined,
     });
   } catch (e) {
-    return `[GEMINI Error: ${(e as Error).message}]`;
+    const msg = e instanceof Error ? e.message : String(e);
+    return `[GEMINI Error: ${msg}]`;
   }
 }

--- a/src/server/customFunctions.ts
+++ b/src/server/customFunctions.ts
@@ -7,14 +7,12 @@
  * - Errors must be returned as strings — thrown exceptions show as generic
  *   script errors in the cell with no useful message
  * - PropertiesService.getScriptProperties() is available after the add-on
- *   has been authorized by the user
+ *   has been authorized by the user (opening the menu triggers authorization)
  * - Range arguments arrive as unknown[][], single cells as raw scalars
  */
 
 import { CONFIG } from "./config";
 import { callGeminiAPI } from "./api";
-import { fetchAndEncodeFile } from "./drive";
-import { extractId } from "./utils";
 import type { GeminiFunctionDeclaration } from "../shared/types";
 
 // ── Tool Registry ────────────────────────────────────────────────────────────
@@ -46,9 +44,6 @@ function flattenArg(val: unknown): string[] {
  * @param {string|Array} userTexts One or more text parts for the user message.
  *   Pass a single string, a cell reference, or a range / array literal.
  *   Example: "Summarize this" or A1 or A1:A3 or {A1,B4,B10}
- * @param {string|Array} inlineData Drive URL(s) or file ID(s) to attach as
- *   inline data. Pass a single URL, a cell reference, or a range / array literal.
- *   Example: A2 or {A2,A3}
  * @param {string} systemPrompt System-level instruction for the model.
  *   Example: "You are a concise summarizer."
  * @param {string|Array} toolNames Names of pre-registered tools to enable.
@@ -56,12 +51,7 @@ function flattenArg(val: unknown): string[] {
  * @return {string} The model's text response, or "[SSI Error: ...]" on failure.
  * @customfunction
  */
-export function SSI(
-  userTexts: unknown,
-  inlineData?: unknown,
-  systemPrompt?: string,
-  toolNames?: unknown,
-): string {
+export function SSI(userTexts: unknown, systemPrompt?: string, toolNames?: unknown): string {
   try {
     // Resolve API key from Script Properties (set via Project Settings)
     const apiKey = PropertiesService.getScriptProperties().getProperty(CONFIG.API_KEY_PROPERTY);
@@ -76,21 +66,10 @@ export function SSI(
       return decl;
     });
 
-    // Normalize inlineData: fetch and encode each Drive URL / file ID
-    const resolvedInlineData =
-      inlineData != null
-        ? flattenArg(inlineData).map((url) => {
-            const id = extractId(url);
-            if (!id) throw new Error(`Could not extract a Drive file ID from: "${url}"`);
-            return fetchAndEncodeFile(id);
-          })
-        : undefined;
-
     return callGeminiAPI({
       apiKey,
       systemPrompt: systemPrompt || undefined,
       userTexts: flattenArg(userTexts),
-      inlineData: resolvedInlineData?.length ? resolvedInlineData : undefined,
       tools: resolvedTools.length ? resolvedTools : undefined,
     });
   } catch (e) {

--- a/src/server/customFunctions.ts
+++ b/src/server/customFunctions.ts
@@ -1,0 +1,95 @@
+/**
+ * customFunctions.ts — Google Sheets custom functions.
+ *
+ * Functions here are callable directly from spreadsheet cells via the
+ * @customfunction JSDoc tag. Key constraints vs. menu-triggered functions:
+ * - Cannot display UI (no dialogs, no prompts, no alerts)
+ * - Errors must be returned as strings — thrown exceptions show as generic
+ *   script errors in the cell with no useful message
+ * - PropertiesService.getScriptProperties() is available after the add-on
+ *   has been authorized by the user
+ * - Range arguments arrive as unknown[][], single cells as raw scalars
+ */
+
+import { CONFIG } from "./config";
+import { callGeminiAPI } from "./api";
+import { fetchAndEncodeFile } from "./drive";
+import { extractId } from "./utils";
+import type { GeminiFunctionDeclaration } from "../shared/types";
+
+// ── Tool Registry ────────────────────────────────────────────────────────────
+//
+// Map tool names to GeminiFunctionDeclaration objects.
+// Add entries here as concrete tool use cases are designed.
+
+const TOOL_REGISTRY: Record<string, GeminiFunctionDeclaration> = {};
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Normalize a custom function argument to a flat array of non-empty strings.
+ * GAS passes single-cell references as raw scalars and ranges as 2D arrays.
+ */
+function flattenArg(val: unknown): string[] {
+  if (!Array.isArray(val)) return val != null ? [String(val)] : [];
+  return (val as unknown[][])
+    .flat()
+    .filter((v) => v !== "" && v != null)
+    .map(String);
+}
+
+// ── Custom Functions ─────────────────────────────────────────────────────────
+
+/**
+ * Call the Gemini API from a spreadsheet cell.
+ *
+ * @param {string|Array} userTexts One or more text parts for the user message.
+ *   Pass a single string, a cell reference, or a range / array literal.
+ *   Example: "Summarize this" or A1 or A1:A3 or {A1,B4,B10}
+ * @param {string|Array} inlineData Drive URL(s) or file ID(s) to attach as
+ *   inline data. Pass a single URL, a cell reference, or a range / array literal.
+ *   Example: A2 or {A2,A3}
+ * @param {string} systemPrompt System-level instruction for the model.
+ *   Example: "You are a concise summarizer."
+ * @param {string|Array} toolNames Names of pre-registered tools to enable.
+ *   Example: "myTool" or {A5,A6}
+ * @return {string} The model's text response, or "[GEMINI Error: ...]" on failure.
+ * @customfunction
+ */
+export function GEMINI(
+  userTexts: unknown,
+  inlineData?: unknown,
+  systemPrompt?: string,
+  toolNames?: unknown,
+): string {
+  try {
+    // Resolve API key from Script Properties (set via Project Settings)
+    const apiKey = PropertiesService.getScriptProperties().getProperty(CONFIG.API_KEY_PROPERTY);
+    if (!apiKey) {
+      return `[GEMINI Error: ${CONFIG.API_KEY_PROPERTY} script property not set. Go to Project Settings > Script Properties to add it.]`;
+    }
+
+    // Normalize and validate tool names
+    const resolvedTools = flattenArg(toolNames).map((name) => {
+      const decl = TOOL_REGISTRY[name];
+      if (!decl) throw new Error(`unknown tool '${name}'`);
+      return decl;
+    });
+
+    // Normalize inlineData: fetch and encode each Drive URL / file ID
+    const resolvedInlineData =
+      inlineData != null
+        ? flattenArg(inlineData).map((url) => fetchAndEncodeFile(extractId(url)))
+        : undefined;
+
+    return callGeminiAPI({
+      apiKey,
+      systemPrompt: systemPrompt || undefined,
+      userTexts: flattenArg(userTexts),
+      inlineData: resolvedInlineData?.length ? resolvedInlineData : undefined,
+      tools: resolvedTools.length ? resolvedTools : undefined,
+    });
+  } catch (e) {
+    return `[GEMINI Error: ${(e as Error).message}]`;
+  }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,7 +8,7 @@
  * assign to `global.*` — that's the contract with Rollup's IIFE output.
  */
 
-export { GEMINI } from "./customFunctions";
+export { SSI } from "./customFunctions";
 import { CONFIG } from "./config";
 import { callGeminiAPI } from "./api";
 import { checkDriveService, extractTextUniversal, fetchAndEncodeFile } from "./drive";

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,6 +8,7 @@
  * assign to `global.*` — that's the contract with Rollup's IIFE output.
  */
 
+export { GEMINI } from "./customFunctions";
 import { CONFIG } from "./config";
 import { callGeminiAPI } from "./api";
 import { checkDriveService, extractTextUniversal, fetchAndEncodeFile } from "./drive";


### PR DESCRIPTION
## Summary

Adds an `SSI()` Google Sheets custom function that calls the Gemini API directly from a cell formula.

- `src/server/customFunctions.ts`: exports `SSI(userTexts, systemPrompt?, toolNames?)` with input normalization via `flattenArg` and a `TOOL_REGISTRY` for named tool declarations
- Named `SSI` rather than `GEMINI` to avoid shadowing Google Sheets' built-in `GEMINI` function
- Wires `SSI` into the Rollup bundle: re-export from `index.ts ` + global stub in `rollup.config.js` footer with `@customfunction` JSDoc (required for Sheets autocomplete — see footer comment for explanation)
- Per-file coverage threshold added: 90/85/100 statements/branches/functions

Drive file attachment (`inlineData`) is deferred — see `feature/ssi-inline-data`.

## How to test

1. `npm run deploy:dev`
2. Open the spreadsheet; confirm **⚡ SSI Toolkit** menu appears and open it once to authorize
3. Confirm `GEMINI_API_KEY` is set in Apps Script > Project Settings > Script Properties

### Smoke tests

| Formula | Expected |
|---|---|
| `=SSI("What is 2+2?")` | `4` or short explanation; appears in autocomplete |
| `=SSI(A1:A3)` (3 prompts in A1:A3) | Response using all 3 as text parts |
| `=SSI("prompt", "Be concise.")` | Short response |
| `=SSI("hello")` with no API key set | `[SSI Error: GEMINI_API_KEY script property not set…]` |
| `=SSI("hello", , "unknownTool")` | `[SSI Error: unknown tool 'unknownTool']` |

## Test plan

- [x] `npm run test:coverage` — all tests pass, all thresholds met
- [x] `npm run typecheck` — no errors
- [x] `npm run lint` — no errors
- [x] `npm run build` — `SSI` stub confirmed in `dist/index.js`
- [x] Deploy to dev and run smoke tests above

🤖 Generated with [Claude Code](https://claude.com/claude-code)