### PR TITLE
feat: client panel-router architecture with component-based sidebar

### DIFF
--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -5,13 +5,7 @@ import { SingleTagList } from "../components/single-tag-list";
 import { RowRange } from "../components/row-range";
 import { getSheetHeaders, runBatchAI } from "../services";
 
-export interface SavedState {
-  userPromptCols: string[];
-  driveFileCols: string[];
-  systemPromptCol: string;
-  outputCol: string;
-  rowRange?: { start: number; end: number };
-}
+export type SavedState = Required<Omit<RunConfig, "rowRange">> & Pick<RunConfig, "rowRange">;
 
 export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState> {
   private userPromptList: TagList | null = null;

--- a/src/client/panels/tool-list.ts
+++ b/src/client/panels/tool-list.ts
@@ -60,18 +60,18 @@ export class ToolListPanel implements Panel {
       </div>
       <div class="section">
         <h3>Main Tools</h3>
-        <button id="btn-import-drive-links" class="tool-btn">
-          <span class="icon">📂</span> Import Drive Links
+        <button id="btn-recipes" class="tool-btn">
+          <span class="icon">🥞</span> Recipes
         </button>
         <button id="btn-run-ai" class="tool-btn">
           <span class="icon">▶️</span> Run AI Inference
         </button>
-        <button id="btn-recipes" class="tool-btn">
-          <span class="icon">🥞</span> Recipes
-        </button>
       </div>
       <div class="section">
         <h3>Extras</h3>
+        <button id="btn-import-drive-links" class="tool-btn">
+          <span class="icon">📂</span> Import Drive Links
+        </button>
         <button id="btn-sample-rows" class="tool-btn">
           <span class="icon">🎲</span> Sample Rows
         </button>


### PR DESCRIPTION
## Summary

- **Router navigation stack**: Replaces the old two-panel toggle with a `Router` class that manages a push/pop navigation history, enabling panels to go back with their state restored.
- **Self-contained components**: `TagList`, `SingleTagList`, `RowRange`, and `LockableField` each own their own DOM subtree, decoupling sidebar layout from business logic.
- **`services.ts` as GAS boundary**: All `google.script.run` calls are wrapped as Promises in a single module with a cached header fetch, making all panel code fully unit-testable without GAS globals.
- **Panels**: `ToolListPanel` (tool launcher), `ConfigureAIRunPanel` (AI run config with savedState roundtrip), `RecipesListPanel` stub, `DocumentSummarizationPanel` stub.
- **Cleanup**: Deletes old `sidebar.ts`, monolithic `sidebar-entry.ts`, and all associated tests/fixtures. Updates `jest.config.cjs` and `tsconfig.client.json` accordingly.

## Architecture

```
sidebar-entry.ts (init)
└── Router (push/pop stack)
    ├── ToolListPanel          — tool buttons, dispatches via services.ts
    ├── ConfigureAIRunPanel    — column selectors + row range + Run AI button
    ├── RecipesListPanel       — stub
    └── DocumentSummarizationPanel — stub ("Coming soon")

services.ts                   — google.script.run → Promise wrappers + header cache
components/
  tag-list.ts                 — multi-select column tags
  single-tag-list.ts          — single-select + new column option
  row-range.ts                — all/range radio + number inputs
  lockable-field.ts           — locked-by-default input/textarea
```

## Tests

162 tests across 14 suites. Per-file coverage thresholds enforced in `jest.config.cjs`.

## Manual Testing Steps

**Prerequisites:**
- Deploy to dev: `npm run deploy:dev` (requires `.clasp.dev.json` and GAS authorization)
- Open the bound spreadsheet → **Extensions → SSI Tools → Open Sidebar**

---

**1. Sidebar loads — tool list renders**
- Expected: Sidebar shows four buttons — "Import Drive Links", "Extract Text", "Sample Rows", "Run AI Inference"
- Expected: No JS errors in the sidebar

**2. Navigate to Configure AI Run**
- Click **"Run AI Inference"**
- Expected: Panel transitions to the AI run configuration view
- Expected: A "← Back" button appears at the top
- Expected: Column selector sections are visible (User Prompt Columns, Drive File Columns, System Prompt Column, Output Column, Row Range)

**3. Headers load into column selectors**
- Expected: After a brief load, column headers from the active sheet populate the tag lists
- Expected: Multi-select sections show checkboxes; single-select sections show radio buttons

**4. Back navigation returns to tool list**
- Click **"← Back"**
- Expected: Returns to the tool list panel

**5. Run AI — happy path**
- Sheet must have columns: `source_drive`, `source_text`, `system_prompt`, `user_prompt`, `ai_inference`
- Set `GEMINI_API_KEY` in Apps Script → Project Settings → Script Properties
- Open Configure AI Run, select appropriate columns, choose row range, click **"Run AI"**
- Expected: Button shows "⏳ Running…" and is disabled while running
- Expected: On success, sidebar returns to the tool list

**6. Run AI — error path**
- Set an invalid `GEMINI_API_KEY` in Script Properties
- Click **"Run AI"**
- Expected: Button re-enables after failure; an alert dialog shows the error message

**7. Recipes stub**
- Click **"Recipes"** on the tool list
- Expected: Navigates to a Recipes panel with a "Document Summarization" button
- Click "Document Summarization" → Expected: "Coming soon." message
- Click Back twice → Expected: Returns to tool list

**8. Other tools still work**
- Verify "Import Drive Links", "Extract Text", and "Sample Rows" all execute without errors (same underlying `runTool` dispatch path as before)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)