### PR TITLE
Feature/gemini tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Thumbs.db
 
 # Gemini CLI internal
 .gemini/
+
+# Git worktrees
+.worktrees/

--- a/__tests__/api-function-tools.test.ts
+++ b/__tests__/api-function-tools.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for buildGeminiPayload — function-calling tool path.
+ *
+ * This file mocks the TOOL_REGISTRY to include a function-calling entry,
+ * exercising the function_declarations assembly branch in buildGeminiPayload.
+ * Kept separate from api.test.ts to avoid module-mock interference.
+ */
+
+jest.mock("../src/server/tools", () => ({
+  TOOL_REGISTRY: {
+    google_search: {
+      kind: "function",
+      declaration: { name: "google_search", description: "Run a web search" },
+    },
+  },
+}));
+
+import { buildGeminiPayload } from "../src/server/api";
+import type { GeminiRequest } from "../src/server/types";
+import type { ToolId } from "../src/shared/types";
+
+const baseReq: GeminiRequest = {
+  apiKey: "key",
+  userTexts: ["hello"],
+};
+
+describe("buildGeminiPayload — function-calling tool", () => {
+  it("assembles a function_declarations entry when the tool is a function kind", () => {
+    const payload = buildGeminiPayload({ ...baseReq, tools: ["google_search" as ToolId] });
+    const tools = payload.tools as unknown[];
+    expect(tools).toHaveLength(1);
+    const entry = tools[0] as { function_declarations: unknown[] };
+    expect(entry).toHaveProperty("function_declarations");
+    expect(entry.function_declarations[0]).toEqual({
+      name: "google_search",
+      description: "Run a web search",
+    });
+  });
+
+  it("omits grounding entries and includes only function_declarations when all tools are functions", () => {
+    const payload = buildGeminiPayload({ ...baseReq, tools: ["google_search" as ToolId] });
+    const tools = payload.tools as unknown[];
+    // Should not have a plain { google_search: {} } grounding entry
+    expect(tools[0]).not.toHaveProperty("google_search");
+  });
+});

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -21,7 +21,7 @@
 
 import { buildGeminiPayload, callGeminiAPI, invokeGemini } from "../src/server/api";
 import { CONFIG } from "../src/server/config";
-import type { GeminiRequest } from "../src/shared/types";
+import type { GeminiRequest } from "../src/server/types";
 
 // ── Helpers ────────────────────────────────────────────────────
 
