### PR TITLE
feat: sidebar UI polish — cards, hierarchy, type cleanup, CLIP wrap

### DIFF
--- a/__tests__/panels/configure-ai-run.test.ts
+++ b/__tests__/panels/configure-ai-run.test.ts
@@ -164,16 +164,10 @@ describe("ConfigureAIRunPanel — Run AI", () => {
   });
 });
 
-describe("ConfigureAIRunPanel — back/cancel", () => {
+describe("ConfigureAIRunPanel — back", () => {
   it("back-btn calls nav.back()", async () => {
     const { container } = await mountAndLoad();
     container.querySelector<HTMLButtonElement>("#back-btn")!.click();
-    expect(mockNav.back).toHaveBeenCalled();
-  });
-
-  it("cancel-btn calls nav.back()", async () => {
-    const { container } = await mountAndLoad();
-    container.querySelector<HTMLButtonElement>("#cancel-btn")!.click();
     expect(mockNav.back).toHaveBeenCalled();
   });
 });

--- a/__tests__/panels/recipe.test.ts
+++ b/__tests__/panels/recipe.test.ts
@@ -8,7 +8,7 @@ jest.mock("../../src/client/services", () => ({
 import { RecipePanel } from "../../src/client/panels/recipe";
 import * as services from "../../src/client/services";
 import type { RecipeParams, PrepRecipeResult } from "../../src/shared/types";
-import type { NavigationContext } from "../../src/client/types";
+import type { NavigationContext, RecipeDefinition } from "../../src/client/types";
 
 const mockPrepRecipe = services.prepRecipe as jest.Mock;
 
@@ -24,7 +24,15 @@ function mount(params: RecipeParams, savedState?: unknown) {
   const container = document.createElement("div");
   const nav = makeNav();
   const panel = new RecipePanel();
-  panel.mount(container, nav, params, savedState as never);
+  const definition: RecipeDefinition = {
+    id: "test",
+    name: "Test Recipe",
+    icon: "🧪",
+    description: "Test",
+    panelId: "recipe",
+    params,
+  };
+  panel.mount(container, nav, definition, savedState as never);
   return { container, nav, panel };
 }
 

--- a/__tests__/panels/recipes-list.test.ts
+++ b/__tests__/panels/recipes-list.test.ts
@@ -50,12 +50,18 @@ describe("RecipesListPanel", () => {
     expect(container.querySelector("#btn-custom")).not.toBeNull();
   });
 
-  it("clicking a recipe button calls nav.navigate with correct panelId and params", () => {
+  it("clicking a recipe button calls nav.navigate with the full RecipeDefinition", () => {
     const { container, nav } = mount();
     container.querySelector<HTMLButtonElement>("#btn-doc-sum")!.click();
-    expect(nav.navigate).toHaveBeenCalledWith("recipe", {
-      driveFolder: { colTitle: "Drive Link" },
-    });
+    expect(nav.navigate).toHaveBeenCalledWith(
+      "recipe",
+      expect.objectContaining({
+        id: "doc-sum",
+        name: "Document Summarization",
+        panelId: "recipe",
+        params: { driveFolder: { colTitle: "Drive Link" } },
+      }),
+    );
   });
 
   it("clicking back calls nav.back()", () => {

--- a/__tests__/services.test.ts
+++ b/__tests__/services.test.ts
@@ -141,6 +141,27 @@ describe("prepRecipe", () => {
     expect(mockRun.prepRecipe).toHaveBeenCalledWith(params);
   });
 
+  it("invalidates the header cache on success so next getSheetHeaders re-fetches", async () => {
+    // Prime the cache
+    const h1 = captureHandlers();
+    const p1 = services.getSheetHeaders();
+    h1.resolve([]);
+    await p1;
+
+    // Prep resolves — should bust the cache
+    const h2 = captureHandlers();
+    const prepPromise = services.prepRecipe({});
+    h2.resolve({ rowRange: { start: 2, end: 2 }, colNames: {} });
+    await prepPromise;
+
+    // Next getSheetHeaders must hit GAS again (not return cached [])
+    const h3 = captureHandlers();
+    const p3 = services.getSheetHeaders();
+    h3.resolve(["new_col"]);
+    await expect(p3).resolves.toEqual(["new_col"]);
+    expect(mockRun.getSheetHeaders).toHaveBeenCalledTimes(2);
+  });
+
   it("rejects on failure", async () => {
     const handlers = captureHandlers();
     const promise = services.prepRecipe({});

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -300,6 +300,25 @@ describe("findOrCreateColumn", () => {
     expect(idx).toBe(1);
     expect(setValueMock).toHaveBeenCalledWith("My Col");
   });
+
+  it("applies wrapStrategy to the new column range when provided", () => {
+    const setValueMock = jest.fn();
+    const setWrapStrategyMock = jest.fn();
+    const sheet = {
+      getLastColumn: () => 0,
+      getMaxRows: () => 100,
+      getRange: jest
+        .fn()
+        .mockImplementation((_row: number, _col: number, numRows?: number) =>
+          numRows !== undefined
+            ? { setWrapStrategy: setWrapStrategyMock }
+            : { setValue: setValueMock },
+        ),
+    } as unknown as GoogleAppsScript.Spreadsheet.Sheet;
+    const wrapStrategy = "CLIP" as unknown as GoogleAppsScript.Spreadsheet.WrapStrategy;
+    findOrCreateColumn(sheet, "My Col", wrapStrategy);
+    expect(setWrapStrategyMock).toHaveBeenCalledWith(wrapStrategy);
+  });
 });
 
 // ── writeColumn ─────────────────────────────────────────────────
@@ -321,5 +340,18 @@ describe("writeColumn", () => {
     } as unknown as GoogleAppsScript.Spreadsheet.Sheet;
     writeColumn(sheet, 1, []);
     expect(sheet.getRange).not.toHaveBeenCalled();
+  });
+
+  it("applies wrapStrategy to the written range when provided", () => {
+    const setValuesMock = jest.fn();
+    const setWrapStrategyMock = jest.fn();
+    const sheet = {
+      getRange: jest
+        .fn()
+        .mockReturnValue({ setValues: setValuesMock, setWrapStrategy: setWrapStrategyMock }),
+    } as unknown as GoogleAppsScript.Spreadsheet.Sheet;
+    const wrapStrategy = "CLIP" as unknown as GoogleAppsScript.Spreadsheet.WrapStrategy;
+    writeColumn(sheet, 3, ["a", "b"], wrapStrategy);
+    expect(setWrapStrategyMock).toHaveBeenCalledWith(wrapStrategy);
   });
 });

--- a/src/client/components/lockable-field.ts
+++ b/src/client/components/lockable-field.ts
@@ -22,20 +22,6 @@ export class LockableField {
   ): HTMLInputElement | HTMLTextAreaElement {
     container.innerHTML = "";
 
-    const header = document.createElement("div");
-    header.className = "lockable-field-header";
-
-    const label = document.createElement("span");
-    label.className = "field-label";
-    label.textContent = config.label;
-
-    const unlockBtn = document.createElement("button");
-    unlockBtn.type = "button";
-    unlockBtn.className = "unlock-btn";
-    unlockBtn.textContent = this.locked ? "🔒 Edit" : "🔓 Lock";
-
-    header.append(label, unlockBtn);
-
     const input: HTMLInputElement | HTMLTextAreaElement = config.multiline
       ? document.createElement("textarea")
       : document.createElement("input");
@@ -46,6 +32,11 @@ export class LockableField {
     if (config.placeholder) input.placeholder = config.placeholder;
     input.disabled = this.locked;
 
+    const unlockBtn = document.createElement("button");
+    unlockBtn.type = "button";
+    unlockBtn.className = "unlock-btn";
+    unlockBtn.textContent = this.locked ? "🔒 Edit" : "🔓 Lock";
+
     unlockBtn.addEventListener("click", () => {
       this.locked = !this.locked;
       input.disabled = this.locked;
@@ -55,7 +46,24 @@ export class LockableField {
       }
     });
 
-    container.append(header, input);
+    const label = document.createElement("span");
+    label.className = "field-label";
+    label.textContent = config.label;
+
+    if (config.multiline) {
+      // Block layout: label + lock button on header row, textarea below
+      const header = document.createElement("div");
+      header.className = "lockable-field-header";
+      header.append(label, unlockBtn);
+      container.append(header, input);
+    } else {
+      // Inline layout: label, input, and lock button all on one row
+      const row = document.createElement("div");
+      row.className = "lockable-field-row";
+      row.append(label, input, unlockBtn);
+      container.append(row);
+    }
+
     return input;
   }
 

--- a/src/client/components/recipe-prep-cook.ts
+++ b/src/client/components/recipe-prep-cook.ts
@@ -26,8 +26,8 @@ export class RecipePrepCook {
   private render(container: HTMLElement, config: RecipePrepCookConfig): void {
     container.innerHTML = `
       <div class="panel-buttons">
-        <button id="prep-btn" class="btn-prep">Prep Recipe</button>
-        <button id="cook-btn" class="btn-cook" disabled>Cook</button>
+        <button id="prep-btn" class="btn-outline">Prep Recipe</button>
+        <button id="cook-btn" class="btn-run" disabled>Cook</button>
       </div>
     `;
     this.prepBtn = container.querySelector<HTMLButtonElement>("#prep-btn")!;

--- a/src/client/components/recipe-prep-cook.ts
+++ b/src/client/components/recipe-prep-cook.ts
@@ -27,7 +27,7 @@ export class RecipePrepCook {
     container.innerHTML = `
       <div class="panel-buttons">
         <button id="prep-btn" class="btn-outline">Prep Recipe</button>
-        <button id="cook-btn" class="btn-run" disabled>Cook</button>
+        <button id="cook-btn" class="btn-run" disabled>Cook ➡️</button>
       </div>
     `;
     this.prepBtn = container.querySelector<HTMLButtonElement>("#prep-btn")!;

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -92,7 +92,6 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
 
   private wireNavButtons(container: HTMLElement): void {
     container.querySelector("#back-btn")?.addEventListener("click", () => this.nav?.back());
-    container.querySelector("#cancel-btn")?.addEventListener("click", () => this.nav?.back());
   }
 
   private handleRun(container: HTMLElement): void {
@@ -175,7 +174,6 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
           <div id="row-range-container"></div>
         </div>
         <div class="panel-buttons">
-          <button id="cancel-btn" class="btn-cancel">Cancel</button>
           <button id="run-btn" class="btn-run">Run AI</button>
         </div>
       </div>

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -148,7 +148,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
     return `
       <div class="panel-header">
         <button id="back-btn" class="back-btn">← Back</button>
-        <span class="panel-title">Configure AI Run</span>
+        <span class="panel-title">▶️ Run AI Inference</span>
       </div>
       <div id="no-headers-msg" class="no-headers-msg" style="display:none">
         No columns found — add headers to your sheet first.

--- a/src/client/panels/recipe.ts
+++ b/src/client/panels/recipe.ts
@@ -1,4 +1,4 @@
-import type { NavigationContext, Panel } from "../types";
+import type { NavigationContext, Panel, RecipeDefinition } from "../types";
 import type {
   RecipeParams,
   PrepRecipeParams,
@@ -20,8 +20,9 @@ type SavedState = {
   preppedRunConfig?: Partial<RunConfig>;
 };
 
-export class RecipePanel implements Panel<RecipeParams, SavedState> {
+export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
   private nav: NavigationContext | null = null;
+  private definition: RecipeDefinition | null = null;
   private params: RecipeParams | null = null;
   private prepCook: RecipePrepCook | null = null;
   private preppedRunConfig: Partial<RunConfig> | null = null;
@@ -38,15 +39,16 @@ export class RecipePanel implements Panel<RecipeParams, SavedState> {
   mount(
     container: HTMLElement,
     nav: NavigationContext,
-    params?: RecipeParams,
+    definition?: RecipeDefinition,
     savedState?: SavedState,
   ): void {
     this.nav = nav;
-    this.params = params ?? {};
+    this.definition = definition ?? null;
+    this.params = definition?.params ?? {};
     this.fields = { userPromptTitles: [], userPromptValues: [] };
     this.preppedRunConfig = savedState?.preppedRunConfig ?? null;
 
-    container.innerHTML = this.template(this.params);
+    container.innerHTML = this.template(this.definition);
 
     container.querySelector("#back-btn")?.addEventListener("click", () => nav.back());
 
@@ -82,7 +84,7 @@ export class RecipePanel implements Panel<RecipeParams, SavedState> {
       this.fields.systemPromptTitle = new LockableField(
         container.querySelector("#system-prompt-title-container")!,
         {
-          label: "Column Title",
+          label: "Column",
           defaultValue: savedState?.systemPromptTitle ?? params.systemPrompt.colTitle.value,
           locked: params.systemPrompt.colTitle.locked,
           onUnlock: reset,
@@ -105,7 +107,7 @@ export class RecipePanel implements Panel<RecipeParams, SavedState> {
         this.fields.userPromptTitles[i] = new LockableField(
           container.querySelector(`#user-prompt-title-${i}-container`)!,
           {
-            label: "Column Title",
+            label: "Column",
             defaultValue: savedState?.userPromptTitles?.[i] ?? up.colTitle.value,
             locked: up.colTitle.locked,
             onUnlock: reset,
@@ -128,7 +130,7 @@ export class RecipePanel implements Panel<RecipeParams, SavedState> {
       this.fields.outputColTitle = new LockableField(
         container.querySelector("#output-col-title-container")!,
         {
-          label: "Output Column Name",
+          label: "Column",
           defaultValue: savedState?.outputColTitle ?? params.outputCol.colTitle.value,
           locked: params.outputCol.colTitle.locked,
           onUnlock: reset,
@@ -201,17 +203,21 @@ export class RecipePanel implements Panel<RecipeParams, SavedState> {
     };
   }
 
-  private template(params: RecipeParams): string {
+  private template(definition: RecipeDefinition | null): string {
+    const params = definition?.params ?? {};
+    const title = definition ? `${definition.icon} ${definition.name}` : "Recipe";
+    const numUserPrompts = params.userPrompts?.length ?? 0;
+
     return `
       <div class="panel-header">
         <button id="back-btn" class="back-btn">← Back</button>
-        <span class="panel-title">Recipe</span>
+        <span class="panel-title">${title}</span>
       </div>
       ${
         params.driveFolder
           ? `
-      <div class="field-group">
-        <span class="field-label">Google Drive Folder Link <span class="required">*</span></span>
+      <div class="recipe-section-card">
+        <div class="recipe-section-card-title">Drive Folder <span class="required">*</span></div>
         ${params.driveFolder.helperText ? `<p class="field-helper">${params.driveFolder.helperText}</p>` : ""}
         <input id="drive-folder-input" type="text" class="text-input"
           placeholder="Paste Google Drive folder URL or ID" />
@@ -221,8 +227,8 @@ export class RecipePanel implements Panel<RecipeParams, SavedState> {
       ${
         params.systemPrompt
           ? `
-      <div class="field-group">
-        <span class="field-label">System Prompt</span>
+      <div class="recipe-section-card">
+        <div class="recipe-section-card-title">System Prompt</div>
         <div id="system-prompt-title-container"></div>
         <div id="system-prompt-value-container"></div>
       </div>`
@@ -231,8 +237,8 @@ export class RecipePanel implements Panel<RecipeParams, SavedState> {
       ${(params.userPrompts ?? [])
         .map(
           (_, i) => `
-      <div class="field-group">
-        <span class="field-label">User Prompt</span>
+      <div class="recipe-section-card">
+        <div class="recipe-section-card-title">User Prompt${numUserPrompts > 1 ? ` ${i + 1}` : ""}</div>
         <div id="user-prompt-title-${i}-container"></div>
         <div id="user-prompt-value-${i}-container"></div>
       </div>`,
@@ -241,8 +247,8 @@ export class RecipePanel implements Panel<RecipeParams, SavedState> {
       ${
         params.outputCol
           ? `
-      <div class="field-group">
-        <span class="field-label">Output Column</span>
+      <div class="recipe-section-card">
+        <div class="recipe-section-card-title">Output Column</div>
         <div id="output-col-title-container"></div>
       </div>`
           : ""

--- a/src/client/panels/recipes-list.ts
+++ b/src/client/panels/recipes-list.ts
@@ -8,7 +8,7 @@ export class RecipesListPanel implements Panel {
     RECIPES.forEach((recipe) => {
       container
         .querySelector(`#btn-${recipe.id}`)
-        ?.addEventListener("click", () => nav.navigate(recipe.panelId, recipe.params));
+        ?.addEventListener("click", () => nav.navigate(recipe.panelId, recipe));
     });
   }
 
@@ -26,10 +26,19 @@ export class RecipesListPanel implements Panel {
         ${RECIPES.map(
           (r) => `
           <button id="btn-${r.id}" class="tool-btn">
-            <span class="icon">${r.icon}</span> ${r.name}
-            <span class="tool-btn-sub">${r.description}</span>
+            <span class="icon">${r.icon}</span>
+            <div class="tool-btn-text">
+              <span class="tool-btn-name">${r.name}</span>
+              <span class="tool-btn-sub">${r.description}</span>
+            </div>
           </button>`,
         ).join("")}
+        <div class="tool-btn-stub">
+          <span class="icon">✨</span>
+          <div class="tool-btn-text">
+            <span class="tool-btn-name">More recipes coming soon…</span>
+          </div>
+        </div>
       </div>
     `;
   }

--- a/src/client/services.ts
+++ b/src/client/services.ts
@@ -40,7 +40,10 @@ export function runTool(fn: string): Promise<void> {
 export function prepRecipe(params: PrepRecipeParams): Promise<PrepRecipeResult> {
   return new Promise((resolve, reject) => {
     google.script.run
-      .withSuccessHandler((result: unknown) => resolve(result as PrepRecipeResult))
+      .withSuccessHandler((result: unknown) => {
+        invalidateHeaderCache();
+        resolve(result as PrepRecipeResult);
+      })
       .withFailureHandler((err: Error) => reject(err))
       .prepRecipe(params);
   });

--- a/src/client/sidebar.css
+++ b/src/client/sidebar.css
@@ -243,3 +243,115 @@
             padding: 24px 0;
             font-style: italic;
         }
+
+        /* ── Recipe list button hierarchy ── */
+
+        .tool-btn-text {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 2px;
+        }
+
+        .tool-btn-sub {
+            font-size: 11px;
+            color: var(--text-secondary);
+            font-weight: 400;
+            line-height: 1.3;
+        }
+
+        .tool-btn:hover .tool-btn-sub { color: var(--primary-blue); opacity: 0.8; }
+
+        /* ── Coming soon stub ── */
+
+        .tool-btn-stub {
+            width: 100%;
+            display: flex;
+            align-items: center;
+            padding: 12px 16px;
+            margin-bottom: 8px;
+            border-radius: 24px;
+            border: 1px dashed var(--border-color);
+            background: #f8f9fa;
+            color: var(--text-secondary);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+            font-size: 14px;
+            font-style: italic;
+            cursor: default;
+            box-sizing: border-box;
+        }
+
+        /* ── Recipe section cards ── */
+
+        .recipe-section-card {
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            padding: 12px;
+            margin-bottom: 12px;
+        }
+
+        .recipe-section-card-title {
+            font-size: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.8px;
+            color: var(--text-secondary);
+            margin-bottom: 10px;
+        }
+
+        .field-helper {
+            font-size: 11px;
+            color: var(--text-secondary);
+            margin: 0 0 8px 0;
+            line-height: 1.4;
+        }
+
+        /* ── LockableField layouts ── */
+
+        .lockable-field-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 4px;
+        }
+
+        .lockable-field-header .field-label { margin-bottom: 0; }
+
+        .lockable-field-row {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            margin-bottom: 6px;
+        }
+
+        .lockable-field-row .field-label {
+            flex: 0 0 auto;
+            white-space: nowrap;
+            margin-bottom: 0;
+        }
+
+        .lockable-field-row .text-input {
+            flex: 1;
+            min-width: 0;
+            width: auto;
+            margin-top: 0;
+        }
+
+        .unlock-btn {
+            flex: 0 0 auto;
+            background: none;
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            color: var(--text-secondary);
+            font-size: 11px;
+            cursor: pointer;
+            padding: 3px 6px;
+            white-space: nowrap;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+            line-height: 1.4;
+        }
+
+        .unlock-btn:hover {
+            border-color: var(--primary-blue);
+            color: var(--primary-blue);
+        }

--- a/src/client/sidebar.css
+++ b/src/client/sidebar.css
@@ -225,6 +225,22 @@
         .btn-run:hover { background: #1557b0; }
         .btn-run:disabled { background: #9aa0a6; cursor: default; }
 
+        .btn-outline {
+            flex: 1;
+            padding: 10px;
+            background: white;
+            color: var(--primary-blue);
+            border: 1px solid var(--primary-blue);
+            border-radius: 4px;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+            font-weight: 500;
+            font-size: 14px;
+            cursor: pointer;
+        }
+
+        .btn-outline:hover { background: #e8f0fe; }
+        .btn-outline:disabled { color: #9aa0a6; border-color: #9aa0a6; cursor: default; }
+
         .btn-cancel {
             padding: 10px 16px;
             background: white;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,3 +1,5 @@
+import type { RecipeParams } from "../shared/types";
+
 /**
  * All registered panel identifiers. Add new panels here first.
  */
@@ -29,5 +31,5 @@ export interface RecipeDefinition {
   icon: string;
   description: string;
   panelId: PanelId;
-  params?: unknown;
+  params?: RecipeParams;
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -356,32 +356,51 @@ export function prepRecipe(params: PrepRecipeParams): PrepRecipeResult {
     const files: { url: string }[] = [];
     getAllFilesRecursive(folder, files);
     numRows = files.length || 1;
-    const col = findOrCreateColumn(sheet, params.driveFolder.colTitle);
+    const col = findOrCreateColumn(
+      sheet,
+      params.driveFolder.colTitle,
+      SpreadsheetApp.WrapStrategy.CLIP,
+    );
     writeColumn(
       sheet,
       col,
       files.map((f) => f.url),
+      SpreadsheetApp.WrapStrategy.CLIP,
     );
     colNames.driveLink = params.driveFolder.colTitle;
   }
 
   if (params.systemPrompt) {
-    const col = findOrCreateColumn(sheet, params.systemPrompt.colTitle);
-    writeColumn(sheet, col, Array(numRows).fill(params.systemPrompt.value) as string[]);
+    const col = findOrCreateColumn(
+      sheet,
+      params.systemPrompt.colTitle,
+      SpreadsheetApp.WrapStrategy.CLIP,
+    );
+    writeColumn(
+      sheet,
+      col,
+      Array(numRows).fill(params.systemPrompt.value) as string[],
+      SpreadsheetApp.WrapStrategy.CLIP,
+    );
     colNames.systemPrompt = params.systemPrompt.colTitle;
   }
 
   if (params.userPrompts) {
     colNames.userPrompts = [];
     for (const up of params.userPrompts) {
-      const col = findOrCreateColumn(sheet, up.colTitle);
-      writeColumn(sheet, col, Array(numRows).fill(up.value) as string[]);
+      const col = findOrCreateColumn(sheet, up.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
+      writeColumn(
+        sheet,
+        col,
+        Array(numRows).fill(up.value) as string[],
+        SpreadsheetApp.WrapStrategy.CLIP,
+      );
       colNames.userPrompts.push(up.colTitle);
     }
   }
 
   if (params.outputCol) {
-    findOrCreateColumn(sheet, params.outputCol.colTitle);
+    findOrCreateColumn(sheet, params.outputCol.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
     colNames.outputCol = params.outputCol.colTitle;
   }
 

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -103,10 +103,12 @@ export function resolveColumns(headers: string[], names: string[]): number[] {
 /**
  * Find a column by header title in row 1, or append a new one.
  * Returns the 1-based column index.
+ * Pass wrapStrategy to apply a wrap format to the entire new column on creation.
  */
 export function findOrCreateColumn(
   sheet: GoogleAppsScript.Spreadsheet.Sheet,
   title: string,
+  wrapStrategy?: GoogleAppsScript.Spreadsheet.WrapStrategy,
 ): number {
   const lastCol = sheet.getLastColumn();
   if (lastCol > 0) {
@@ -116,18 +118,27 @@ export function findOrCreateColumn(
   }
   const newCol = lastCol + 1;
   sheet.getRange(1, newCol).setValue(title);
+  if (wrapStrategy !== undefined) {
+    sheet.getRange(1, newCol, sheet.getMaxRows(), 1).setWrapStrategy(wrapStrategy);
+  }
   return newCol;
 }
 
 /**
  * Write an array of string values to a column starting at row 2.
  * Uses a single setValues() call for efficiency.
+ * Pass wrapStrategy to apply a wrap format to the written range.
  */
 export function writeColumn(
   sheet: GoogleAppsScript.Spreadsheet.Sheet,
   colIdx: number,
   values: string[],
+  wrapStrategy?: GoogleAppsScript.Spreadsheet.WrapStrategy,
 ): void {
   if (values.length === 0) return;
-  sheet.getRange(2, colIdx, values.length, 1).setValues(values.map((v) => [v]));
+  const range = sheet.getRange(2, colIdx, values.length, 1);
+  range.setValues(values.map((v) => [v]));
+  if (wrapStrategy !== undefined) {
+    range.setWrapStrategy(wrapStrategy);
+  }
 }


### PR DESCRIPTION
## Summary

- **Recipe section cards** — each param group (Drive Folder, System Prompt, User Prompt, Output Column) is now rendered in a bordered card with an ALL-CAPS section title, giving clear visual separation between form sections
- **LockableField inline layout** — single-line fields (column title) render label + input + lock button on one compact row; multiline fields (prompts) keep the header-row + textarea layout
- **Recipe button hierarchy** — description text drops below the recipe name as smaller secondary text, using a flex-column `.tool-btn-text` wrapper
- **Recipe panel header** — now shows the recipe's icon + name (e.g. `📄 Document Summarization`) instead of the generic "Recipe" title
- **`RecipeDefinition.params` typed as `RecipeParams`** (was `unknown`) — `RecipePanel` now receives the full `RecipeDefinition` so name and icon flow naturally with no new interface needed; `RecipesListPanel` navigates with the whole definition
- **Panel rename** — Configure AI Run → `▶️ Run AI Inference` to match the tool-list button label
- **"More recipes coming soon" stub** — dashed-border, non-interactive entry at the bottom of the recipes list
- **Column wrap strategy** — `findOrCreateColumn` and `writeColumn` accept an optional `wrapStrategy` param; all `prepRecipe` call sites pass `CLIP` so newly created columns don't wrap long text and blast users

## Test plan

- [ ] Open sidebar → Recipes → Document Summarization: panel header shows "📄 Document Summarization"
- [ ] Recipe form sections appear as distinct bordered cards (Drive Folder, System Prompt, User Prompt, Output Column)
- [ ] Column title fields (single-line) show label + input + lock button on one row
- [ ] Prompt fields (multiline) show label + lock button header, textarea below
- [ ] Recipes list shows description as smaller text below each recipe name
- [ ] "✨ More recipes coming soon…" stub appears at bottom of recipes list (dashed border, not clickable)
- [ ] Run AI Inference panel title reads "▶️ Run AI Inference"
- [ ] After Prep Recipe, newly created columns in the sheet have CLIP wrap strategy (text doesn't overflow cell height)
- [ ] All 197 Jest tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)