### PR TITLE
refactor: remove header cache from services.ts

### DIFF
--- a/__tests__/services.test.ts
+++ b/__tests__/services.test.ts
@@ -54,35 +54,11 @@ describe("getSheetHeaders", () => {
     expect(mockRun.getSheetHeaders).toHaveBeenCalledTimes(1);
   });
 
-  it("caches the result — second call does not hit GAS", async () => {
-    const handlers = captureHandlers();
-    const p1 = services.getSheetHeaders();
-    handlers.resolve(["col_a"]);
-    await p1;
-    await services.getSheetHeaders();
-    expect(mockRun.getSheetHeaders).toHaveBeenCalledTimes(1);
-  });
-
   it("rejects with the error on failure", async () => {
     const handlers = captureHandlers();
     const promise = services.getSheetHeaders();
     handlers.reject(new Error("sheet error"));
     await expect(promise).rejects.toThrow("sheet error");
-  });
-});
-
-describe("invalidateHeaderCache", () => {
-  it("clears cache so next getSheetHeaders re-fetches", async () => {
-    const handlers = captureHandlers();
-    const p1 = services.getSheetHeaders();
-    handlers.resolve(["col_a"]);
-    await p1;
-    services.invalidateHeaderCache();
-    const handlers2 = captureHandlers();
-    const p2 = services.getSheetHeaders();
-    handlers2.resolve(["col_b"]);
-    await p2;
-    expect(mockRun.getSheetHeaders).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -139,27 +115,6 @@ describe("prepRecipe", () => {
     handlers.resolve(result);
     await expect(promise).resolves.toEqual(result);
     expect(mockRun.prepRecipe).toHaveBeenCalledWith(params);
-  });
-
-  it("invalidates the header cache on success so next getSheetHeaders re-fetches", async () => {
-    // Prime the cache
-    const h1 = captureHandlers();
-    const p1 = services.getSheetHeaders();
-    h1.resolve([]);
-    await p1;
-
-    // Prep resolves — should bust the cache
-    const h2 = captureHandlers();
-    const prepPromise = services.prepRecipe({});
-    h2.resolve({ rowRange: { start: 2, end: 2 }, colNames: {} });
-    await prepPromise;
-
-    // Next getSheetHeaders must hit GAS again (not return cached [])
-    const h3 = captureHandlers();
-    const p3 = services.getSheetHeaders();
-    h3.resolve(["new_col"]);
-    await expect(p3).resolves.toEqual(["new_col"]);
-    expect(mockRun.getSheetHeaders).toHaveBeenCalledTimes(2);
   });
 
   it("rejects on failure", async () => {

--- a/src/client/services.ts
+++ b/src/client/services.ts
@@ -1,22 +1,12 @@
 import type { PrepRecipeParams, PrepRecipeResult, RunConfig } from "../shared/types";
 
-let cachedHeaders: string[] | null = null;
-
 export function getSheetHeaders(): Promise<string[]> {
-  if (cachedHeaders !== null) return Promise.resolve(cachedHeaders);
   return new Promise((resolve, reject) => {
     google.script.run
-      .withSuccessHandler((headers: unknown) => {
-        cachedHeaders = headers as string[];
-        resolve(cachedHeaders);
-      })
+      .withSuccessHandler((headers: unknown) => resolve(headers as string[]))
       .withFailureHandler((err: Error) => reject(err))
       .getSheetHeaders();
   });
-}
-
-export function invalidateHeaderCache(): void {
-  cachedHeaders = null;
 }
 
 export function runBatchAI(config: RunConfig): Promise<void> {
@@ -40,10 +30,7 @@ export function runTool(fn: string): Promise<void> {
 export function prepRecipe(params: PrepRecipeParams): Promise<PrepRecipeResult> {
   return new Promise((resolve, reject) => {
     google.script.run
-      .withSuccessHandler((result: unknown) => {
-        invalidateHeaderCache();
-        resolve(result as PrepRecipeResult);
-      })
+      .withSuccessHandler((result: unknown) => resolve(result as PrepRecipeResult))
       .withFailureHandler((err: Error) => reject(err))
       .prepRecipe(params);
   });


### PR DESCRIPTION
## Summary

- Removes the module-level `cachedHeaders` variable and `invalidateHeaderCache()` export from `services.ts`
- `getSheetHeaders()` now always fetches live from GAS on every call
- Deletes stale cache tests (`caches the result`, `invalidateHeaderCache` describe block, `invalidates the header cache on success`)

## Motivation

The cache had two correctness bugs with no clean fix:
1. **Poisoned by first empty lookup** — if headers were fetched before any columns existed, the empty array was cached and subsequent calls returned stale data even after columns were created
2. **No sheet-switching invalidation** — switching the active sheet mid-session would cause the sidebar to operate on stale headers from the previous sheet

The cache only saved one GAS round-trip per sidebar open. Given the Prep/Cook workflow already involves several GAS calls, the complexity wasn't worth the marginal save.

## Test plan
- [x] `npm run test:coverage` — 196 tests passing, all per-file thresholds met
- [x] `services.ts` coverage: 100% statements / 100% branches / 100% functions / 100% lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)