@@ -93,7 +93,7 @@ describe("buildGeminiPayload", () => {
   it("includes tools when provided", () => {
     const req: GeminiRequest = {
       ...baseReq,
-      tools: [{ name: "myFn", description: "does stuff" }],
+      tools: [{ name: "myFn", description: "does stuff" }] as unknown as import("../src/shared/types").ToolId[],
     };
     const payload = buildGeminiPayload(req);
     expect((payload.tools as any)[0].function_declarations[0].name).toBe("myFn");

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -90,18 +90,23 @@ describe("buildGeminiPayload", () => {
     expect((payload.system_instruction as any).parts[0].text).toBe("You are a helpful assistant.");
   });
 
-  it("includes tools when provided", () => {
-    const req: GeminiRequest = {
-      ...baseReq,
-      tools: [{ name: "myFn", description: "does stuff" }] as unknown as import("../src/shared/types").ToolId[],
-    };
-    const payload = buildGeminiPayload(req);
-    expect((payload.tools as any)[0].function_declarations[0].name).toBe("myFn");
-  });
+  describe("tool resolution in buildGeminiPayload", () => {
+    it("omits tools key when tools array is absent", () => {
+      const payload = buildGeminiPayload(baseReq);
+      expect(payload.tools).toBeUndefined();
+    });
 
-  it("omits tools key when tools array is empty or absent", () => {
-    const payload = buildGeminiPayload(baseReq);
-    expect(payload.tools).toBeUndefined();
+    it("omits tools key when tools array is empty", () => {
+      const payload = buildGeminiPayload({ ...baseReq, tools: [] });
+      expect(payload.tools).toBeUndefined();
+    });
+
+    it("assembles a grounding tool entry for google_search", () => {
+      const payload = buildGeminiPayload({ ...baseReq, tools: ["google_search"] });
+      const tools = payload.tools as unknown[];
+      expect(tools).toHaveLength(1);
+      expect(tools[0]).toEqual({ google_search: {} });
+    });
   });
 
   it("passes through generationConfig when provided", () => {

--- a/__tests__/client/tools.test.ts
+++ b/__tests__/client/tools.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+import { TOOL_CATALOG } from "../../src/client/tools";
+import type { ToolId } from "../../src/shared/types";
+
+describe("TOOL_CATALOG", () => {
+  it("contains an entry for every ToolId", () => {
+    // If a ToolId is added to shared/types.ts but not TOOL_CATALOG, this test fails.
+    const knownIds: ToolId[] = ["google_search"];
+    const catalogIds = TOOL_CATALOG.map((t) => t.id);
+    expect(catalogIds).toEqual(expect.arrayContaining(knownIds));
+    expect(TOOL_CATALOG).toHaveLength(knownIds.length);
+  });
+
+  it("each entry has id, name, and description", () => {
+    for (const entry of TOOL_CATALOG) {
+      expect(typeof entry.id).toBe("string");
+      expect(typeof entry.name).toBe("string");
+      expect(typeof entry.description).toBe("string");
+      expect(entry.name.length).toBeGreaterThan(0);
+      expect(entry.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("google_search entry has expected display values", () => {
+    const entry = TOOL_CATALOG.find((t) => t.id === "google_search");
+    expect(entry).toBeDefined();
+    expect(entry!.name).toBe("Google Search");
+  });
+});

--- a/__tests__/components/tag-list.test.ts
+++ b/__tests__/components/tag-list.test.ts
@@ -49,4 +49,39 @@ describe("TagList", () => {
     const list = new TagList(c, ["col_a"]);
     expect(list.getValue()).toEqual([]);
   });
+
+  describe("label/value items", () => {
+    it("displays label as textContent but stores value in data-value", () => {
+      const c = makeContainer();
+      new TagList(c, [{ label: "Google Search", value: "google_search" }]);
+      const tag = c.querySelector<HTMLButtonElement>(".tag")!;
+      expect(tag.textContent).toBe("Google Search");
+      expect(tag.getAttribute("data-value")).toBe("google_search");
+    });
+
+    it("getValue() returns value (not label) for label/value items", () => {
+      const c = makeContainer();
+      const list = new TagList(c, [{ label: "Google Search", value: "google_search" }]);
+      c.querySelector<HTMLButtonElement>('[data-value="google_search"]')!.click();
+      expect(list.getValue()).toEqual(["google_search"]);
+    });
+
+    it("pre-selects by value when using label/value items", () => {
+      const c = makeContainer();
+      new TagList(c, [{ label: "Google Search", value: "google_search" }], ["google_search"]);
+      const selected = c.querySelectorAll(".tag.selected");
+      expect(selected).toHaveLength(1);
+      expect(selected[0].getAttribute("data-value")).toBe("google_search");
+    });
+
+    it("mixed string and label/value items render correctly", () => {
+      const c = makeContainer();
+      const list = new TagList(
+        c,
+        ["col_a", { label: "Google Search", value: "google_search" }],
+        ["col_a", "google_search"],
+      );
+      expect(list.getValue()).toEqual(["col_a", "google_search"]);
+    });
+  });
 });

--- a/__tests__/customFunctions.test.ts
+++ b/__tests__/customFunctions.test.ts
@@ -19,7 +19,7 @@
 
 // ── Import after mocks ─────────────────────────────────────────
 
-import { SSI, TOOL_REGISTRY } from "../src/server/customFunctions";
+import { SSI } from "../src/server/customFunctions";
 
 // ── Helpers ────────────────────────────────────────────────────
 
@@ -107,13 +107,13 @@ describe("SSI", () => {
       expect(result).toMatch(/\[SSI Error:.*nonExistentTool/);
     });
 
-    it("includes a known tool declaration in the API payload", () => {
+    it("includes google_search in the API payload when specified", () => {
       mockOkResponse("ok");
-      TOOL_REGISTRY["testTool"] = { name: "testTool", description: "A test tool" };
-      SSI("prompt", undefined, "testTool");
-      delete TOOL_REGISTRY["testTool"];
+      SSI("prompt", undefined, "google_search");
       const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
-      expect(payload.tools[0].function_declarations[0].name).toBe("testTool");
+      // google_search is a grounding tool — appears as { google_search: {} }
+      expect(payload.tools).toBeDefined();
+      expect(payload.tools[0]).toHaveProperty("google_search");
     });
   });
 

--- a/__tests__/inference.test.ts
+++ b/__tests__/inference.test.ts
@@ -118,4 +118,19 @@ describe("runInference", () => {
       "Error: File not found",
     );
   });
+
+  it("passes tools to the payload when provided", () => {
+    mockOkResponse("ok");
+    runInference("prompt", undefined, undefined, ["google_search"]);
+    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    expect(payload.tools).toBeDefined();
+    expect(payload.tools[0]).toHaveProperty("google_search");
+  });
+
+  it("omits tools from the payload when not provided", () => {
+    mockOkResponse("ok");
+    runInference("prompt");
+    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    expect(payload.tools).toBeUndefined();
+  });
 });

--- a/__tests__/inference.test.ts
+++ b/__tests__/inference.test.ts
@@ -87,7 +87,6 @@ describe("runInference", () => {
     mockOkResponse("ok");
     runInference("prompt");
     const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
-    expect(payload.tools).toBeUndefined();
     expect(payload.contents[0].parts).toHaveLength(1);
   });
 

--- a/__tests__/panels/configure-ai-run.test.ts
+++ b/__tests__/panels/configure-ai-run.test.ts
@@ -186,8 +186,11 @@ describe("ConfigureAIRunPanel — tools TagList", () => {
     // Tools must be present immediately — no await
     const tags = container.querySelectorAll("#tools-list .tag");
     expect(tags.length).toBeGreaterThan(0);
-    expect(tags[0].getAttribute("data-value")).toBe("google_search");
-    expect(tags[0].textContent).toBe("Google Search");
+    const googleSearchTag = container.querySelector<HTMLElement>(
+      '#tools-list .tag[data-value="google_search"]',
+    );
+    expect(googleSearchTag).not.toBeNull();
+    expect(googleSearchTag!.textContent).toBe("Google Search");
   });
 
   it("includes selected tool IDs in runBatchAI call", async () => {
@@ -215,6 +218,7 @@ describe("ConfigureAIRunPanel — unmount", () => {
     const state = panel.unmount();
     expect(state).not.toBeUndefined();
     expect((state as { userPromptCols: string[] }).userPromptCols).toContain("col_a");
+    expect((state as { tools: string[] }).tools).toEqual([]); // no tools selected
   });
 
   it("unmount() before headers load returns undefined", () => {

--- a/__tests__/panels/configure-ai-run.test.ts
+++ b/__tests__/panels/configure-ai-run.test.ts
@@ -172,6 +172,39 @@ describe("ConfigureAIRunPanel — back", () => {
   });
 });
 
+describe("ConfigureAIRunPanel — tools TagList", () => {
+  it("renders a tools field group in the template", async () => {
+    const { container } = await mountAndLoad();
+    expect(container.querySelector("#tools-list")).not.toBeNull();
+  });
+
+  it("populates tools from TOOL_CATALOG synchronously (before headers load)", () => {
+    (services.getSheetHeaders as jest.Mock).mockReturnValue(new Promise(() => {})); // never resolves
+    const container = makeContainer();
+    const panel = new ConfigureAIRunPanel();
+    panel.mount(container, mockNav);
+    // Tools must be present immediately — no await
+    const tags = container.querySelectorAll("#tools-list .tag");
+    expect(tags.length).toBeGreaterThan(0);
+    expect(tags[0].getAttribute("data-value")).toBe("google_search");
+    expect(tags[0].textContent).toBe("Google Search");
+  });
+
+  it("includes selected tool IDs in runBatchAI call", async () => {
+    (services.runBatchAI as jest.Mock).mockResolvedValue(undefined);
+    const { container } = await mountAndLoad({
+      userPromptCols: ["col_a"],
+      outputCol: "ai_inference",
+    });
+    container.querySelector<HTMLButtonElement>('[data-value="google_search"]')!.click();
+    container.querySelector<HTMLButtonElement>("#run-btn")!.click();
+    await Promise.resolve();
+    expect(services.runBatchAI).toHaveBeenCalledWith(
+      expect.objectContaining({ tools: ["google_search"] }),
+    );
+  });
+});
+
 describe("ConfigureAIRunPanel — unmount", () => {
   it("unmount() returns current form state as SavedState", async () => {
     const { container, panel } = await mountAndLoad();

--- a/__tests__/panels/recipe.test.ts
+++ b/__tests__/panels/recipe.test.ts
@@ -7,7 +7,8 @@ jest.mock("../../src/client/services", () => ({
 
 import { RecipePanel } from "../../src/client/panels/recipe";
 import * as services from "../../src/client/services";
-import type { RecipeParams, PrepRecipeResult } from "../../src/shared/types";
+import type { PrepRecipeResult } from "../../src/shared/types";
+import type { RecipeParams } from "../../src/client/types";
 import type { NavigationContext, RecipeDefinition } from "../../src/client/types";
 
 const mockPrepRecipe = services.prepRecipe as jest.Mock;

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -18,7 +18,7 @@ import {
   findOrCreateColumn,
   writeColumn,
 } from "../src/server/utils";
-import type { DriveFileInfo } from "../src/shared/types";
+import type { DriveFileInfo } from "../src/server/types";
 
 describe("extractId", () => {
   it("extracts ID from a standard Drive file URL", () => {

--- a/docs/plans/2026-03-04-gemini-tools-design.md
+++ b/docs/plans/2026-03-04-gemini-tools-design.md
@@ -1,0 +1,372 @@
+# Gemini Tools — Design
+
+**Date:** 2026-03-04
+**Scope:** Google Search grounding tool (initial), with architecture that accommodates future grounding and function-calling tools.
+
+---
+
+## Background
+
+The Gemini REST API supports two categories of tools:
+
+- **Grounding tools** (`google_search`, `url_context`, `code_execution`) — declared in the request; Google's servers execute them automatically. No multi-turn loop required.
+- **Function-calling tools** — declared in the request as schemas; your code executes them and feeds results back in a second request. Requires a multi-turn loop.
+
+Both categories land in the same `tools` array in the Gemini payload but with different entry shapes:
+
+```json
+{ "tools": [
+    { "google_search": {} },
+    { "function_declarations": [{ "name": "...", "description": "..." }] }
+]}
+```
+
+This feature introduces Google Search as the first grounding tool, lays the type and registry infrastructure for both tool categories, and exposes tool selection in the `ConfigureAIRunPanel` sidebar UI.
+
+The multi-turn function-calling loop is **out of scope** — the architecture accommodates it without requiring a rewrite, but does not implement it.
+
+---
+
+## 1. Type Reorganization
+
+### Motivation
+
+`shared/types.ts` has accumulated types that never cross the client↔server boundary. This feature is an opportunity to enforce a clean separation.
+
+**Rule:** `shared/types.ts` contains only types that cross `google.script.run` calls.
+
+### `shared/types.ts` — after
+
+```ts
+/**
+ * Shared types for the SSI Toolkit.
+ *
+ * IMPORTANT: This file is the client↔server RPC boundary.
+ * Only types that cross google.script.run calls belong here.
+ * - Server-only types (Gemini API shapes): src/server/types.ts
+ * - Client-only types (UI, panels, recipes): src/client/types.ts
+ */
+
+/**
+ * All tool IDs recognized by the toolkit.
+ * Extend this union when adding a new tool — the compiler will then
+ * require a matching entry in TOOL_REGISTRY (server/tools.ts)
+ * and TOOL_CATALOG (client/tools.ts).
+ */
+export type ToolId = "google_search";
+
+export interface RunConfig {
+  userPromptCols: string[];
+  driveFileCols?: string[];
+  systemPromptCol?: string;
+  outputCol: string;
+  rowRange?: { start: number; end: number };
+  /** Tool IDs to enable for every row in this run. */
+  tools?: ToolId[];
+}
+
+export interface PrepRecipeParams {
+  driveFolder?: { url: string; colTitle: string };
+  systemPrompt?: { colTitle: string; value: string };
+  userPrompts?: Array<{ colTitle: string; value: string }>;
+  outputCol?: { colTitle: string };
+  /** Tool IDs to pass through to PrepRecipeResult for preppedRunConfig assembly. */
+  tools?: ToolId[];
+}
+
+export interface PrepRecipeResult {
+  rowRange: { start: number; end: number };
+  colNames: {
+    driveLink?: string;
+    systemPrompt?: string;
+    userPrompts?: string[];
+    outputCol?: string;
+  };
+  /** Echoed from PrepRecipeParams — no server processing, preserves single-source-of-truth invariant. */
+  tools?: ToolId[];
+}
+```
+
+### Moves
+
+| Type | From | To |
+|---|---|---|
+| `AppConfig` | `shared/types.ts` | `server/types.ts` |
+| `GeminiRequest` | `shared/types.ts` | `server/types.ts` |
+| `GeminiInlineData` | `shared/types.ts` | `server/types.ts` |
+| `GeminiFunctionDeclaration` | `shared/types.ts` | `server/types.ts` |
+| `GeminiGenerationConfig` | `shared/types.ts` | `server/types.ts` |
+| `DriveFileInfo` | `shared/types.ts` | deleted (unused) |
+| `RecipeParams` | `shared/types.ts` | `client/types.ts` |
+| `RecipeFieldConfig` | `shared/types.ts` | `client/types.ts` |
+
+---
+
+## 2. Tool Registries
+
+Two registries represent the same tool set from different perspectives — display metadata on the client, payload construction data on the server. `ToolId` is the shared key that links them.
+
+### Client — `client/tools.ts` (new file)
+
+```ts
+import type { ToolId } from "../shared/types";
+
+/**
+ * Display metadata for a tool shown in the sidebar TagList.
+ * No payload or kind information — those are server concerns.
+ */
+export interface ToolCatalogEntry {
+  id: ToolId;
+  name: string;
+  description: string;
+}
+
+/**
+ * All tools available for selection in the sidebar.
+ * Hardcoded at build time — the tool list is static compiled code,
+ * not user data, so no RPC is needed to populate it.
+ *
+ * When adding a new tool: add a ToolId to shared/types.ts, add an
+ * entry here, and add a matching entry to TOOL_REGISTRY in server/tools.ts.
+ */
+export const TOOL_CATALOG: ToolCatalogEntry[] = [
+  {
+    id: "google_search",
+    name: "Google Search",
+    description: "Ground responses in live web search results",
+  },
+];
+```
+
+### Server — `server/tools.ts` (replaces current TOOL_REGISTRY)
+
+```ts
+import type { ToolId } from "../shared/types";
+import type { GeminiFunctionDeclaration } from "./types";
+
+/**
+ * Internal discriminated union representing a tool entry in the registry.
+ * Not exported — only buildGeminiPayload needs to act on the kind distinction.
+ *
+ * The Gemini REST API places grounding tools ({ google_search: {} }) and
+ * function-calling tools ({ function_declarations: [...] }) as separate
+ * entries in the same tools array. buildGeminiPayload splits on `kind`
+ * to assemble each correctly.
+ */
+type GeminiTool =
+  | { kind: "grounding"; id: ToolId }
+  | { kind: "function"; declaration: GeminiFunctionDeclaration };
+
+/**
+ * Server-side tool registry. Maps every ToolId to its payload construction data.
+ * Record<ToolId, GeminiTool> enforces at compile time that every ToolId has
+ * a matching server implementation — adding a new ToolId without a registry
+ * entry is a type error.
+ */
+export const TOOL_REGISTRY: Record<ToolId, GeminiTool> = {
+  google_search: { kind: "grounding", id: "google_search" },
+};
+```
+
+---
+
+## 3. GeminiRequest and buildGeminiPayload
+
+### `GeminiRequest` (server/types.ts)
+
+`tools` changes from `GeminiFunctionDeclaration[]` to `ToolId[]`. Resolution happens inside `buildGeminiPayload` — `GeminiRequest` stays close to the caller's vocabulary (IDs) rather than the payload's vocabulary (shaped objects).
+
+```ts
+export interface GeminiRequest {
+  apiKey: string;
+  modelName?: string;
+  systemPrompt?: string;
+  userTexts: string[];
+  inlineData?: GeminiInlineData[];
+  /** Tool IDs to enable. Resolved against TOOL_REGISTRY in buildGeminiPayload. */
+  tools?: ToolId[];
+  generationConfig?: GeminiGenerationConfig;
+}
+```
+
+### `buildGeminiPayload` (api.ts)
+
+Imports `TOOL_REGISTRY`, resolves IDs, splits by kind, assembles the correct Gemini payload structure:
+
+```ts
+if (req.tools?.length) {
+  const entries = req.tools.map((id) => TOOL_REGISTRY[id]);
+
+  const grounding = entries.filter((t) => t.kind === "grounding");
+  const functions = entries
+    .filter((t) => t.kind === "function")
+    .map((t) => t.declaration);
+
+  const toolsPayload = [
+    ...grounding.map((t) => ({ [t.id]: {} })),
+    ...(functions.length ? [{ function_declarations: functions }] : []),
+  ];
+
+  payload.tools = toolsPayload;
+}
+```
+
+Note: `buildGeminiPayload` was previously a pure function with no external imports. Importing `TOOL_REGISTRY` breaks that purity, but keeps `GeminiRequest` cleaner and avoids a resolution step in every caller. The tradeoff is accepted.
+
+### SSI custom function (`customFunctions.ts`)
+
+Currently pulls `GeminiFunctionDeclaration` objects directly from the old `TOOL_REGISTRY`. Updated to filter for `kind: "function"` entries and pass IDs to `invokeGemini`:
+
+```ts
+const resolvedToolIds = flattenArg(toolNames).map((name) => {
+  const entry = TOOL_REGISTRY[name as ToolId];
+  if (!entry || entry.kind !== "function")
+    throw new Error(`unknown function tool '${name}'`);
+  return name as ToolId;
+});
+
+return invokeGemini({
+  userTexts: flattenArg(userTexts),
+  systemPrompt: systemPrompt || undefined,
+  tools: resolvedToolIds.length ? resolvedToolIds : undefined,
+});
+```
+
+---
+
+## 4. Inference Chain
+
+`tools?: ToolId[]` threads through each layer with minimal changes:
+
+```
+RunConfig.tools?: ToolId[]
+  └─ runBatchAI         passes config.tools to runInference
+       └─ runInference  gains tools?: ToolId[] parameter, passes to invokeGemini
+            └─ invokeGemini / callGeminiAPI  GeminiRequest.tools already ToolId[]
+                 └─ buildGeminiPayload  resolves IDs → assembles payload
+```
+
+`runInference` signature change:
+```ts
+export function runInference(
+  userPrompts: unknown[],
+  driveLinks: unknown[] | undefined,
+  systemPrompt: unknown,
+  tools?: ToolId[],   // new
+): string | null
+```
+
+No other signature changes needed in the inference chain.
+
+---
+
+## 5. UI — ConfigureAIRunPanel
+
+### TagList extension
+
+`TagList` currently accepts `string[]` and returns `string[]` — display value equals stored value. Tools need to display `name` ("Google Search") but return `id` ("google_search").
+
+`TagList` already separates display (`textContent`) from stored value (`data-value`). A backward-compatible extension accepts either format:
+
+```ts
+constructor(
+  container: HTMLElement,
+  items: Array<string | { label: string; value: string }>,
+  selected: string[] = [],
+)
+```
+
+Internally normalized to `{ label, value }` pairs. `getValue()` already reads from `data-value` — no change needed. All existing callers (plain `string[]` headers) continue to work unchanged.
+
+**Rule of thumb:** pass `string[]` when label equals value (column headers); pass `{ label, value }[]` when they diverge (tools).
+
+### ConfigureAIRunPanel changes
+
+New field group in template, after output column, before row range:
+
+```html
+<div class="field-group">
+  <span class="field-label">Tools <span class="optional">(optional)</span></span>
+  <div id="tools-list" class="tag-list"></div>
+</div>
+```
+
+Tools populated synchronously on mount (no async, unlike headers):
+
+```ts
+this.toolsList = new TagList(
+  container.querySelector("#tools-list")!,
+  TOOL_CATALOG.map((t) => ({ label: t.name, value: t.id })),
+  preset.tools ?? [],
+);
+```
+
+`assembleRunConfig` gains:
+```ts
+const tools = this.toolsList?.getValue() as ToolId[];
+// ...
+tools: tools?.length ? tools : undefined,
+```
+
+`SavedState` picks up `tools` naturally via `Required<Omit<RunConfig, "rowRange">>` — defaults to `[]` in `unmount()`.
+
+---
+
+## 6. Recipe Compatibility
+
+Tools flow through the recipe prep cycle to preserve the **single-source-of-truth invariant**: `preppedRunConfig` must be assembled entirely from `PrepRecipeResult`, never from local form state.
+
+Tools require no server-side processing during prep (they aren't written to the sheet). `prepRecipe` echoes them from params to result unchanged:
+
+```ts
+return {
+  rowRange: { ... },
+  colNames: { ... },
+  tools: params.tools,  // pass-through
+};
+```
+
+Recipe panel assembles `preppedRunConfig`:
+```ts
+const preppedRunConfig: Partial<RunConfig> = {
+  userPromptCols: result.colNames.userPrompts ?? [],
+  // ...other cols from result...
+  rowRange: result.rowRange,
+  tools: result.tools,  // from result, not form state
+};
+```
+
+`RecipeParams` type scaffolding for future tool UI in recipes is deferred — the `tools` fields on `PrepRecipeParams` and `PrepRecipeResult` are sufficient to wire it up when needed.
+
+---
+
+## 7. Add-a-Tool Checklist
+
+When adding a new tool in the future:
+
+1. Add its ID to `ToolId` in `src/shared/types.ts`
+2. Add a `TOOL_REGISTRY` entry in `src/server/tools.ts` — compile error if skipped (`Record<ToolId, GeminiTool>` enforces completeness)
+3. Add a `TOOL_CATALOG` entry in `src/client/tools.ts`
+
+For function-calling tools, also:
+
+4. Implement the function execution logic
+5. Extend `invokeGemini` / `callGeminiAPI` with the multi-turn loop
+
+---
+
+## Files Touched
+
+| File | Change |
+|---|---|
+| `src/shared/types.ts` | Add `ToolId`; add `tools` to `RunConfig`, `PrepRecipeParams`, `PrepRecipeResult`; remove moved types |
+| `src/server/types.ts` | New file — absorbs `AppConfig`, `GeminiRequest` (updated), `GeminiInlineData`, `GeminiFunctionDeclaration`, `GeminiGenerationConfig` |
+| `src/server/tools.ts` | Replace `TOOL_REGISTRY` with unified `Record<ToolId, GeminiTool>` |
+| `src/server/api.ts` | Update `buildGeminiPayload` to import `TOOL_REGISTRY` and resolve tool IDs |
+| `src/server/customFunctions.ts` | Update tool resolution to filter `kind: "function"` |
+| `src/server/inference.ts` | Add `tools?: ToolId[]` parameter |
+| `src/server/index.ts` | Pass `config.tools` to `runInference`; echo tools in `prepRecipe` |
+| `src/client/types.ts` | Add `RecipeParams`, `RecipeFieldConfig` (moved from shared) |
+| `src/client/tools.ts` | New file — `ToolCatalogEntry`, `TOOL_CATALOG` |
+| `src/client/components/tag-list.ts` | Extend to accept `Array<string \| { label, value }>` |
+| `src/client/panels/configure-ai-run.ts` | Add tools `TagList`, update `assembleRunConfig` and `SavedState` |

--- a/docs/plans/2026-03-04-gemini-tools.md
+++ b/docs/plans/2026-03-04-gemini-tools.md
@@ -1,0 +1,1084 @@
+# Gemini Tools Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Introduce Google Search as the first Gemini grounding tool, with type infrastructure that accommodates future grounding and function-calling tools.
+
+**Architecture:** `ToolId` (shared string union) is the boundary between client and server. The client renders `TOOL_CATALOG` (display metadata) in a sidebar TagList. The server resolves tool IDs via `TOOL_REGISTRY` (a `Record<ToolId, GeminiTool>` discriminated union) inside `buildGeminiPayload`, which assembles the correct Gemini REST API payload shapes for grounding vs. function-calling entries.
+
+**Design doc:** `docs/plans/2026-03-04-gemini-tools-design.md`
+
+**Tech Stack:** TypeScript, Jest/ts-jest, Google Apps Script (GAS), Rollup, jsdom (client tests)
+
+**Worktree:** `.worktrees/feature/gemini-tools` on branch `feature/gemini-tools`
+
+---
+
+## Task 1: Create `src/server/types.ts`
+
+Move all server-only Gemini/config types out of `shared/types.ts`. These types never cross the client↔server boundary and don't belong in shared.
+
+**Files:**
+- Create: `src/server/types.ts`
+
+**Step 1: Create the file with moved types**
+
+`GeminiRequest.tools` changes from `GeminiFunctionDeclaration[]` to `ToolId[]` here (forward-compatible — `ToolId` will be added in Task 2, so use a temporary `string[]` placeholder for now if needed, or do Tasks 1 and 2 together).
+
+```ts
+/**
+ * Server-only types. Never imported by client code.
+ *
+ * GeminiTool is an internal discriminated union used by buildGeminiPayload
+ * to split tool IDs into the correct Gemini REST API payload shapes.
+ * Grounding tools produce { google_search: {} } entries; function-calling
+ * tools produce { function_declarations: [...] } entries — both in the same
+ * tools array, but with different structures.
+ */
+
+import type { ToolId } from "../shared/types";
+
+export interface AppConfig {
+  API_KEY_PROPERTY: string;
+  MODEL_NAME: string;
+  MAX_FILE_SIZE_BYTES: number;
+}
+
+export interface GeminiInlineData {
+  mime_type: string;
+  data: string; // base64-encoded bytes
+}
+
+export interface GeminiFunctionDeclaration {
+  name: string;
+  description: string;
+  parameters?: Record<string, unknown>; // JSON Schema object
+}
+
+export interface GeminiGenerationConfig {
+  temperature?: number;
+  maxOutputTokens?: number;
+  responseMimeType?: string;
+}
+
+/**
+ * Internal discriminated union. Not exported — only buildGeminiPayload acts on kind.
+ * Lives here (rather than in api.ts) so TOOL_REGISTRY can reference it.
+ */
+export type GeminiTool =
+  | { kind: "grounding"; id: ToolId }
+  | { kind: "function"; declaration: GeminiFunctionDeclaration };
+
+export interface GeminiRequest {
+  apiKey: string;
+  modelName?: string; // defaults to CONFIG.MODEL_NAME if omitted
+  systemPrompt?: string;
+  userTexts: string[]; // assembled into parts: [{text}, {text}, ...]
+  inlineData?: GeminiInlineData[]; // each item appended as an inline_data part
+  /** Tool IDs to enable. Resolved against TOOL_REGISTRY in buildGeminiPayload. */
+  tools?: ToolId[];
+  generationConfig?: GeminiGenerationConfig;
+}
+```
+
+**Step 2: Run typecheck to verify the new file is valid**
+
+```bash
+npm run typecheck
+```
+
+Expected: errors about missing `ToolId` import (not added yet). That's fine — we'll fix in Task 2. OR add a temporary `type ToolId = string` stub at the top of this file and remove it in Task 2.
+
+**Step 3: Commit**
+
+```bash
+git add src/server/types.ts
+git commit -m "feat: add server/types.ts with Gemini API types and GeminiTool union"
+```
+
+---
+
+## Task 2: Update `src/shared/types.ts`
+
+Add `ToolId`, add `tools?: ToolId[]` to `RunConfig`/`PrepRecipeParams`/`PrepRecipeResult`, and remove types that now live in `server/types.ts` or `client/types.ts`.
+
+**Files:**
+- Modify: `src/shared/types.ts`
+
+**Step 1: Rewrite shared/types.ts**
+
+```ts
+/**
+ * Shared types for the SSI Toolkit.
+ *
+ * IMPORTANT: This file is the client↔server RPC boundary.
+ * Only types that cross google.script.run calls belong here.
+ * - Server-only types (Gemini API shapes, AppConfig): src/server/types.ts
+ * - Client-only types (UI, panels, recipes): src/client/types.ts
+ */
+
+// ── Tool vocabulary ─────────────────────────────────────────────
+
+/**
+ * All tool IDs recognized by the toolkit.
+ * Extend this union when adding a new tool — the compiler will then
+ * require a matching entry in TOOL_REGISTRY (server/tools.ts)
+ * and TOOL_CATALOG (client/tools.ts).
+ */
+export type ToolId = "google_search";
+
+// ── Configuration ───────────────────────────────────────────────
+
+export interface RunConfig {
+  userPromptCols: string[];
+  driveFileCols?: string[];
+  systemPromptCol?: string;
+  outputCol: string;
+  rowRange?: { start: number; end: number };
+  /** Tool IDs to enable for every row in this run. */
+  tools?: ToolId[];
+}
+
+// ── Recipes ─────────────────────────────────────────────────────
+
+export interface PrepRecipeParams {
+  driveFolder?: { url: string; colTitle: string };
+  systemPrompt?: { colTitle: string; value: string };
+  userPrompts?: Array<{ colTitle: string; value: string }>;
+  outputCol?: { colTitle: string };
+  /**
+   * Tool IDs to pass through to PrepRecipeResult.
+   * The server does not process these during prep — they are echoed back
+   * to preserve the single-source-of-truth invariant for preppedRunConfig.
+   */
+  tools?: ToolId[];
+}
+
+export interface PrepRecipeResult {
+  rowRange: { start: number; end: number };
+  colNames: {
+    driveLink?: string;
+    systemPrompt?: string;
+    userPrompts?: string[];
+    outputCol?: string;
+  };
+  /** Echoed from PrepRecipeParams — no server-side processing. */
+  tools?: ToolId[];
+}
+```
+
+**Step 2: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: many errors about missing imports (files that imported the removed types from shared). That's expected — we'll fix them in Task 3 and Task 4.
+
+**Step 3: Commit**
+
+```bash
+git add src/shared/types.ts
+git commit -m "feat: add ToolId to shared types, add tools field to RunConfig/PrepRecipeParams/PrepRecipeResult"
+```
+
+---
+
+## Task 3: Update `src/client/types.ts`
+
+Move `RecipeParams` and `RecipeFieldConfig` here from `shared/types.ts`.
+
+**Files:**
+- Modify: `src/client/types.ts`
+
+**Step 1: Add RecipeParams and RecipeFieldConfig**
+
+Open `src/client/types.ts` and add at the top (before the existing PanelId type):
+
+```ts
+// ── Recipe UI types ─────────────────────────────────────────────
+// These are client-only — they define sidebar form structure, not RPC payloads.
+
+export interface RecipeFieldConfig {
+  value: string;
+  locked?: boolean; // defaults to true
+  placeholder?: string;
+}
+
+export interface RecipeParams {
+  driveFolder?: {
+    colTitle: string;
+    helperText?: string;
+  };
+  systemPrompt?: {
+    colTitle: RecipeFieldConfig;
+    prompt: RecipeFieldConfig;
+  };
+  userPrompts?: Array<{
+    colTitle: RecipeFieldConfig;
+    prompt: RecipeFieldConfig;
+  }>;
+  outputCol?: {
+    colTitle: RecipeFieldConfig;
+  };
+}
+```
+
+**Step 2: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/client/types.ts
+git commit -m "refactor: move RecipeParams and RecipeFieldConfig to client/types.ts"
+```
+
+---
+
+## Task 4: Fix all broken imports across the codebase
+
+After moving types, all files that imported from `shared/types` need their import paths corrected.
+
+**Files to update:**
+
+- `src/server/config.ts` — imports `AppConfig` from `../shared/types` → change to `./types`
+- `src/server/api.ts` — imports `GeminiInlineData`, `GeminiRequest` from `../shared/types` → change to `./types`
+- `src/server/tools.ts` — imports `GeminiFunctionDeclaration` from `../shared/types` → change to `./types`
+- `src/server/inference.ts` — imports `GeminiInlineData` from `../shared/types` → change to `./types`
+- `src/server/index.ts` — imports `RunConfig`, `PrepRecipeParams`, `PrepRecipeResult` from `../shared/types` → keep (still in shared). Remove any import of moved types.
+- `src/client/panels/recipe.ts` — imports `RecipeParams` from `../../shared/types` → change to `../types`
+- `src/client/recipes.ts` — imports `RecipeParams` from `../shared/types` → check and update
+- `__tests__/api.test.ts` — imports `GeminiRequest` from `../src/shared/types` → change to `../src/server/types`
+
+**Step 1: Update each file's imports one at a time**
+
+For each file, open it, find the import from `shared/types`, and reroute to the correct location. Use `npm run typecheck` after each file to catch mistakes immediately.
+
+**Step 2: Run typecheck until clean**
+
+```bash
+npm run typecheck
+```
+
+Expected: 0 errors.
+
+**Step 3: Run tests**
+
+```bash
+npm test
+```
+
+Expected: all 196 tests pass (no logic changed).
+
+**Step 4: Commit**
+
+```bash
+git add -p   # stage import changes file by file
+git commit -m "refactor: fix imports after type reorganization"
+```
+
+---
+
+## Task 5: Update `src/server/tools.ts`
+
+Replace the old `Record<string, GeminiFunctionDeclaration>` registry with the new unified `Record<ToolId, GeminiTool>` registry.
+
+**Files:**
+- Modify: `src/server/tools.ts`
+
+**Step 1: Write a failing test first**
+
+The existing test in `__tests__/customFunctions.test.ts` at line 110-117 mutates `TOOL_REGISTRY` directly:
+
+```ts
+TOOL_REGISTRY["testTool"] = { name: "testTool", description: "A test tool" };
+```
+
+This will break because `TOOL_REGISTRY` no longer accepts arbitrary string keys. First, update that test to verify grounding tool support instead. Open `__tests__/customFunctions.test.ts` and replace the `toolNames` describe block:
+
+```ts
+describe("toolNames", () => {
+  it("returns an error string for an unknown tool name", () => {
+    const result = SSI("prompt", undefined, "nonExistentTool");
+    expect(result).toMatch(/\[SSI Error:.*nonExistentTool/);
+  });
+
+  it("includes google_search in the API payload when specified", () => {
+    mockOkResponse("ok");
+    SSI("prompt", undefined, "google_search");
+    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    // google_search is a grounding tool — appears as { google_search: {} }
+    expect(payload.tools).toBeDefined();
+    expect(payload.tools[0]).toHaveProperty("google_search");
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+npx jest __tests__/customFunctions.test.ts -t "toolNames"
+```
+
+Expected: FAIL — `TOOL_REGISTRY` still has the old shape.
+
+**Step 3: Rewrite server/tools.ts**
+
+```ts
+/**
+ * server/tools.ts — Unified tool registry.
+ *
+ * Maps every ToolId to its Gemini payload construction data.
+ * Record<ToolId, GeminiTool> enforces at compile time that every ToolId
+ * has a matching server implementation — adding a new ToolId without a
+ * registry entry is a type error.
+ *
+ * To add a new tool:
+ * 1. Add its ID to ToolId in src/shared/types.ts
+ * 2. Add an entry here
+ * 3. Add a display entry to TOOL_CATALOG in src/client/tools.ts
+ */
+
+import type { ToolId } from "../shared/types";
+import type { GeminiTool } from "./types";
+
+export const TOOL_REGISTRY: Record<ToolId, GeminiTool> = {
+  google_search: { kind: "grounding", id: "google_search" },
+};
+```
+
+**Step 4: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: errors in `customFunctions.ts` and `api.ts` which reference the old registry shape — fix those in Tasks 6 and 7.
+
+**Step 5: Run the toolNames tests**
+
+```bash
+npx jest __tests__/customFunctions.test.ts -t "toolNames"
+```
+
+Hold off — the `SSI` function and `buildGeminiPayload` need updating too (Tasks 7 and 8). For now, commit the registry change.
+
+**Step 6: Commit**
+
+```bash
+git add src/server/tools.ts __tests__/customFunctions.test.ts
+git commit -m "feat: replace TOOL_REGISTRY with unified Record<ToolId, GeminiTool>"
+```
+
+---
+
+## Task 6: Create `src/client/tools.ts`
+
+New file — client-side tool catalog for populating the sidebar TagList.
+
+**Files:**
+- Create: `src/client/tools.ts`
+
+**Step 1: Write a failing test**
+
+Create `__tests__/client/tools.test.ts`:
+
+```ts
+/**
+ * @jest-environment jsdom
+ */
+import { TOOL_CATALOG } from "../../src/client/tools";
+import type { ToolId } from "../../src/shared/types";
+
+describe("TOOL_CATALOG", () => {
+  it("contains an entry for every ToolId", () => {
+    // If a ToolId is added to shared/types.ts but not TOOL_CATALOG, this test fails.
+    const knownIds: ToolId[] = ["google_search"];
+    const catalogIds = TOOL_CATALOG.map((t) => t.id);
+    expect(catalogIds).toEqual(expect.arrayContaining(knownIds));
+    expect(TOOL_CATALOG).toHaveLength(knownIds.length);
+  });
+
+  it("each entry has id, name, and description", () => {
+    for (const entry of TOOL_CATALOG) {
+      expect(typeof entry.id).toBe("string");
+      expect(typeof entry.name).toBe("string");
+      expect(typeof entry.description).toBe("string");
+      expect(entry.name.length).toBeGreaterThan(0);
+      expect(entry.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("google_search entry has expected display values", () => {
+    const entry = TOOL_CATALOG.find((t) => t.id === "google_search");
+    expect(entry).toBeDefined();
+    expect(entry!.name).toBe("Google Search");
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+```bash
+npx jest __tests__/client/tools.test.ts
+```
+
+Expected: FAIL — module not found.
+
+**Step 3: Create the file**
+
+```ts
+/**
+ * client/tools.ts — Client-side tool catalog.
+ *
+ * Provides display metadata for tools shown in the sidebar TagList.
+ * Hardcoded at build time — the tool list is static compiled code,
+ * not user data, so no RPC is needed to populate it.
+ *
+ * When adding a new tool:
+ * 1. Add its ID to ToolId in src/shared/types.ts
+ * 2. Add a matching entry to TOOL_REGISTRY in src/server/tools.ts
+ * 3. Add a display entry here
+ */
+
+import type { ToolId } from "../shared/types";
+
+/**
+ * Display metadata for a tool shown in the sidebar TagList.
+ * Contains only what the client needs — no payload or kind information.
+ */
+export interface ToolCatalogEntry {
+  id: ToolId;
+  name: string;
+  description: string;
+}
+
+export const TOOL_CATALOG: ToolCatalogEntry[] = [
+  {
+    id: "google_search",
+    name: "Google Search",
+    description: "Ground responses in live web search results",
+  },
+];
+```
+
+**Step 4: Run tests to verify they pass**
+
+```bash
+npx jest __tests__/client/tools.test.ts
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/client/tools.ts __tests__/client/tools.test.ts
+git commit -m "feat: add client/tools.ts with TOOL_CATALOG and ToolCatalogEntry"
+```
+
+---
+
+## Task 7: Update `buildGeminiPayload` in `src/server/api.ts`
+
+Change tool handling: `tools` is now `ToolId[]`. `buildGeminiPayload` resolves IDs via `TOOL_REGISTRY`, splits by kind, and assembles the correct Gemini payload shapes.
+
+**Files:**
+- Modify: `src/server/api.ts`
+- Modify: `__tests__/api.test.ts`
+
+**Step 1: Update the existing tools test and add new ones**
+
+In `__tests__/api.test.ts`, the existing test at line 93-100 passes `GeminiFunctionDeclaration` objects directly. Replace it with tests for the new ToolId-based approach:
+
+```ts
+describe("tool resolution in buildGeminiPayload", () => {
+  it("omits tools key when tools array is absent", () => {
+    const payload = buildGeminiPayload(baseReq);
+    expect(payload.tools).toBeUndefined();
+  });
+
+  it("omits tools key when tools array is empty", () => {
+    const payload = buildGeminiPayload({ ...baseReq, tools: [] });
+    expect(payload.tools).toBeUndefined();
+  });
+
+  it("assembles a grounding tool entry for google_search", () => {
+    const payload = buildGeminiPayload({ ...baseReq, tools: ["google_search"] });
+    const tools = payload.tools as unknown[];
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toEqual({ google_search: {} });
+  });
+});
+```
+
+Also update the `baseReq` type import at line 24: change from `../src/shared/types` to `../src/server/types`.
+
+**Step 2: Run to verify the new tests fail**
+
+```bash
+npx jest __tests__/api.test.ts -t "tool resolution"
+```
+
+Expected: FAIL.
+
+**Step 3: Update `src/server/api.ts`**
+
+Update the import at the top — `GeminiInlineData` and `GeminiRequest` now come from `./types`:
+
+```ts
+import { CONFIG } from "./config";
+import { TOOL_REGISTRY } from "./tools";
+import type { GeminiInlineData, GeminiRequest } from "./types";
+```
+
+Replace the tools section of `buildGeminiPayload` (currently lines 37-39):
+
+```ts
+  if (req.tools && req.tools.length > 0) {
+    const entries = req.tools.map((id) => TOOL_REGISTRY[id]);
+
+    const groundingEntries = entries
+      .filter((t): t is Extract<typeof t, { kind: "grounding" }> => t.kind === "grounding")
+      .map((t) => ({ [t.id]: {} }));
+
+    const functionDeclarations = entries
+      .filter((t): t is Extract<typeof t, { kind: "function" }> => t.kind === "function")
+      .map((t) => t.declaration);
+
+    const toolsPayload = [
+      ...groundingEntries,
+      ...(functionDeclarations.length ? [{ function_declarations: functionDeclarations }] : []),
+    ];
+
+    payload.tools = toolsPayload;
+  }
+```
+
+**Step 4: Run all tests**
+
+```bash
+npm test
+```
+
+Expected: all tests pass. (The `customFunctions.ts` tests may still fail until Task 8.)
+
+**Step 5: Commit**
+
+```bash
+git add src/server/api.ts __tests__/api.test.ts
+git commit -m "feat: update buildGeminiPayload to resolve ToolId[] via TOOL_REGISTRY"
+```
+
+---
+
+## Task 8: Update `src/server/customFunctions.ts`
+
+`SSI` previously resolved `GeminiFunctionDeclaration` objects from `TOOL_REGISTRY`. Now it validates that the tool ID exists and passes IDs straight through to `invokeGemini`. All tool types (grounding + function) are allowed.
+
+**Files:**
+- Modify: `src/server/customFunctions.ts`
+
+**Step 1: Run the existing toolNames tests to confirm current failure**
+
+```bash
+npx jest __tests__/customFunctions.test.ts -t "toolNames"
+```
+
+Expected: FAIL (registry shape mismatch from Task 5).
+
+**Step 2: Update `src/server/customFunctions.ts`**
+
+Replace the tool resolution block in the `SSI` function body. The new logic validates existence and passes IDs through:
+
+```ts
+import { invokeGemini } from "./api";
+import { flattenArg } from "./utils";
+import { TOOL_REGISTRY } from "./tools";
+import type { ToolId } from "../shared/types";
+
+export { TOOL_REGISTRY };
+
+export function SSI(userTexts: unknown, systemPrompt?: string, toolNames?: unknown): string {
+  try {
+    const resolvedToolIds = flattenArg(toolNames).map((name) => {
+      if (!TOOL_REGISTRY[name as ToolId]) throw new Error(`unknown tool '${name}'`);
+      return name as ToolId;
+    });
+
+    return invokeGemini({
+      systemPrompt: systemPrompt || undefined,
+      userTexts: flattenArg(userTexts),
+      tools: resolvedToolIds.length ? resolvedToolIds : undefined,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return `[SSI Error: ${msg}]`;
+  }
+}
+```
+
+**Step 3: Run the customFunctions tests**
+
+```bash
+npx jest __tests__/customFunctions.test.ts
+```
+
+Expected: all pass.
+
+**Step 4: Run all tests**
+
+```bash
+npm test
+```
+
+Expected: all pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/server/customFunctions.ts
+git commit -m "feat: update SSI to validate ToolId and support all tool types"
+```
+
+---
+
+## Task 9: Update `src/server/inference.ts`
+
+Add `tools?: ToolId[]` parameter and pass it through to `invokeGemini`.
+
+**Files:**
+- Modify: `src/server/inference.ts`
+- Modify: `__tests__/inference.test.ts`
+
+**Step 1: Write the failing test**
+
+Add to `__tests__/inference.test.ts` inside the `describe("runInference")` block:
+
+```ts
+it("passes tools to the payload when provided", () => {
+  mockOkResponse("ok");
+  runInference("prompt", undefined, undefined, ["google_search"]);
+  const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+  expect(payload.tools).toBeDefined();
+  expect(payload.tools[0]).toHaveProperty("google_search");
+});
+
+it("omits tools from the payload when not provided", () => {
+  mockOkResponse("ok");
+  runInference("prompt");
+  const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+  expect(payload.tools).toBeUndefined();
+});
+```
+
+**Step 2: Run to verify they fail**
+
+```bash
+npx jest __tests__/inference.test.ts -t "tools"
+```
+
+Expected: FAIL — `runInference` only accepts 3 parameters.
+
+**Step 3: Update `src/server/inference.ts`**
+
+Add the `tools` parameter and pass it to `invokeGemini`. Also update the import to get `GeminiInlineData` from `./types`:
+
+```ts
+import { invokeGemini } from "./api";
+import { fetchAndEncodeFile } from "./drive";
+import { flattenArg, isValidDriveLink, extractId } from "./utils";
+import type { GeminiInlineData } from "./types";
+import type { ToolId } from "../shared/types";
+
+export function runInference(
+  userPrompts: unknown,
+  driveLinks?: unknown,
+  systemPrompt?: unknown,
+  tools?: ToolId[],
+): string | null {
+  const userTexts = flattenArg(userPrompts);
+  if (userTexts.length === 0) return null;
+
+  try {
+    const inlineData: GeminiInlineData[] =
+      driveLinks !== undefined
+        ? flattenArg(driveLinks)
+            .filter(isValidDriveLink)
+            .map((link) => fetchAndEncodeFile(extractId(link)))
+        : [];
+
+    return invokeGemini({
+      systemPrompt: systemPrompt !== undefined ? flattenArg(systemPrompt)[0] : undefined,
+      userTexts,
+      inlineData: inlineData.length ? inlineData : undefined,
+      tools: tools?.length ? tools : undefined,
+    });
+  } catch (e) {
+    return "Error: " + (e as Error).message;
+  }
+}
+```
+
+**Step 4: Run inference tests**
+
+```bash
+npx jest __tests__/inference.test.ts
+```
+
+Expected: all pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/server/inference.ts __tests__/inference.test.ts
+git commit -m "feat: add tools parameter to runInference"
+```
+
+---
+
+## Task 10: Update `src/server/index.ts`
+
+Pass `config.tools` to `runInference` in `runBatchAI`, and echo tools through in `prepRecipe`.
+
+**Files:**
+- Modify: `src/server/index.ts`
+
+**Step 1: Update `runBatchAI`**
+
+Find the `runInference` call in `runBatchAI` (around line 317) and add the fourth argument:
+
+```ts
+const result = runInference(userPrompts, driveLinks, systemPrompt, config.tools);
+```
+
+**Step 2: Update `prepRecipe`**
+
+Find the return statement at the bottom of `prepRecipe` and add `tools`:
+
+```ts
+return {
+  rowRange: { start: 2, end: 2 + numRows - 1 },
+  colNames,
+  tools: params.tools,
+};
+```
+
+**Step 3: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: 0 errors.
+
+**Step 4: Run all tests**
+
+```bash
+npm test
+```
+
+Expected: all pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/server/index.ts
+git commit -m "feat: thread tools through runBatchAI and prepRecipe"
+```
+
+---
+
+## Task 11: Extend `TagList` to support label/value items
+
+`TagList` currently renders string items where display text equals stored value. Tools need to display `name` ("Google Search") but store `id` ("google_search"). Extend the constructor to accept either format — existing callers are unaffected.
+
+**Files:**
+- Modify: `src/client/components/tag-list.ts`
+- Modify: `__tests__/components/tag-list.test.ts`
+
+**Step 1: Write failing tests**
+
+Add to `__tests__/components/tag-list.test.ts`:
+
+```ts
+describe("label/value items", () => {
+  it("displays label as textContent but stores value in data-value", () => {
+    const c = makeContainer();
+    new TagList(c, [{ label: "Google Search", value: "google_search" }]);
+    const tag = c.querySelector<HTMLButtonElement>(".tag")!;
+    expect(tag.textContent).toBe("Google Search");
+    expect(tag.getAttribute("data-value")).toBe("google_search");
+  });
+
+  it("getValue() returns value (not label) for label/value items", () => {
+    const c = makeContainer();
+    const list = new TagList(c, [{ label: "Google Search", value: "google_search" }]);
+    c.querySelector<HTMLButtonElement>('[data-value="google_search"]')!.click();
+    expect(list.getValue()).toEqual(["google_search"]);
+  });
+
+  it("pre-selects by value when using label/value items", () => {
+    const c = makeContainer();
+    new TagList(c, [{ label: "Google Search", value: "google_search" }], ["google_search"]);
+    const selected = c.querySelectorAll(".tag.selected");
+    expect(selected).toHaveLength(1);
+    expect(selected[0].getAttribute("data-value")).toBe("google_search");
+  });
+
+  it("mixed string and label/value items render correctly", () => {
+    const c = makeContainer();
+    const list = new TagList(
+      c,
+      ["col_a", { label: "Google Search", value: "google_search" }],
+      ["col_a", "google_search"],
+    );
+    expect(list.getValue()).toEqual(["col_a", "google_search"]);
+  });
+});
+```
+
+**Step 2: Run to verify they fail**
+
+```bash
+npx jest __tests__/components/tag-list.test.ts -t "label/value"
+```
+
+Expected: FAIL — constructor only accepts `string[]`.
+
+**Step 3: Update `src/client/components/tag-list.ts`**
+
+```ts
+type TagItem = string | { label: string; value: string };
+
+function normalize(item: TagItem): { label: string; value: string } {
+  return typeof item === "string" ? { label: item, value: item } : item;
+}
+
+export class TagList {
+  private readonly container: HTMLElement;
+
+  constructor(container: HTMLElement, items: TagItem[], selected: string[] = []) {
+    this.container = container;
+    this.render(items, selected);
+  }
+
+  private render(items: TagItem[], selected: string[]): void {
+    this.container.innerHTML = "";
+    items.forEach((item) => {
+      const { label, value } = normalize(item);
+      const btn = document.createElement("button");
+      btn.className = "tag";
+      btn.type = "button";
+      btn.textContent = label;
+      btn.setAttribute("data-value", value);
+      if (selected.includes(value)) btn.classList.add("selected");
+      btn.addEventListener("click", () => btn.classList.toggle("selected"));
+      this.container.appendChild(btn);
+    });
+  }
+
+  getValue(): string[] {
+    return Array.from(this.container.querySelectorAll<HTMLButtonElement>(".tag.selected"))
+      .map((t) => t.getAttribute("data-value") ?? "")
+      .filter(Boolean);
+  }
+}
+```
+
+**Step 4: Run all TagList tests**
+
+```bash
+npx jest __tests__/components/tag-list.test.ts
+```
+
+Expected: all pass (old tests + new tests).
+
+**Step 5: Run full test suite to confirm no regressions**
+
+```bash
+npm test
+```
+
+Expected: all pass.
+
+**Step 6: Commit**
+
+```bash
+git add src/client/components/tag-list.ts __tests__/components/tag-list.test.ts
+git commit -m "feat: extend TagList to support label/value items alongside plain strings"
+```
+
+---
+
+## Task 12: Update `ConfigureAIRunPanel` to add tools TagList
+
+Add the tools field group to the template, populate it synchronously from `TOOL_CATALOG`, update `assembleRunConfig`, and update `SavedState`.
+
+**Files:**
+- Modify: `src/client/panels/configure-ai-run.ts`
+- Modify: `__tests__/panels/configure-ai-run.test.ts`
+
+**Step 1: Read the existing configure-ai-run test**
+
+Open `__tests__/panels/configure-ai-run.test.ts` to understand the existing test setup before adding new tests.
+
+**Step 2: Add failing tests**
+
+Look for how the test sets up `document.body.innerHTML` and add:
+
+```ts
+describe("tools TagList", () => {
+  it("renders a tools field group in the template", () => {
+    // mount the panel and check the tools-list container exists
+    const container = document.createElement("div");
+    const nav = { navigate: jest.fn(), back: jest.fn(), canGoBack: jest.fn() };
+    panel.mount(container, nav as any);
+    expect(container.querySelector("#tools-list")).not.toBeNull();
+  });
+
+  it("populates tools from TOOL_CATALOG (not from headers RPC)", () => {
+    const container = document.createElement("div");
+    const nav = { navigate: jest.fn(), back: jest.fn(), canGoBack: jest.fn() };
+    panel.mount(container, nav as any);
+    // Tools tags should be present immediately (synchronous, no await needed)
+    const tags = container.querySelectorAll("#tools-list .tag");
+    expect(tags.length).toBeGreaterThan(0);
+    expect(tags[0].getAttribute("data-value")).toBe("google_search");
+    expect(tags[0].textContent).toBe("Google Search");
+  });
+
+  it("includes selected tool IDs in assembleRunConfig output", () => {
+    // mount, select google_search tag, click run — verify runBatchAI called with tools
+    // (follow the existing pattern in configure-ai-run.test.ts for how run is triggered)
+  });
+});
+```
+
+Adapt the test structure to match the existing test patterns in the file.
+
+**Step 3: Run to verify they fail**
+
+```bash
+npx jest __tests__/panels/configure-ai-run.test.ts -t "tools TagList"
+```
+
+Expected: FAIL.
+
+**Step 4: Update `src/client/panels/configure-ai-run.ts`**
+
+Add the import:
+```ts
+import { TOOL_CATALOG } from "../tools";
+import type { ToolId } from "../../shared/types";
+```
+
+Add the class field:
+```ts
+private toolsList: TagList | null = null;
+```
+
+Update `SavedState` type to include `tools`:
+```ts
+export type SavedState = Required<Omit<RunConfig, "rowRange">> & Pick<RunConfig, "rowRange">;
+// tools?: ToolId[] becomes tools: ToolId[] via Required — handled below
+```
+
+In the `mount` method, populate tools synchronously right after `container.innerHTML = this.template()`:
+```ts
+this.toolsList = new TagList(
+  container.querySelector("#tools-list")!,
+  TOOL_CATALOG.map((t) => ({ label: t.name, value: t.id })),
+  preset.tools ?? [],
+);
+```
+
+In `unmount()`, add:
+```ts
+tools: (this.toolsList?.getValue() ?? []) as ToolId[],
+```
+
+In `assembleRunConfig()`, add:
+```ts
+const tools = (this.toolsList?.getValue() ?? []) as ToolId[];
+// in the return:
+tools: tools.length > 0 ? tools : undefined,
+```
+
+In `template()`, add the field group after output-col and before row-range-container:
+```html
+<div class="field-group">
+  <span class="field-label">Tools <span class="optional">(optional)</span></span>
+  <div id="tools-list" class="tag-list"></div>
+</div>
+```
+
+**Step 5: Run configure-ai-run tests**
+
+```bash
+npx jest __tests__/panels/configure-ai-run.test.ts
+```
+
+Expected: all pass.
+
+**Step 6: Run full test suite**
+
+```bash
+npm test
+```
+
+Expected: all pass.
+
+**Step 7: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: 0 errors.
+
+**Step 8: Commit**
+
+```bash
+git add src/client/panels/configure-ai-run.ts __tests__/panels/configure-ai-run.test.ts
+git commit -m "feat: add tools TagList to ConfigureAIRunPanel"
+```
+
+---
+
+## Final: Verify and clean up
+
+**Step 1: Run full test suite with coverage**
+
+```bash
+npm run test:coverage
+```
+
+Expected: all thresholds pass.
+
+**Step 2: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: no errors.
+
+**Step 3: Run build to confirm Rollup is happy**
+
+```bash
+npm run build
+```
+
+Expected: clean build, `dist/` updated.
+
+**Step 4: Final commit if anything was tidied**
+
+```bash
+git add -p
+git commit -m "chore: post-feature cleanup"
+```

--- a/src/client/components/tag-list.ts
+++ b/src/client/components/tag-list.ts
@@ -1,20 +1,27 @@
+type TagItem = string | { label: string; value: string };
+
+function normalize(item: TagItem): { label: string; value: string } {
+  return typeof item === "string" ? { label: item, value: item } : item;
+}
+
 export class TagList {
   private readonly container: HTMLElement;
 
-  constructor(container: HTMLElement, headers: string[], selected: string[] = []) {
+  constructor(container: HTMLElement, items: TagItem[], selected: string[] = []) {
     this.container = container;
-    this.render(headers, selected);
+    this.render(items, selected);
   }
 
-  private render(headers: string[], selected: string[]): void {
+  private render(items: TagItem[], selected: string[]): void {
     this.container.innerHTML = "";
-    headers.forEach((h) => {
+    items.forEach((item) => {
+      const { label, value } = normalize(item);
       const btn = document.createElement("button");
       btn.className = "tag";
       btn.type = "button";
-      btn.textContent = h;
-      btn.setAttribute("data-value", h);
-      if (selected.includes(h)) btn.classList.add("selected");
+      btn.textContent = label;
+      btn.setAttribute("data-value", value);
+      if (selected.includes(value)) btn.classList.add("selected");
       btn.addEventListener("click", () => btn.classList.toggle("selected"));
       this.container.appendChild(btn);
     });

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -5,7 +5,8 @@ import { SingleTagList } from "../components/single-tag-list";
 import { RowRange } from "../components/row-range";
 import { getSheetHeaders, runBatchAI } from "../services";
 
-export type SavedState = Required<Omit<RunConfig, "rowRange">> & Pick<RunConfig, "rowRange">;
+export type SavedState = Required<Omit<RunConfig, "rowRange" | "tools">> &
+  Pick<RunConfig, "rowRange" | "tools">;
 
 export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState> {
   private userPromptList: TagList | null = null;

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -1,9 +1,10 @@
 import type { NavigationContext, Panel } from "../types";
-import type { RunConfig } from "../../shared/types";
+import type { RunConfig, ToolId } from "../../shared/types";
 import { TagList } from "../components/tag-list";
 import { SingleTagList } from "../components/single-tag-list";
 import { RowRange } from "../components/row-range";
 import { getSheetHeaders, runBatchAI } from "../services";
+import { TOOL_CATALOG } from "../tools";
 
 export type SavedState = Required<Omit<RunConfig, "rowRange" | "tools">> &
   Pick<RunConfig, "rowRange" | "tools">;
@@ -14,6 +15,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
   private systemPromptList: SingleTagList | null = null;
   private outputColList: SingleTagList | null = null;
   private rowRangeComp: RowRange | null = null;
+  private toolsList: TagList | null = null;
   private nav: NavigationContext | null = null;
 
   mount(
@@ -34,8 +36,15 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
           systemPromptCol: savedState.systemPromptCol || undefined,
           outputCol: savedState.outputCol || undefined,
           rowRange: savedState.rowRange,
+          tools: savedState.tools,
         }
       : (params ?? {});
+
+    this.toolsList = new TagList(
+      container.querySelector("#tools-list")!,
+      TOOL_CATALOG.map((t) => ({ label: t.name, value: t.id })),
+      preset.tools ?? [],
+    );
 
     getSheetHeaders().then(
       (headers) => {
@@ -88,6 +97,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
       systemPromptCol: this.systemPromptList?.getValue() ?? "",
       outputCol: this.outputColList?.getValue() ?? "",
       rowRange: this.rowRangeComp?.getValue(),
+      tools: (this.toolsList?.getValue() ?? []) as ToolId[],
     };
   }
 
@@ -135,12 +145,15 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
 
     const rowRange = this.rowRangeComp?.getValue();
 
+    const tools = (this.toolsList?.getValue() ?? []) as ToolId[];
+
     return {
       userPromptCols,
       driveFileCols: driveFileCols.length > 0 ? driveFileCols : undefined,
       systemPromptCol,
       outputCol,
       rowRange,
+      tools: tools.length > 0 ? tools : undefined,
     };
   }
 
@@ -169,6 +182,10 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
         <div class="field-group">
           <span class="field-label">Output column <span class="required">*</span></span>
           <div id="output-col" class="tag-list"></div>
+        </div>
+        <div class="field-group">
+          <span class="field-label">Tools <span class="optional">(optional)</span></span>
+          <div id="tools-list" class="tag-list"></div>
         </div>
         <div class="field-group">
           <span class="field-label">Rows to process</span>

--- a/src/client/panels/recipe.ts
+++ b/src/client/panels/recipe.ts
@@ -1,10 +1,6 @@
 import type { NavigationContext, Panel, RecipeDefinition } from "../types";
-import type {
-  RecipeParams,
-  PrepRecipeParams,
-  PrepRecipeResult,
-  RunConfig,
-} from "../../shared/types";
+import type { RecipeParams } from "../types";
+import type { PrepRecipeParams, PrepRecipeResult, RunConfig } from "../../shared/types";
 import { LockableField } from "../components/lockable-field";
 import { RecipePrepCook } from "../components/recipe-prep-cook";
 import { prepRecipe } from "../services";

--- a/src/client/recipes.ts
+++ b/src/client/recipes.ts
@@ -1,5 +1,5 @@
 import type { RecipeDefinition } from "./types";
-import type { RecipeParams } from "../shared/types";
+import type { RecipeParams } from "./types";
 
 export const RECIPES: RecipeDefinition[] = [
   {

--- a/src/client/tools.ts
+++ b/src/client/tools.ts
@@ -1,0 +1,32 @@
+/**
+ * client/tools.ts — Client-side tool catalog.
+ *
+ * Provides display metadata for tools shown in the sidebar TagList.
+ * Hardcoded at build time — the tool list is static compiled code,
+ * not user data, so no RPC is needed to populate it.
+ *
+ * When adding a new tool:
+ * 1. Add its ID to ToolId in src/shared/types.ts
+ * 2. Add a matching entry to TOOL_REGISTRY in src/server/tools.ts
+ * 3. Add a display entry here
+ */
+
+import type { ToolId } from "../shared/types";
+
+/**
+ * Display metadata for a tool shown in the sidebar TagList.
+ * Contains only what the client needs — no payload or kind information.
+ */
+export interface ToolCatalogEntry {
+  id: ToolId;
+  name: string;
+  description: string;
+}
+
+export const TOOL_CATALOG: ToolCatalogEntry[] = [
+  {
+    id: "google_search",
+    name: "Google Search",
+    description: "Ground responses in live web search results",
+  },
+];

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,4 +1,29 @@
-import type { RecipeParams } from "../shared/types";
+// ── Recipe UI types ─────────────────────────────────────────────
+// These are client-only — they define sidebar form structure, not RPC payloads.
+
+export interface RecipeFieldConfig {
+  value: string;
+  locked?: boolean; // defaults to true
+  placeholder?: string;
+}
+
+export interface RecipeParams {
+  driveFolder?: {
+    colTitle: string;
+    helperText?: string;
+  };
+  systemPrompt?: {
+    colTitle: RecipeFieldConfig;
+    prompt: RecipeFieldConfig;
+  };
+  userPrompts?: Array<{
+    colTitle: RecipeFieldConfig;
+    prompt: RecipeFieldConfig;
+  }>;
+  outputCol?: {
+    colTitle: RecipeFieldConfig;
+  };
+}
 
 /**
  * All registered panel identifiers. Add new panels here first.

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -8,7 +8,7 @@
  */
 
 import { CONFIG } from "./config";
-import type { GeminiInlineData, GeminiRequest } from "../shared/types";
+import type { GeminiInlineData, GeminiRequest } from "./types";
 
 interface GeminiPart {
   text?: string;

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -8,6 +8,7 @@
  */
 
 import { CONFIG } from "./config";
+import { TOOL_REGISTRY } from "./tools";
 import type { GeminiInlineData, GeminiRequest } from "./types";
 
 interface GeminiPart {
@@ -35,7 +36,22 @@ export function buildGeminiPayload(req: GeminiRequest): Record<string, unknown> 
   }
 
   if (req.tools && req.tools.length > 0) {
-    payload.tools = [{ function_declarations: req.tools }];
+    const entries = req.tools.map((id) => TOOL_REGISTRY[id]);
+
+    const groundingEntries = entries
+      .filter((t): t is Extract<typeof t, { kind: "grounding" }> => t.kind === "grounding")
+      .map((t) => ({ [t.id]: {} }));
+
+    const functionDeclarations = entries
+      .filter((t): t is Extract<typeof t, { kind: "function" }> => t.kind === "function")
+      .map((t) => t.declaration);
+
+    const toolsPayload = [
+      ...groundingEntries,
+      ...(functionDeclarations.length ? [{ function_declarations: functionDeclarations }] : []),
+    ];
+
+    payload.tools = toolsPayload;
   }
 
   return payload;

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -4,7 +4,7 @@
  * Matches the CONFIG object from the original Code.gs.
  */
 
-import type { AppConfig } from "../shared/types";
+import type { AppConfig } from "./types";
 
 export const CONFIG: AppConfig = {
   API_KEY_PROPERTY: "GEMINI_API_KEY",

--- a/src/server/customFunctions.ts
+++ b/src/server/customFunctions.ts
@@ -41,7 +41,7 @@ export function SSI(userTexts: unknown, systemPrompt?: string, toolNames?: unkno
     return invokeGemini({
       systemPrompt: systemPrompt || undefined,
       userTexts: flattenArg(userTexts),
-      tools: resolvedTools.length ? resolvedTools : undefined,
+      tools: resolvedTools.length ? (resolvedTools as unknown as import("../shared/types").ToolId[]) : undefined,
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/src/server/customFunctions.ts
+++ b/src/server/customFunctions.ts
@@ -14,6 +14,7 @@
 import { invokeGemini } from "./api";
 import { flattenArg } from "./utils";
 import { TOOL_REGISTRY } from "./tools";
+import type { ToolId } from "../shared/types";
 
 export { TOOL_REGISTRY };
 
@@ -25,23 +26,22 @@ export { TOOL_REGISTRY };
  *   Example: "Summarize this" or A1 or A1:A3 or {A1,B4,B10}
  * @param {string} [systemPrompt] (Optional) System-level instruction for the model.
  *   Example: "You are a concise summarizer."
- * @param {string|Array} [toolNames] (Optional) Names of pre-registered tools to enable.
- *   Example: "myTool" or {A5,A6}
+ * @param {string|Array} [toolNames] (Optional) Names of tools to enable.
+ *   Example: "google_search" or {A5,A6}
  * @return {string} The model's text response, or "[SSI Error: ...]" on failure.
  * @customfunction
  */
 export function SSI(userTexts: unknown, systemPrompt?: string, toolNames?: unknown): string {
   try {
-    const resolvedTools = flattenArg(toolNames).map((name) => {
-      const decl = TOOL_REGISTRY[name];
-      if (!decl) throw new Error(`unknown tool '${name}'`);
-      return decl;
+    const resolvedToolIds = flattenArg(toolNames).map((name) => {
+      if (!TOOL_REGISTRY[name as ToolId]) throw new Error(`unknown tool '${name}'`);
+      return name as ToolId;
     });
 
     return invokeGemini({
       systemPrompt: systemPrompt || undefined,
       userTexts: flattenArg(userTexts),
-      tools: resolvedTools.length ? (resolvedTools as unknown as import("../shared/types").ToolId[]) : undefined,
+      tools: resolvedToolIds.length ? resolvedToolIds : undefined,
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/src/server/customFunctions.ts
+++ b/src/server/customFunctions.ts
@@ -16,8 +16,6 @@ import { flattenArg } from "./utils";
 import { TOOL_REGISTRY } from "./tools";
 import type { ToolId } from "../shared/types";
 
-export { TOOL_REGISTRY };
-
 /**
  * Call the Gemini API from a spreadsheet cell.
  *

--- a/src/server/drive.ts
+++ b/src/server/drive.ts
@@ -7,7 +7,7 @@
  */
 
 import { CONFIG } from "./config";
-import type { GeminiInlineData } from "../shared/types";
+import type { GeminiInlineData } from "./types";
 
 /**
  * Check that the Drive Advanced Service is available.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -314,7 +314,7 @@ export function runBatchAI(config: RunConfig): void {
     const driveLinks = driveFileIdxs.length > 0 ? driveFileIdxs.map((idx) => row[idx]) : undefined;
     const systemPrompt = systemPromptIdx >= 0 ? row[systemPromptIdx] : undefined;
 
-    const result = runInference(userPrompts, driveLinks, systemPrompt);
+    const result = runInference(userPrompts, driveLinks, systemPrompt, config.tools);
     if (result === null) continue;
 
     sheet.getRange(realRowIndex, outputIdx + 1).setValue(result);
@@ -409,5 +409,6 @@ export function prepRecipe(params: PrepRecipeParams): PrepRecipeResult {
   return {
     rowRange: { start: 2, end: 2 + numRows - 1 },
     colNames,
+    tools: params.tools,
   };
 }

--- a/src/server/inference.ts
+++ b/src/server/inference.ts
@@ -10,6 +10,7 @@ import { invokeGemini } from "./api";
 import { fetchAndEncodeFile } from "./drive";
 import { flattenArg, isValidDriveLink, extractId } from "./utils";
 import type { GeminiInlineData } from "./types";
+import type { ToolId } from "../shared/types";
 
 /**
  * Execute a single Gemini inference from raw cell values.
@@ -20,6 +21,7 @@ import type { GeminiInlineData } from "./types";
  *                     Omit or pass `undefined` to skip Drive attachment.
  * @param systemPrompt Cell value for the system instruction. First non-empty
  *                     string is used. Omit or pass `undefined` to use the model default.
+ * @param tools        Tool IDs to enable for this inference call.
  * @returns The model response string, an "Error: ..." string on failure,
  *          or null if userPrompts is empty (signals caller to skip this row).
  */
@@ -27,6 +29,7 @@ export function runInference(
   userPrompts: unknown,
   driveLinks?: unknown,
   systemPrompt?: unknown,
+  tools?: ToolId[],
 ): string | null {
   const userTexts = flattenArg(userPrompts);
   if (userTexts.length === 0) return null;
@@ -43,6 +46,7 @@ export function runInference(
       systemPrompt: systemPrompt !== undefined ? flattenArg(systemPrompt)[0] : undefined,
       userTexts,
       inlineData: inlineData.length ? inlineData : undefined,
+      tools: tools?.length ? tools : undefined,
     });
   } catch (e) {
     return "Error: " + (e as Error).message;

--- a/src/server/inference.ts
+++ b/src/server/inference.ts
@@ -9,7 +9,7 @@
 import { invokeGemini } from "./api";
 import { fetchAndEncodeFile } from "./drive";
 import { flattenArg, isValidDriveLink, extractId } from "./utils";
-import type { GeminiInlineData } from "../shared/types";
+import type { GeminiInlineData } from "./types";
 
 /**
  * Execute a single Gemini inference from raw cell values.

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -1,4 +1,4 @@
 // src/server/tools.ts
-import type { GeminiFunctionDeclaration } from "../shared/types";
+import type { GeminiFunctionDeclaration } from "./types";
 
 export const TOOL_REGISTRY: Record<string, GeminiFunctionDeclaration> = {};

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -1,4 +1,20 @@
-// src/server/tools.ts
-import type { GeminiFunctionDeclaration } from "./types";
+/**
+ * server/tools.ts — Unified tool registry.
+ *
+ * Maps every ToolId to its Gemini payload construction data.
+ * Record<ToolId, GeminiTool> enforces at compile time that every ToolId
+ * has a matching server implementation — adding a new ToolId without a
+ * registry entry is a type error.
+ *
+ * To add a new tool:
+ * 1. Add its ID to ToolId in src/shared/types.ts
+ * 2. Add an entry here
+ * 3. Add a display entry to TOOL_CATALOG in src/client/tools.ts
+ */
 
-export const TOOL_REGISTRY: Record<string, GeminiFunctionDeclaration> = {};
+import type { ToolId } from "../shared/types";
+import type { GeminiTool } from "./types";
+
+export const TOOL_REGISTRY: Record<ToolId, GeminiTool> = {
+  google_search: { kind: "grounding", id: "google_search" },
+};

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -35,7 +35,10 @@ export interface GeminiGenerationConfig {
 }
 
 /**
- * Internal discriminated union. Not exported — only buildGeminiPayload acts on kind.
+ * Discriminated union for Gemini REST API tool payload construction.
+ * External callers pass ToolId[] — this type is internal to buildGeminiPayload,
+ * which resolves IDs and acts on the kind discriminant to assemble the correct
+ * payload shape for each tool category.
  * Lives here (rather than in api.ts) so TOOL_REGISTRY can reference it.
  */
 export type GeminiTool =

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -8,8 +8,7 @@
  * tools array, but with different structures.
  */
 
-// TODO Task 2: replace with import from ../shared/types
-type ToolId = string;
+import type { ToolId } from "../shared/types";
 
 export interface AppConfig {
   API_KEY_PROPERTY: string;

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -44,6 +44,10 @@ export type GeminiTool =
   | { kind: "grounding"; id: ToolId }
   | { kind: "function"; declaration: GeminiFunctionDeclaration };
 
+export interface DriveFileInfo {
+  url: string;
+}
+
 export interface GeminiRequest {
   apiKey: string;
   modelName?: string; // defaults to CONFIG.MODEL_NAME if omitted

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Server-only types. Never imported by client code.
+ *
+ * GeminiTool is an internal discriminated union used by buildGeminiPayload
+ * to split tool IDs into the correct Gemini REST API payload shapes.
+ * Grounding tools produce { google_search: {} } entries; function-calling
+ * tools produce { function_declarations: [...] } entries — both in the same
+ * tools array, but with different structures.
+ */
+
+// TODO Task 2: replace with import from ../shared/types
+type ToolId = string;
+
+export interface AppConfig {
+  API_KEY_PROPERTY: string;
+  MODEL_NAME: string;
+  MAX_FILE_SIZE_BYTES: number;
+}
+
+export interface GeminiInlineData {
+  mime_type: string;
+  data: string; // base64-encoded bytes
+}
+
+export interface GeminiFunctionDeclaration {
+  name: string;
+  description: string;
+  parameters?: Record<string, unknown>; // JSON Schema object
+}
+
+export interface GeminiGenerationConfig {
+  temperature?: number;
+  maxOutputTokens?: number;
+  responseMimeType?: string;
+}
+
+/**
+ * Internal discriminated union. Not exported — only buildGeminiPayload acts on kind.
+ * Lives here (rather than in api.ts) so TOOL_REGISTRY can reference it.
+ */
+export type GeminiTool =
+  | { kind: "grounding"; id: ToolId }
+  | { kind: "function"; declaration: GeminiFunctionDeclaration };
+
+export interface GeminiRequest {
+  apiKey: string;
+  modelName?: string; // defaults to CONFIG.MODEL_NAME if omitted
+  systemPrompt?: string;
+  userTexts: string[]; // assembled into parts: [{text}, {text}, ...]
+  inlineData?: GeminiInlineData[]; // each item appended as an inline_data part
+  /** Tool IDs to enable. Resolved against TOOL_REGISTRY in buildGeminiPayload. */
+  tools?: ToolId[];
+  generationConfig?: GeminiGenerationConfig;
+}

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -6,7 +6,7 @@
  * Functions that operate purely on plain values have no GAS dependency at all.
  */
 
-import type { DriveFileInfo } from "../shared/types";
+import type { DriveFileInfo } from "./types";
 
 /**
  * Extract a Google Drive file/folder ID from a URL or raw ID string.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,14 +1,23 @@
 /**
- * Shared types for the SSI Drive & AI Tools project.
+ * Shared types for the SSI Toolkit.
+ *
+ * IMPORTANT: This file is the client↔server RPC boundary.
+ * Only types that cross google.script.run calls belong here.
+ * - Server-only types (Gemini API shapes, AppConfig): src/server/types.ts
+ * - Client-only types (UI, panels, recipes): src/client/types.ts
  */
 
-// ── Configuration ──────────────────────────────────────────────
+// ── Tool vocabulary ─────────────────────────────────────────────
 
-export interface AppConfig {
-  API_KEY_PROPERTY: string;
-  MODEL_NAME: string;
-  MAX_FILE_SIZE_BYTES: number;
-}
+/**
+ * All tool IDs recognized by the toolkit.
+ * Extend this union when adding a new tool — the compiler will then
+ * require a matching entry in TOOL_REGISTRY (server/tools.ts)
+ * and TOOL_CATALOG (client/tools.ts).
+ */
+export type ToolId = "google_search";
+
+// ── Configuration ───────────────────────────────────────────────
 
 export interface RunConfig {
   userPromptCols: string[];
@@ -16,39 +25,23 @@ export interface RunConfig {
   systemPromptCol?: string;
   outputCol: string;
   rowRange?: { start: number; end: number };
+  /** Tool IDs to enable for every row in this run. */
+  tools?: ToolId[];
 }
 
-// ── Recipes ────────────────────────────────────────────────────
-
-export interface RecipeFieldConfig {
-  value: string;
-  locked?: boolean; // defaults to true
-  placeholder?: string;
-}
-
-export interface RecipeParams {
-  driveFolder?: {
-    colTitle: string;
-    helperText?: string;
-  };
-  systemPrompt?: {
-    colTitle: RecipeFieldConfig;
-    prompt: RecipeFieldConfig;
-  };
-  userPrompts?: Array<{
-    colTitle: RecipeFieldConfig;
-    prompt: RecipeFieldConfig;
-  }>;
-  outputCol?: {
-    colTitle: RecipeFieldConfig;
-  };
-}
+// ── Recipes ─────────────────────────────────────────────────────
 
 export interface PrepRecipeParams {
   driveFolder?: { url: string; colTitle: string };
   systemPrompt?: { colTitle: string; value: string };
   userPrompts?: Array<{ colTitle: string; value: string }>;
   outputCol?: { colTitle: string };
+  /**
+   * Tool IDs to pass through to PrepRecipeResult.
+   * The server does not process these during prep — they are echoed back
+   * to preserve the single-source-of-truth invariant for preppedRunConfig.
+   */
+  tools?: ToolId[];
 }
 
 export interface PrepRecipeResult {
@@ -59,39 +52,6 @@ export interface PrepRecipeResult {
     userPrompts?: string[];
     outputCol?: string;
   };
-}
-
-// ── Gemini API ─────────────────────────────────────────────────
-
-export interface GeminiInlineData {
-  mime_type: string;
-  data: string; // base64-encoded bytes
-}
-
-export interface GeminiFunctionDeclaration {
-  name: string;
-  description: string;
-  parameters?: Record<string, unknown>; // JSON Schema object
-}
-
-export interface GeminiGenerationConfig {
-  temperature?: number;
-  maxOutputTokens?: number;
-  responseMimeType?: string;
-}
-
-export interface GeminiRequest {
-  apiKey: string;
-  modelName?: string; // defaults to CONFIG.MODEL_NAME if omitted
-  systemPrompt?: string;
-  userTexts: string[]; // assembled into parts: [{text}, {text}, ...]
-  inlineData?: GeminiInlineData[]; // each item appended as an inline_data part
-  tools?: GeminiFunctionDeclaration[];
-  generationConfig?: GeminiGenerationConfig;
-}
-
-// ── Drive ──────────────────────────────────────────────────────
-
-export interface DriveFileInfo {
-  url: string;
+  /** Echoed from PrepRecipeParams — no server-side processing. */
+  tools?: ToolId[];
 }


### PR DESCRIPTION
Summary

  - Introduces Google Search as the first Gemini grounding tool, selectable in the ConfigureAIRunPanel sidebar
  - Reorganizes types: shared/types.ts is now a clean RPC boundary; server-only Gemini shapes live in server/types.ts; client-only UI types in client/types.ts
  - Lays compile-time-safe architecture for future grounding and function-calling tools

  Changes

  Type reorganization
  - src/shared/types.ts — now contains only ToolId, RunConfig, PrepRecipeParams, PrepRecipeResult (all with tools?: ToolId[])
  - src/server/types.ts — new file; absorbs AppConfig, GeminiRequest, GeminiInlineData, GeminiFunctionDeclaration, GeminiGenerationConfig, and GeminiTool discriminated union
  - src/client/types.ts — absorbs RecipeParams, RecipeFieldConfig from shared

  Tool registries
  - src/server/tools.ts — TOOL_REGISTRY: Record<ToolId, GeminiTool> enforces compile-time exhaustiveness (adding a ToolId without a registry entry is a type error)
  - src/client/tools.ts — new file; TOOL_CATALOG: ToolCatalogEntry[] for sidebar display (hardcoded, no RPC)

  Inference chain
  - buildGeminiPayload resolves ToolId[] via TOOL_REGISTRY, splits by kind to assemble grounding ({ google_search: {} }) vs function-calling ({ function_declarations: [...] }) entries
  - runInference gains tools?: ToolId[] parameter
  - runBatchAI passes config.tools to runInference; prepRecipe echoes tools through to PrepRecipeResult

  Sidebar UI
  - TagList extended to accept Array<string | { label: string; value: string }> — existing callers unaffected
  - ConfigureAIRunPanel has a new "Tools (optional)" field group, populated synchronously from TOOL_CATALOG

  Adding a new tool (checklist)

  1. Add its ID to ToolId in src/shared/types.ts
  2. Add a TOOL_REGISTRY entry in src/server/tools.ts — compile error if skipped
  3. Add a TOOL_CATALOG entry in src/client/tools.ts

  For function-calling tools, also implement the execution logic and multi-turn loop in invokeGemini / callGeminiAPI.

  Docs

  - docs/plans/2026-03-04-gemini-tools-design.md — full design rationale
  - docs/plans/2026-03-04-gemini-tools.md — implementation plan

  Test plan

  - npm test — 211 tests across 19 suites, all pass
  - npm run test:coverage — all per-file thresholds met
  - npm run typecheck — 0 errors
  - npm run lint — clean
  - npm run build — clean Rollup build

  🤖 Generated with Claude Code