### PR TITLE
Feature: grounding metadata presentation and rich cell text

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -157,31 +157,35 @@ describe("callGeminiAPI", () => {
 
   it("assembles text from multiple text parts (code execution interleaving)", () => {
     mockFetchResponse({
-      candidates: [{
-        content: {
-          parts: [
-            { text: "Let me check." },
-            { executable_code: { language: "PYTHON", code: "1+1" } },
-            { code_execution_result: { outcome: "OUTCOME_OK", output: "2\n" } },
-            { text: "The answer is 2." },
-          ],
+      candidates: [
+        {
+          content: {
+            parts: [
+              { text: "Let me check." },
+              { executable_code: { language: "PYTHON", code: "1+1" } },
+              { code_execution_result: { outcome: "OUTCOME_OK", output: "2\n" } },
+              { text: "The answer is 2." },
+            ],
+          },
         },
-      }],
+      ],
     });
     expect(callGeminiAPI(baseReq).text).toBe("Let me check.\n\nThe answer is 2.");
   });
 
   it("populates codePairs when executable_code and code_execution_result parts are present", () => {
     mockFetchResponse({
-      candidates: [{
-        content: {
-          parts: [
-            { text: "Sure." },
-            { executable_code: { language: "PYTHON", code: "print(42)" } },
-            { code_execution_result: { outcome: "OUTCOME_OK", output: "42\n" } },
-          ],
+      candidates: [
+        {
+          content: {
+            parts: [
+              { text: "Sure." },
+              { executable_code: { language: "PYTHON", code: "print(42)" } },
+              { code_execution_result: { outcome: "OUTCOME_OK", output: "42\n" } },
+            ],
+          },
         },
-      }],
+      ],
     });
     const resp = callGeminiAPI(baseReq);
     expect(resp.codePairs).toHaveLength(1);
@@ -191,13 +195,15 @@ describe("callGeminiAPI", () => {
 
   it("populates groundingMetadata for google_search results", () => {
     mockFetchResponse({
-      candidates: [{
-        content: { parts: [{ text: "Found it." }] },
-        groundingMetadata: {
-          webSearchQueries: ["test query"],
-          groundingChunks: [{ web: { uri: "https://example.com", title: "Example" } }],
+      candidates: [
+        {
+          content: { parts: [{ text: "Found it." }] },
+          groundingMetadata: {
+            webSearchQueries: ["test query"],
+            groundingChunks: [{ web: { uri: "https://example.com", title: "Example" } }],
+          },
         },
-      }],
+      ],
     });
     const resp = callGeminiAPI(baseReq);
     expect(resp.groundingMetadata?.webSearchQueries).toEqual(["test query"]);
@@ -206,15 +212,21 @@ describe("callGeminiAPI", () => {
 
   it("populates groundingMetadata for url_context results", () => {
     mockFetchResponse({
-      candidates: [{
-        content: { parts: [{ text: "From the URL." }] },
-        groundingMetadata: {
-          groundingChunks: [{ retrievedContext: { uri: "https://example.com", title: "Example" } }],
+      candidates: [
+        {
+          content: { parts: [{ text: "From the URL." }] },
+          groundingMetadata: {
+            groundingChunks: [
+              { retrievedContext: { uri: "https://example.com", title: "Example" } },
+            ],
+          },
         },
-      }],
+      ],
     });
     const resp = callGeminiAPI(baseReq);
-    expect(resp.groundingMetadata?.groundingChunks![0].retrievedContext?.uri).toBe("https://example.com");
+    expect(resp.groundingMetadata?.groundingChunks![0].retrievedContext?.uri).toBe(
+      "https://example.com",
+    );
   });
 
   it("returns undefined groundingMetadata and codePairs when not present", () => {
@@ -232,10 +244,10 @@ describe("callGeminiAPI", () => {
 describe("invokeGemini", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("calls callGeminiAPI with the resolved API key", () => {
+  it("returns a GeminiResponse with text from the first candidate", () => {
     mockFetchResponse({ candidates: [{ content: { parts: [{ text: "result" }] } }] });
     const result = invokeGemini({ userTexts: ["hello"] });
-    expect(result).toBe("result");
+    expect(result.text).toBe("result");
     const url = (UrlFetchApp.fetch as jest.Mock).mock.calls[0][0] as string;
     expect(url).toContain("test-api-key");
   });

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -162,8 +162,8 @@ describe("callGeminiAPI", () => {
           content: {
             parts: [
               { text: "Let me check." },
-              { executable_code: { language: "PYTHON", code: "1+1" } },
-              { code_execution_result: { outcome: "OUTCOME_OK", output: "2\n" } },
+              { executableCode: { language: "PYTHON", code: "1+1" } },
+              { codeExecutionResult: { outcome: "OUTCOME_OK", output: "2\n" } },
               { text: "The answer is 2." },
             ],
           },
@@ -173,15 +173,15 @@ describe("callGeminiAPI", () => {
     expect(callGeminiAPI(baseReq).text).toBe("Let me check.\n\nThe answer is 2.");
   });
 
-  it("populates codePairs when executable_code and code_execution_result parts are present", () => {
+  it("populates codePairs when executableCode and codeExecutionResult parts are present", () => {
     mockFetchResponse({
       candidates: [
         {
           content: {
             parts: [
               { text: "Sure." },
-              { executable_code: { language: "PYTHON", code: "print(42)" } },
-              { code_execution_result: { outcome: "OUTCOME_OK", output: "42\n" } },
+              { executableCode: { language: "PYTHON", code: "print(42)" } },
+              { codeExecutionResult: { outcome: "OUTCOME_OK", output: "42\n" } },
             ],
           },
         },

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -128,12 +128,12 @@ describe("callGeminiAPI", () => {
     mockFetchResponse({
       candidates: [{ content: { parts: [{ text: "AI says hello" }] } }],
     });
-    expect(callGeminiAPI(baseReq)).toBe("AI says hello");
+    expect(callGeminiAPI(baseReq).text).toBe("AI says hello");
   });
 
   it("returns 'No response.' when candidates are empty", () => {
     mockFetchResponse({ candidates: [] });
-    expect(callGeminiAPI(baseReq)).toBe("No response.");
+    expect(callGeminiAPI(baseReq).text).toBe("No response.");
   });
 
   it("throws on API error response", () => {
@@ -151,8 +151,79 @@ describe("callGeminiAPI", () => {
   it("falls back to CONFIG.MODEL_NAME when modelName is omitted", () => {
     mockFetchResponse({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
     callGeminiAPI(baseReq);
-    const url = (UrlFetchApp.fetch as jest.Mock).mock.calls[0][0];
+    const url = (UrlFetchApp.fetch as jest.Mock).mock.calls[0][0] as string;
     expect(url).toContain(CONFIG.MODEL_NAME);
+  });
+
+  it("assembles text from multiple text parts (code execution interleaving)", () => {
+    mockFetchResponse({
+      candidates: [{
+        content: {
+          parts: [
+            { text: "Let me check." },
+            { executable_code: { language: "PYTHON", code: "1+1" } },
+            { code_execution_result: { outcome: "OUTCOME_OK", output: "2\n" } },
+            { text: "The answer is 2." },
+          ],
+        },
+      }],
+    });
+    expect(callGeminiAPI(baseReq).text).toBe("Let me check.\n\nThe answer is 2.");
+  });
+
+  it("populates codePairs when executable_code and code_execution_result parts are present", () => {
+    mockFetchResponse({
+      candidates: [{
+        content: {
+          parts: [
+            { text: "Sure." },
+            { executable_code: { language: "PYTHON", code: "print(42)" } },
+            { code_execution_result: { outcome: "OUTCOME_OK", output: "42\n" } },
+          ],
+        },
+      }],
+    });
+    const resp = callGeminiAPI(baseReq);
+    expect(resp.codePairs).toHaveLength(1);
+    expect(resp.codePairs![0].code.code).toBe("print(42)");
+    expect(resp.codePairs![0].result.output).toBe("42\n");
+  });
+
+  it("populates groundingMetadata for google_search results", () => {
+    mockFetchResponse({
+      candidates: [{
+        content: { parts: [{ text: "Found it." }] },
+        groundingMetadata: {
+          webSearchQueries: ["test query"],
+          groundingChunks: [{ web: { uri: "https://example.com", title: "Example" } }],
+        },
+      }],
+    });
+    const resp = callGeminiAPI(baseReq);
+    expect(resp.groundingMetadata?.webSearchQueries).toEqual(["test query"]);
+    expect(resp.groundingMetadata?.groundingChunks![0].web?.uri).toBe("https://example.com");
+  });
+
+  it("populates groundingMetadata for url_context results", () => {
+    mockFetchResponse({
+      candidates: [{
+        content: { parts: [{ text: "From the URL." }] },
+        groundingMetadata: {
+          groundingChunks: [{ retrievedContext: { uri: "https://example.com", title: "Example" } }],
+        },
+      }],
+    });
+    const resp = callGeminiAPI(baseReq);
+    expect(resp.groundingMetadata?.groundingChunks![0].retrievedContext?.uri).toBe("https://example.com");
+  });
+
+  it("returns undefined groundingMetadata and codePairs when not present", () => {
+    mockFetchResponse({
+      candidates: [{ content: { parts: [{ text: "plain" }] } }],
+    });
+    const resp = callGeminiAPI(baseReq);
+    expect(resp.groundingMetadata).toBeUndefined();
+    expect(resp.codePairs).toBeUndefined();
   });
 });
 

--- a/__tests__/inference.test.ts
+++ b/__tests__/inference.test.ts
@@ -49,7 +49,7 @@ describe("runInference", () => {
 
   it("returns the model response string for a scalar user prompt", () => {
     mockOkResponse("AI response");
-    expect(runInference("Hello AI")).toBe("AI response");
+    expect(runInference("Hello AI")?.text).toBe("AI response");
   });
 
   it("returns null when userPrompts flattens to empty", () => {
@@ -106,14 +106,14 @@ describe("runInference", () => {
 
   it("returns an error string when invokeGemini throws", () => {
     mockFetchResponse({ error: { message: "quota exceeded" } });
-    expect(runInference("prompt")).toBe("Error: quota exceeded");
+    expect(runInference("prompt")?.text).toBe("Error: quota exceeded");
   });
 
   it("returns an error string when Drive fetch throws", () => {
     (DriveApp.getFileById as jest.Mock).mockImplementationOnce(() => {
       throw new Error("File not found");
     });
-    expect(runInference("prompt", "https://drive.google.com/file/d/abc123/view")).toBe(
+    expect(runInference("prompt", "https://drive.google.com/file/d/abc123/view")?.text).toBe(
       "Error: File not found",
     );
   });

--- a/__tests__/panels/configure-ai-run.test.ts
+++ b/__tests__/panels/configure-ai-run.test.ts
@@ -208,6 +208,106 @@ describe("ConfigureAIRunPanel — tools TagList", () => {
   });
 });
 
+describe("includeGrounding checkbox", () => {
+  it("renders the include-grounding checkbox", async () => {
+    const { container } = await mountAndLoad();
+    expect(container.querySelector("#include-grounding-cb")).not.toBeNull();
+  });
+
+  it("assembleRunConfig includes includeGrounding: true when checkbox is checked", async () => {
+    (services.runBatchAI as jest.Mock).mockResolvedValue(undefined);
+    const { container } = await mountAndLoad({
+      userPromptCols: ["col_a"],
+      outputCol: "ai_inference",
+    });
+    const cb = container.querySelector<HTMLInputElement>("#include-grounding-cb")!;
+    cb.checked = true;
+    container.querySelector<HTMLButtonElement>("#run-btn")!.click();
+    await Promise.resolve();
+    const config = (services.runBatchAI as jest.Mock).mock.calls[0]?.[0] as RunConfig | undefined;
+    expect(config?.includeGrounding).toBe(true);
+  });
+
+  it("assembleRunConfig omits includeGrounding when checkbox is unchecked", async () => {
+    (services.runBatchAI as jest.Mock).mockResolvedValue(undefined);
+    const { container } = await mountAndLoad({
+      userPromptCols: ["col_a"],
+      outputCol: "ai_inference",
+    });
+    container.querySelector<HTMLInputElement>("#include-grounding-cb")!.checked = false;
+    container.querySelector<HTMLButtonElement>("#run-btn")!.click();
+    await Promise.resolve();
+    const config = (services.runBatchAI as jest.Mock).mock.calls[0]?.[0] as RunConfig | undefined;
+    expect(config?.includeGrounding).toBeUndefined();
+  });
+
+  it("unmount saves includeGrounding state", async () => {
+    const { container, panel } = await mountAndLoad();
+    container.querySelector<HTMLInputElement>("#include-grounding-cb")!.checked = true;
+    // Select at least one user-prompt column so unmount() returns a value (not undefined)
+    container.querySelectorAll<HTMLElement>("#user-prompt-cols .tag")[0]?.click();
+    const saved = panel.unmount();
+    expect(saved?.includeGrounding).toBe(true);
+  });
+
+  it("updates grounding column label when output column selection changes", async () => {
+    const { container } = await mountAndLoad(); // no pre-selected output column
+    const tag = container.querySelector<HTMLButtonElement>("#output-col .tag");
+    if (!tag) return; // guard against no tags in jsdom
+    tag.click();
+    const label = container.querySelector<HTMLElement>("#grounding-col-name");
+    expect(label?.textContent).toBe(`${tag.textContent}_grounding`);
+  });
+
+  it("restores includeGrounding from savedState", async () => {
+    const { container } = await mountAndLoad(undefined, {
+      userPromptCols: ["col_a"],
+      driveFileCols: [],
+      systemPromptCol: "",
+      outputCol: "ai_inference",
+      tools: ["google_search"], // ← add this line
+      includeGrounding: true,
+    });
+    const cb = container.querySelector<HTMLInputElement>("#include-grounding-cb")!;
+    expect(cb.checked).toBe(true);
+  });
+
+  it("hides the grounding group when no tools are selected", async () => {
+    const { container } = await mountAndLoad();
+    const group = container.querySelector<HTMLElement>("#include-grounding-group");
+    expect(group?.style.display).toBe("none");
+  });
+
+  it("shows the grounding group when a tool is selected", async () => {
+    const { container } = await mountAndLoad();
+    container.querySelector<HTMLElement>("#tools-list .tag")?.click();
+    const group = container.querySelector<HTMLElement>("#include-grounding-group");
+    expect(group?.style.display).toBe("block");
+  });
+
+  it("shows the grounding group on mount when tools are pre-selected in savedState", async () => {
+    const { container } = await mountAndLoad(undefined, {
+      userPromptCols: ["col_a"],
+      driveFileCols: [],
+      systemPromptCol: "",
+      outputCol: "ai_inference",
+      tools: ["google_search"],
+      includeGrounding: false,
+    });
+    const group = container.querySelector<HTMLElement>("#include-grounding-group");
+    expect(group?.style.display).toBe("block");
+  });
+
+  it("hides the grounding group again when all tools are deselected", async () => {
+    const { container } = await mountAndLoad();
+    const tag = container.querySelector<HTMLElement>("#tools-list .tag")!;
+    tag.click(); // select
+    tag.click(); // deselect
+    const group = container.querySelector<HTMLElement>("#include-grounding-group");
+    expect(group?.style.display).toBe("none");
+  });
+});
+
 describe("ConfigureAIRunPanel — unmount", () => {
   it("unmount() returns current form state as SavedState", async () => {
     const { container, panel } = await mountAndLoad();

--- a/__tests__/rich-text.test.ts
+++ b/__tests__/rich-text.test.ts
@@ -1,0 +1,305 @@
+/// <reference types="node" />
+import type { GeminiResponse } from "../src/server/types";
+import { buildInferenceCellContent, buildGroundingCellContent } from "../src/server/rich-text";
+
+// ---- helpers ----
+
+function makeResponse(overrides: Partial<GeminiResponse> = {}): GeminiResponse {
+  return { text: "Hello world.", ...overrides };
+}
+
+function makeGroundedResponse(overrides: Partial<GeminiResponse> = {}): GeminiResponse {
+  return {
+    text: "Paris is the capital of France.",
+    groundingMetadata: {
+      groundingChunks: [{ web: { uri: "https://example.com/paris", title: "Paris - Wikipedia" } }],
+      groundingSupports: [
+        {
+          segment: { startIndex: 0, endIndex: 31, text: "Paris is the capital of France." },
+          groundingChunkIndices: [0],
+        },
+      ],
+      webSearchQueries: ["capital of France"],
+    },
+    ...overrides,
+  };
+}
+
+// ============================================================
+// buildInferenceCellContent
+// ============================================================
+
+describe("buildInferenceCellContent", () => {
+  it("returns plain text with no ranges for a simple response", () => {
+    const result = buildInferenceCellContent(makeResponse({ text: "Hello world." }));
+    expect(result.text).toBe("Hello world.");
+    expect(result.ranges).toHaveLength(0);
+  });
+
+  it("strips **bold** markers and produces a bold range", () => {
+    const result = buildInferenceCellContent(makeResponse({ text: "The **sky** is blue." }));
+    expect(result.text).toBe("The sky is blue.");
+    const bold = result.ranges.find((r) => r.bold);
+    expect(bold).toEqual({ startIndex: 4, endIndex: 7, bold: true });
+  });
+
+  it("strips *italic* markers and produces an italic range", () => {
+    const result = buildInferenceCellContent(makeResponse({ text: "A *quick* test." }));
+    expect(result.text).toBe("A quick test.");
+    const italic = result.ranges.find((r) => r.italic);
+    expect(italic).toEqual({ startIndex: 2, endIndex: 7, italic: true });
+  });
+
+  it("strips ## heading prefix and produces a bold range", () => {
+    const result = buildInferenceCellContent(
+      makeResponse({ text: "## Section Title\nBody text." }),
+    );
+    expect(result.text).toBe("Section Title\nBody text.");
+    expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 13, bold: true });
+  });
+
+  it("adds url range for a citation, remapped through markdown position map", () => {
+    // "The **sky** is blue." → cleanText "The sky is blue." (len 16)
+    // groundingSupport: segment 0..15 (covers "The **sky** is" in original)
+    // original idx 0 → clean 0, original idx 15 → clean 11
+    const response = makeResponse({
+      text: "The **sky** is blue.",
+      groundingMetadata: {
+        groundingChunks: [{ web: { uri: "https://example.com", title: "Example" } }],
+        groundingSupports: [
+          {
+            segment: { startIndex: 0, endIndex: 15, text: "The **sky** is" },
+            groundingChunkIndices: [0],
+          },
+        ],
+        webSearchQueries: [],
+      },
+    });
+    const result = buildInferenceCellContent(response);
+    const link = result.ranges.find((r) => r.url);
+    expect(link).toBeDefined();
+    expect(link?.url).toBe("https://example.com");
+    // remapped: 0→0, 15→11
+    expect(link?.startIndex).toBe(0);
+    expect(link?.endIndex).toBe(11);
+  });
+
+  it("merges overlapping citation ranges and keeps the first URI", () => {
+    const response = makeResponse({
+      text: "Hello world.",
+      groundingMetadata: {
+        groundingChunks: [
+          { web: { uri: "https://a.com", title: "A" } },
+          { web: { uri: "https://b.com", title: "B" } },
+        ],
+        groundingSupports: [
+          { segment: { startIndex: 0, endIndex: 8, text: "Hello wo" }, groundingChunkIndices: [0] },
+          { segment: { startIndex: 5, endIndex: 12, text: "world." }, groundingChunkIndices: [1] },
+        ],
+        webSearchQueries: [],
+      },
+    });
+    const result = buildInferenceCellContent(response);
+    const links = result.ranges.filter((r) => r.url);
+    expect(links).toHaveLength(1);
+    expect(links[0].startIndex).toBe(0);
+    expect(links[0].endIndex).toBe(12);
+    expect(links[0].url).toBe("https://a.com");
+  });
+
+  it("skips citations with no sources", () => {
+    const response = makeResponse({
+      text: "Hello world.",
+      groundingMetadata: {
+        groundingChunks: [],
+        groundingSupports: [
+          { segment: { startIndex: 0, endIndex: 5, text: "Hello" }, groundingChunkIndices: [] },
+        ],
+        webSearchQueries: [],
+      },
+    });
+    const result = buildInferenceCellContent(response);
+    expect(result.ranges.filter((r) => r.url)).toHaveLength(0);
+  });
+
+  it("returns text with no ranges when groundingMetadata is absent", () => {
+    const result = buildInferenceCellContent(makeResponse({ text: "Plain text." }));
+    expect(result.ranges.filter((r) => r.url)).toHaveLength(0);
+  });
+});
+
+// ============================================================
+// buildGroundingCellContent
+// ============================================================
+
+describe("buildGroundingCellContent", () => {
+  it("returns null when response has no grounding data", () => {
+    expect(buildGroundingCellContent(makeResponse())).toBeNull();
+  });
+
+  it("returns null when groundingMetadata has empty arrays", () => {
+    const response = makeResponse({
+      groundingMetadata: { groundingChunks: [], groundingSupports: [], webSearchQueries: [] },
+    });
+    expect(buildGroundingCellContent(response)).toBeNull();
+  });
+
+  it("includes search query text and a Google Search url range", () => {
+    const response = makeGroundedResponse();
+    const result = buildGroundingCellContent(response)!;
+    expect(result.text).toContain('"capital of France"');
+    const queryLink = result.ranges.find((r) => r.url?.startsWith("https://www.google.com/search"));
+    expect(queryLink).toBeDefined();
+    expect(queryLink?.url).toBe("https://www.google.com/search?q=capital%20of%20France");
+    // The link should cover the quoted query text
+    const quotedQuery = '"capital of France"';
+    const idx = result.text.indexOf(quotedQuery);
+    expect(queryLink?.startIndex).toBe(idx);
+    expect(queryLink?.endIndex).toBe(idx + quotedQuery.length);
+  });
+
+  it("includes source title text and a url range pointing to the source URI", () => {
+    const response = makeGroundedResponse();
+    const result = buildGroundingCellContent(response)!;
+    expect(result.text).toContain("Paris - Wikipedia");
+    const sourceLink = result.ranges.find((r) => r.url?.startsWith("https://example.com/paris"));
+    expect(sourceLink).toBeDefined();
+    const titleText = "Paris - Wikipedia";
+    const idx = result.text.indexOf(titleText);
+    expect(sourceLink?.startIndex).toBe(idx);
+    expect(sourceLink?.endIndex).toBe(idx + titleText.length);
+  });
+
+  it("does not include an Unverified section", () => {
+    const response = makeGroundedResponse();
+    const result = buildGroundingCellContent(response)!;
+    expect(result.text).not.toContain("Unverified");
+  });
+
+  it("formats code execution as plain text without markdown fences", () => {
+    const response = makeResponse({
+      codePairs: [
+        {
+          code: { language: "PYTHON", code: "print(1+1)" },
+          result: { outcome: "OUTCOME_OK", output: "2\n" },
+        },
+      ],
+    });
+    const result = buildGroundingCellContent(response)!;
+    expect(result.text).toContain("Code (python):");
+    expect(result.text).toContain("print(1+1)");
+    expect(result.text).toContain("Output:");
+    expect(result.text).toContain("2\n");
+    expect(result.text).not.toContain("```");
+    expect(result.ranges).toHaveLength(0);
+  });
+
+  it("handles multiple sources with individual url ranges", () => {
+    const response = makeResponse({
+      groundingMetadata: {
+        groundingChunks: [
+          { web: { uri: "https://a.com", title: "Site A" } },
+          { web: { uri: "https://b.com", title: "Site B" } },
+        ],
+        groundingSupports: [],
+        webSearchQueries: [],
+      },
+    });
+    const result = buildGroundingCellContent(response)!;
+    const links = result.ranges.filter((r) => r.url);
+    expect(links).toHaveLength(2);
+
+    const linkA = links.find((r) => r.url === "https://a.com");
+    const linkB = links.find((r) => r.url === "https://b.com");
+    expect(linkA).toBeDefined();
+    expect(linkB).toBeDefined();
+
+    const idxA = result.text.indexOf("Site A");
+    const idxB = result.text.indexOf("Site B");
+    expect(linkA?.startIndex).toBe(idxA);
+    expect(linkA?.endIndex).toBe(idxA + "Site A".length);
+    expect(linkB?.startIndex).toBe(idxB);
+    expect(linkB?.endIndex).toBe(idxB + "Site B".length);
+  });
+
+  it("handles multiple search queries with individual url ranges", () => {
+    const response = makeResponse({
+      groundingMetadata: {
+        groundingChunks: [],
+        groundingSupports: [],
+        webSearchQueries: ["query one", "query two"],
+      },
+    });
+    const result = buildGroundingCellContent(response)!;
+    const links = result.ranges.filter((r) => r.url?.includes("google.com"));
+    expect(links).toHaveLength(2);
+    expect(links[0].url).toBe("https://www.google.com/search?q=query%20one");
+    expect(links[1].url).toBe("https://www.google.com/search?q=query%20two");
+  });
+
+  it("handles retrievedContext chunks (no web property)", () => {
+    const response = makeResponse({
+      groundingMetadata: {
+        groundingChunks: [
+          { retrievedContext: { uri: "https://docs.example.com/page", title: "Docs Page" } },
+        ],
+        groundingSupports: [],
+        webSearchQueries: [],
+      },
+    });
+    const result = buildGroundingCellContent(response)!;
+    expect(result.text).toContain("Docs Page");
+    const link = result.ranges.find((r) => r.url === "https://docs.example.com/page");
+    expect(link).toBeDefined();
+    const idx = result.text.indexOf("Docs Page");
+    expect(link?.startIndex).toBe(idx);
+    expect(link?.endIndex).toBe(idx + "Docs Page".length);
+  });
+
+  it("returns only code section — no search/source sections — when codePairs present", () => {
+    const response = makeResponse({
+      groundingMetadata: {
+        groundingChunks: [{ web: { uri: "https://x.com", title: "X" } }],
+        groundingSupports: [],
+        webSearchQueries: ["something"],
+      },
+      codePairs: [
+        {
+          code: { language: "PYTHON", code: "x=1" },
+          result: { outcome: "OUTCOME_OK", output: "1" },
+        },
+      ],
+    });
+    const result = buildGroundingCellContent(response)!;
+    expect(result.text).not.toContain("Search queries");
+    expect(result.text).not.toContain("Sources");
+    expect(result.text).toContain("Code");
+  });
+});
+
+// ============================================================
+// parseMarkdown edge cases (via buildInferenceCellContent)
+// ============================================================
+
+describe("buildInferenceCellContent markdown edge cases", () => {
+  it("does not treat unmatched * as italic", () => {
+    const result = buildInferenceCellContent(makeResponse({ text: "Price: $5 * tax" }));
+    expect(result.text).toBe("Price: $5 * tax");
+    expect(result.ranges.filter((r) => r.italic)).toHaveLength(0);
+  });
+
+  it("handles # heading at the very start", () => {
+    const result = buildInferenceCellContent(makeResponse({ text: "# Title" }));
+    expect(result.text).toBe("Title");
+    expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 5, bold: true });
+  });
+
+  it("handles multiple bold spans", () => {
+    const result = buildInferenceCellContent(makeResponse({ text: "**A** and **B**" }));
+    expect(result.text).toBe("A and B");
+    const bold = result.ranges.filter((r) => r.bold);
+    expect(bold).toHaveLength(2);
+    expect(bold[0]).toEqual({ startIndex: 0, endIndex: 1, bold: true });
+    expect(bold[1]).toEqual({ startIndex: 6, endIndex: 7, bold: true });
+  });
+});

--- a/docs/plans/2026-03-05-grounding-metadata-enrichment-design.md
+++ b/docs/plans/2026-03-05-grounding-metadata-enrichment-design.md
@@ -1,0 +1,76 @@
+# Grounding Metadata Enrichment — Design
+
+## Problem
+
+The three Gemini grounding tools (Google Search, URL Context, Code Execution) return metadata alongside the model's text response that the current implementation discards. `callGeminiAPI` extracts only `candidates[0].content.parts[0].text` and throws away everything else. Users who enable these tools get no visibility into what sources were consulted, what queries were run, or what code executed.
+
+## Scope of This Design
+
+This document covers the **call-chain refactor**: lifting response parsing out of `callGeminiAPI` so that the full structured response is preserved for callers. How the metadata is ultimately presented in the spreadsheet (formatting, column strategy, etc.) is a separate decision deferred to a follow-up design.
+
+## What Each Tool Returns
+
+### Google Search
+Metadata in `candidates[0].groundingMetadata`:
+- `webSearchQueries` — the search queries used
+- `groundingChunks[].web` — `{ uri, title }` for each source
+
+### URL Context
+Metadata in `candidates[0].groundingMetadata`:
+- `groundingChunks[].retrievedContext` — `{ uri, title }` for each fetched URL
+- No `webSearchQueries`
+
+### Code Execution
+Extra parts interspersed in `candidates[0].content.parts`:
+- `executableCode: { language, code }` — the generated code
+- `codeExecutionResult: { outcome, output }` — what it returned
+- Text parts appear before and after code blocks; all must be joined for a coherent response.
+
+## Design Decisions
+
+### Decision 1: Lift response parsing out of `callGeminiAPI`
+
+**Decision:** Change `callGeminiAPI` (and `invokeGemini`, `runInference`) to return a typed `GeminiResponse` object instead of a bare `string`. Callers are then responsible for extracting what they need.
+
+**Alternatives considered:**
+- Keep `callGeminiAPI` returning `string`, add a parallel `callGeminiAPIRich` path — rejected as duplication.
+- String-append metadata to the text in `callGeminiAPI` — rejected because it mixes structured data with prose, is not reversible, and locks in a presentation decision at the wrong layer.
+
+**Why this approach:** Clean separation of concerns. `callGeminiAPI` is a pure HTTP adapter; it should faithfully parse and return the API response. Presentation decisions belong to callers. Both are independently testable.
+
+### Decision 2: No external typing package for Gemini response types
+
+**Decision:** Define lean types in `server/types.ts` for only the fields we consume (`GeminiGroundingChunk`, `GeminiGroundingMetadata`, `GeminiCodePair`, `GeminiResponse`).
+
+**Alternatives considered:**
+- Add `@google/generative-ai` as a devDependency, use `import type` — zero runtime cost, but brings in a large type surface we don't use, and the SDK's processed response types may drift from the raw REST JSON returned by `UrlFetchApp`.
+
+**Why this approach:** Scope is narrow and well-defined. Owning the types means no surprise breakage from SDK updates.
+
+### Decision 3: `runInference` returns `GeminiResponse | null`
+
+**Decision:** Update `runInference` to return `GeminiResponse | null`. Error cases (caught exceptions) return `{ text: "Error: ..." }` — a `GeminiResponse` with no metadata, preserving existing error-string behavior at the cell level.
+
+**Why:** `runBatchAI` is the only caller of `runInference`. Changing the return type affects exactly one callsite. Returning a `GeminiResponse` for errors keeps `runBatchAI`'s loop simple — no special-casing needed for error vs. success.
+
+### Decision 4: `SSI` calls `.text` — behavior unchanged
+
+**Decision:** `SSI` (the Sheets custom function) has a single-cell `string` return contract. It calls `invokeGemini(...).text`. No metadata is surfaced via `SSI`; metadata is a batch-run concern deferred to a follow-up design.
+
+## Files Changed (This Phase)
+
+| File | Change |
+|------|--------|
+| `src/server/types.ts` | Add `GeminiGroundingChunk`, `GeminiGroundingMetadata`, `GeminiCodePair`, `GeminiResponse` |
+| `src/server/api.ts` | `callGeminiAPI` → `GeminiResponse`; `invokeGemini` → `GeminiResponse` |
+| `src/server/inference.ts` | `runInference` → `GeminiResponse \| null`; error catch returns `{ text: "Error: ..." }` |
+| `src/server/customFunctions.ts` | `SSI` calls `invokeGemini(...).text` |
+| `__tests__/api.test.ts` | Update return type assertions; add new tests for metadata fields |
+| `__tests__/inference.test.ts` | Update return type assertions |
+| `__tests__/customFunctions.test.ts` | No behavior changes; tests pass as-is |
+
+## Deferred
+
+- How metadata is formatted for the spreadsheet cell
+- Whether metadata goes in the same cell as text or a separate column
+- Whether `runBatchAI` needs `RunConfig` changes to support metadata output

--- a/docs/plans/2026-03-05-grounding-metadata-enrichment.md
+++ b/docs/plans/2026-03-05-grounding-metadata-enrichment.md
@@ -1,0 +1,605 @@
+# Grounding Metadata Enrichment Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Lift response parsing out of `callGeminiAPI` so the full structured Gemini response (text + grounding metadata + code execution pairs) is preserved for callers instead of discarding everything except the text.
+
+**Architecture:** Change `callGeminiAPI` and `invokeGemini` to return a new `GeminiResponse` typed object. Update `runInference` to return `GeminiResponse | null`. Update `SSI` to call `.text` on the result — behavior unchanged. `runBatchAI` is left untouched in this phase; metadata presentation is a separate design decision.
+
+**Tech Stack:** TypeScript, Jest, Google Apps Script (UrlFetchApp), Gemini REST API v1beta
+
+---
+
+## Gemini API Response Shapes (Reference)
+
+### Google Search / URL Context
+Metadata lives on `candidates[0].groundingMetadata`:
+```json
+{
+  "webSearchQueries": ["query string"],
+  "groundingChunks": [
+    { "web": { "uri": "https://...", "title": "Page Title" } },
+    { "retrievedContext": { "uri": "https://...", "title": "Page Title" } }
+  ]
+}
+```
+
+### Code Execution
+Extra parts interspersed in `candidates[0].content.parts`:
+```json
+[
+  { "text": "Let me calculate..." },
+  { "executableCode": { "language": "PYTHON", "code": "print(1+1)" } },
+  { "codeExecutionResult": { "outcome": "OUTCOME_OK", "output": "2\n" } },
+  { "text": "The result is 2." }
+]
+```
+Text assembly must join all `text` parts. Code pairs are captured separately.
+
+---
+
+### Task 1: Add `GeminiResponse` types to `server/types.ts`
+
+**Files:**
+- Modify: `src/server/types.ts`
+
+No tests needed — pure type definitions.
+
+**Step 1: Add the new interfaces**
+
+Add after the existing `GeminiGenerationConfig` interface (around line 34):
+
+```typescript
+export interface GeminiGroundingChunk {
+  web?: { uri: string; title: string };
+  retrievedContext?: { uri: string; title: string };
+}
+
+export interface GeminiGroundingMetadata {
+  webSearchQueries?: string[];
+  groundingChunks?: GeminiGroundingChunk[];
+}
+
+export interface GeminiCodePair {
+  code: { language: string; code: string };
+  result: { outcome: string; output: string };
+}
+
+/**
+ * Structured representation of a Gemini generateContent response.
+ * Returned by callGeminiAPI and invokeGemini in place of a bare string.
+ */
+export interface GeminiResponse {
+  /** Assembled from all text parts in candidates[0].content.parts. */
+  text: string;
+  /** Present when google_search or url_context grounding was active. */
+  groundingMetadata?: GeminiGroundingMetadata;
+  /** Present when code_execution was active and code blocks were returned. */
+  codePairs?: GeminiCodePair[];
+}
+```
+
+**Step 2: Typecheck**
+
+```bash
+npm run typecheck
+```
+Expected: passes (no usages changed yet).
+
+**Step 3: Commit**
+
+```bash
+git add src/server/types.ts
+git commit -m "feat: add GeminiResponse types to server/types.ts"
+```
+
+---
+
+### Task 2: Update `callGeminiAPI` to return `GeminiResponse`
+
+**Files:**
+- Modify: `src/server/api.ts`
+- Modify: `__tests__/api.test.ts`
+
+**Step 1: Update the failing tests first**
+
+In `__tests__/api.test.ts`, update the import and the `callGeminiAPI` describe block:
+
+```typescript
+import { buildGeminiPayload, callGeminiAPI, invokeGemini } from "../src/server/api";
+import { CONFIG } from "../src/server/config";
+import type { GeminiRequest } from "../src/server/types";
+```
+
+Replace the entire `callGeminiAPI` describe block with:
+
+```typescript
+describe("callGeminiAPI", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns the text from the first candidate", () => {
+    mockFetchResponse({
+      candidates: [{ content: { parts: [{ text: "AI says hello" }] } }],
+    });
+    expect(callGeminiAPI(baseReq).text).toBe("AI says hello");
+  });
+
+  it("returns 'No response.' when candidates are empty", () => {
+    mockFetchResponse({ candidates: [] });
+    expect(callGeminiAPI(baseReq).text).toBe("No response.");
+  });
+
+  it("throws on API error response", () => {
+    mockFetchResponse({ error: { message: "Invalid API key" } });
+    expect(() => callGeminiAPI({ ...baseReq, apiKey: "bad" })).toThrow("Invalid API key");
+  });
+
+  it("uses modelName from request when provided", () => {
+    mockFetchResponse({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
+    callGeminiAPI({ ...baseReq, modelName: "gemini-1.5-pro" });
+    const url = (UrlFetchApp.fetch as jest.Mock).mock.calls[0][0];
+    expect(url).toContain("gemini-1.5-pro");
+  });
+
+  it("falls back to CONFIG.MODEL_NAME when modelName is omitted", () => {
+    mockFetchResponse({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
+    callGeminiAPI(baseReq);
+    const url = (UrlFetchApp.fetch as jest.Mock).mock.calls[0][0] as string;
+    expect(url).toContain(CONFIG.MODEL_NAME);
+  });
+
+  it("assembles text from multiple text parts (code execution interleaving)", () => {
+    mockFetchResponse({
+      candidates: [{
+        content: {
+          parts: [
+            { text: "Let me check." },
+            { executableCode: { language: "PYTHON", code: "1+1" } },
+            { codeExecutionResult: { outcome: "OUTCOME_OK", output: "2\n" } },
+            { text: "The answer is 2." },
+          ],
+        },
+      }],
+    });
+    expect(callGeminiAPI(baseReq).text).toBe("Let me check.\n\nThe answer is 2.");
+  });
+
+  it("populates codePairs when executableCode and codeExecutionResult parts are present", () => {
+    mockFetchResponse({
+      candidates: [{
+        content: {
+          parts: [
+            { text: "Sure." },
+            { executableCode: { language: "PYTHON", code: "print(42)" } },
+            { codeExecutionResult: { outcome: "OUTCOME_OK", output: "42\n" } },
+          ],
+        },
+      }],
+    });
+    const resp = callGeminiAPI(baseReq);
+    expect(resp.codePairs).toHaveLength(1);
+    expect(resp.codePairs![0].code.code).toBe("print(42)");
+    expect(resp.codePairs![0].result.output).toBe("42\n");
+  });
+
+  it("populates groundingMetadata for google_search results", () => {
+    mockFetchResponse({
+      candidates: [{
+        content: { parts: [{ text: "Found it." }] },
+        groundingMetadata: {
+          webSearchQueries: ["test query"],
+          groundingChunks: [{ web: { uri: "https://example.com", title: "Example" } }],
+        },
+      }],
+    });
+    const resp = callGeminiAPI(baseReq);
+    expect(resp.groundingMetadata?.webSearchQueries).toEqual(["test query"]);
+    expect(resp.groundingMetadata?.groundingChunks![0].web?.uri).toBe("https://example.com");
+  });
+
+  it("populates groundingMetadata for url_context results", () => {
+    mockFetchResponse({
+      candidates: [{
+        content: { parts: [{ text: "From the URL." }] },
+        groundingMetadata: {
+          groundingChunks: [{ retrievedContext: { uri: "https://example.com", title: "Example" } }],
+        },
+      }],
+    });
+    const resp = callGeminiAPI(baseReq);
+    expect(resp.groundingMetadata?.groundingChunks![0].retrievedContext?.uri).toBe("https://example.com");
+  });
+
+  it("returns undefined groundingMetadata and codePairs when not present", () => {
+    mockFetchResponse({
+      candidates: [{ content: { parts: [{ text: "plain" }] } }],
+    });
+    const resp = callGeminiAPI(baseReq);
+    expect(resp.groundingMetadata).toBeUndefined();
+    expect(resp.codePairs).toBeUndefined();
+  });
+});
+```
+
+**Step 2: Run to confirm failures**
+
+```bash
+npx jest __tests__/api.test.ts
+```
+Expected: the updated `callGeminiAPI` tests fail (return type is still `string`).
+
+**Step 3: Update `callGeminiAPI` in `src/server/api.ts`**
+
+Update the import line:
+```typescript
+import type { GeminiInlineData, GeminiRequest, GeminiResponse, GeminiCodePair } from "./types";
+```
+
+Replace the `callGeminiAPI` function (current lines 63–82):
+
+```typescript
+export function callGeminiAPI(req: GeminiRequest): GeminiResponse {
+  const modelName = req.modelName ?? CONFIG.MODEL_NAME;
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent?key=${req.apiKey}`;
+
+  const options: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
+    method: "post",
+    contentType: "application/json",
+    payload: JSON.stringify(buildGeminiPayload(req)),
+    muteHttpExceptions: true,
+  };
+
+  const response = UrlFetchApp.fetch(url, options);
+  const json = JSON.parse(response.getContentText()) as Record<string, unknown>;
+
+  if (json.error) throw new Error((json.error as { message: string }).message);
+
+  const candidate = (json.candidates as Array<Record<string, unknown>> | undefined)?.[0];
+  const parts =
+    (candidate?.content as { parts?: Array<Record<string, unknown>> } | undefined)?.parts ?? [];
+
+  // Assemble text from all text parts (may be interspersed with code execution parts)
+  const textParts = parts
+    .filter((p): p is { text: string } => typeof p["text"] === "string")
+    .map((p) => p.text);
+  const text = textParts.join("\n\n") || "No response.";
+
+  // Extract consecutive executableCode + codeExecutionResult pairs
+  const codePairs: GeminiCodePair[] = [];
+  for (let i = 0; i < parts.length - 1; i++) {
+    const curr = parts[i];
+    const next = parts[i + 1];
+    if (curr["executableCode"] !== undefined && next["codeExecutionResult"] !== undefined) {
+      codePairs.push({
+        code: curr["executableCode"] as GeminiCodePair["code"],
+        result: next["codeExecutionResult"] as GeminiCodePair["result"],
+      });
+      i++; // skip the result part — already consumed
+    }
+  }
+
+  const groundingMetadata = candidate?.["groundingMetadata"] as
+    | GeminiResponse["groundingMetadata"]
+    | undefined;
+
+  return {
+    text,
+    ...(groundingMetadata !== undefined && { groundingMetadata }),
+    ...(codePairs.length > 0 && { codePairs }),
+  };
+}
+```
+
+**Step 4: Run `callGeminiAPI` tests**
+
+```bash
+npx jest __tests__/api.test.ts
+```
+Expected: `callGeminiAPI` tests pass. `invokeGemini` tests will fail — fix next.
+
+---
+
+### Task 3: Update `invokeGemini` to return `GeminiResponse`
+
+**Files:**
+- Modify: `src/server/api.ts` (return type only)
+- Modify: `__tests__/api.test.ts` (invokeGemini describe block)
+
+**Step 1: Update invokeGemini tests**
+
+Replace the `invokeGemini` describe block:
+
+```typescript
+describe("invokeGemini", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns a GeminiResponse with text from the first candidate", () => {
+    mockFetchResponse({ candidates: [{ content: { parts: [{ text: "result" }] } }] });
+    const result = invokeGemini({ userTexts: ["hello"] });
+    expect(result.text).toBe("result");
+    const url = (UrlFetchApp.fetch as jest.Mock).mock.calls[0][0] as string;
+    expect(url).toContain("test-api-key");
+  });
+
+  it("throws when the API key property is not set", () => {
+    (PropertiesService.getScriptProperties().getProperty as jest.Mock).mockReturnValueOnce(null);
+    expect(() => invokeGemini({ userTexts: ["hello"] })).toThrow(/GEMINI_API_KEY/);
+  });
+
+  it("passes systemPrompt through to the payload", () => {
+    mockFetchResponse({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
+    invokeGemini({ systemPrompt: "Be concise", userTexts: ["hello"] });
+    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    expect(payload.system_instruction.parts[0].text).toBe("Be concise");
+  });
+
+  it("passes inlineData through to the payload", () => {
+    mockFetchResponse({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
+    invokeGemini({
+      userTexts: ["describe this"],
+      inlineData: [{ mime_type: "application/pdf", data: "base64==" }],
+    });
+    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    expect(payload.contents[0].parts[1].inline_data.mime_type).toBe("application/pdf");
+  });
+});
+```
+
+**Step 2: Run to confirm failures**
+
+```bash
+npx jest __tests__/api.test.ts
+```
+Expected: `invokeGemini` tests fail.
+
+**Step 3: Update `invokeGemini` return type in `src/server/api.ts`**
+
+```typescript
+export function invokeGemini(params: Omit<GeminiRequest, "apiKey">): GeminiResponse {
+  const apiKey = PropertiesService.getScriptProperties().getProperty(CONFIG.API_KEY_PROPERTY);
+  if (!apiKey) throw new Error(`${CONFIG.API_KEY_PROPERTY} script property not set`);
+  return callGeminiAPI({ apiKey, ...params });
+}
+```
+
+**Step 4: Run all api tests**
+
+```bash
+npx jest __tests__/api.test.ts
+```
+Expected: all pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/server/api.ts __tests__/api.test.ts
+git commit -m "feat: callGeminiAPI and invokeGemini return GeminiResponse"
+```
+
+---
+
+### Task 4: Update `runInference` to return `GeminiResponse | null`
+
+**Files:**
+- Modify: `src/server/inference.ts`
+- Modify: `__tests__/inference.test.ts`
+
+**Step 1: Update the failing tests**
+
+In `__tests__/inference.test.ts`, update return-value assertions. The mock body shape is unchanged — only the assertion style changes.
+
+```typescript
+describe("runInference", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns a GeminiResponse for a scalar user prompt", () => {
+    mockOkResponse("AI response");
+    expect(runInference("Hello AI")?.text).toBe("AI response");
+  });
+
+  it("returns null when userPrompts flattens to empty", () => {
+    expect(runInference(null)).toBeNull();
+    expect(runInference("")).toBeNull();
+  });
+
+  it("flattens a vertical range of user prompts", () => {
+    mockOkResponse("ok");
+    runInference([["p1"], ["p2"]]);
+    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    expect(payload.contents[0].parts).toHaveLength(2);
+    expect(payload.contents[0].parts[0].text).toBe("p1");
+    expect(payload.contents[0].parts[1].text).toBe("p2");
+  });
+
+  it("encodes a valid drive link as inlineData", () => {
+    mockOkResponse("ok");
+    runInference("prompt", "https://drive.google.com/file/d/abc123/view");
+    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    expect(payload.contents[0].parts[1].inline_data).toEqual({
+      mime_type: "application/pdf",
+      data: "encoded==",
+    });
+  });
+
+  it("filters out invalid drive links silently", () => {
+    mockOkResponse("ok");
+    runInference("prompt", "not-a-drive-link");
+    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    expect(payload.contents[0].parts).toHaveLength(1);
+  });
+
+  it("omits inlineData from payload when driveLinks is omitted", () => {
+    mockOkResponse("ok");
+    runInference("prompt");
+    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    expect(payload.contents[0].parts).toHaveLength(1);
+  });
+
+  it("passes systemPrompt to the payload", () => {
+    mockOkResponse("ok");
+    runInference("prompt", undefined, "Be concise");
+    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    expect(payload.system_instruction.parts[0].text).toBe("Be concise");
+  });
+
+  it("uses default system prompt when systemPrompt is omitted", () => {
+    mockOkResponse("ok");
+    runInference("prompt");
+    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    expect(payload.system_instruction.parts[0].text).toBe("You are a helpful assistant.");
+  });
+
+  it("returns an error response when invokeGemini throws", () => {
+    mockFetchResponse({ error: { message: "quota exceeded" } });
+    expect(runInference("prompt")?.text).toBe("Error: quota exceeded");
+  });
+
+  it("returns an error response when Drive fetch throws", () => {
+    (DriveApp.getFileById as jest.Mock).mockImplementationOnce(() => {
+      throw new Error("File not found");
+    });
+    expect(runInference("prompt", "https://drive.google.com/file/d/abc123/view")?.text).toBe(
+      "Error: File not found",
+    );
+  });
+
+  it("passes tools to the payload when provided", () => {
+    mockOkResponse("ok");
+    runInference("prompt", undefined, undefined, ["google_search"]);
+    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    expect(payload.tools).toBeDefined();
+    expect(payload.tools[0]).toHaveProperty("google_search");
+  });
+
+  it("omits tools from the payload when not provided", () => {
+    mockOkResponse("ok");
+    runInference("prompt");
+    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    expect(payload.tools).toBeUndefined();
+  });
+});
+```
+
+**Step 2: Run to confirm failures**
+
+```bash
+npx jest __tests__/inference.test.ts
+```
+Expected: FAIL on `?.text` assertions.
+
+**Step 3: Update `runInference` in `src/server/inference.ts`**
+
+```typescript
+import { invokeGemini } from "./api";
+import { fetchAndEncodeFile } from "./drive";
+import { flattenArg, isValidDriveLink, extractId } from "./utils";
+import type { GeminiInlineData, GeminiResponse } from "./types";
+import type { ToolId } from "../shared/types";
+
+export function runInference(
+  userPrompts: unknown,
+  driveLinks?: unknown,
+  systemPrompt?: unknown,
+  tools?: ToolId[],
+): GeminiResponse | null {
+  const userTexts = flattenArg(userPrompts);
+  if (userTexts.length === 0) return null;
+
+  try {
+    const inlineData: GeminiInlineData[] =
+      driveLinks !== undefined
+        ? flattenArg(driveLinks)
+            .filter(isValidDriveLink)
+            .map((link) => fetchAndEncodeFile(extractId(link)))
+        : [];
+
+    return invokeGemini({
+      systemPrompt: systemPrompt !== undefined ? flattenArg(systemPrompt)[0] : undefined,
+      userTexts,
+      inlineData: inlineData.length ? inlineData : undefined,
+      tools: tools?.length ? tools : undefined,
+    });
+  } catch (e) {
+    return { text: "Error: " + (e as Error).message };
+  }
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+npx jest __tests__/inference.test.ts
+```
+Expected: all pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/server/inference.ts __tests__/inference.test.ts
+git commit -m "feat: runInference returns GeminiResponse | null"
+```
+
+---
+
+### Task 5: Update `SSI` to call `.text` on `invokeGemini` result
+
+**Files:**
+- Modify: `src/server/customFunctions.ts`
+
+**Step 1: Run existing SSI tests to expose the breakage**
+
+```bash
+npx jest __tests__/customFunctions.test.ts
+```
+Expected: failures — `SSI` is now returning a stringified object instead of the text.
+
+**Step 2: Update the `invokeGemini` call in `src/server/customFunctions.ts`**
+
+Only the `return invokeGemini(...)` line changes:
+
+```typescript
+return invokeGemini({
+  systemPrompt: systemPrompt || undefined,
+  userTexts: flattenArg(userTexts),
+  tools: resolvedToolIds.length ? resolvedToolIds : undefined,
+}).text;
+```
+
+**Step 3: Run SSI tests**
+
+```bash
+npx jest __tests__/customFunctions.test.ts
+```
+Expected: all pass (behavior unchanged from the user's perspective).
+
+**Step 4: Commit**
+
+```bash
+git add src/server/customFunctions.ts
+git commit -m "feat: SSI uses invokeGemini().text after GeminiResponse refactor"
+```
+
+---
+
+### Task 6: Full verification
+
+**Step 1: Run full test suite with coverage**
+
+```bash
+npm run test:coverage
+```
+Expected: all pass, coverage thresholds met.
+
+**Step 2: Build**
+
+```bash
+npm run build
+```
+Expected: clean build, no errors.
+
+**Step 3: Lint and format check**
+
+```bash
+npm run lint && npm run format:check
+```
+Expected: no issues.

--- a/docs/plans/2026-03-05-grounding-metadata-presentation-design.md
+++ b/docs/plans/2026-03-05-grounding-metadata-presentation-design.md
@@ -1,0 +1,198 @@
+# Grounding Metadata Presentation — Design
+
+## Goal
+
+Surface Gemini grounding tool metadata in the spreadsheet in a way that gives journalists actionable pathways to verify AI-generated claims. Inline citations link specific claims directly to their sources; an optional provenance column exposes the full picture.
+
+## Scope
+
+Builds on the `GeminiResponse` refactor (PR #35). That PR gave callers access to `groundingMetadata` and `codePairs`; this design specifies how to render them into spreadsheet cells.
+
+---
+
+## User Experience
+
+### `{outputCol}` cell (always)
+
+`{outputCol}` is whatever the user configured in the sidebar (e.g., `ai_inference`, `results`, any column name). The model's text response is written as a `RichTextValue`. Character spans identified by `groundingSupports` are hyperlinked to their source URIs — the journalist clicks the claim, lands on the source. Attribution is driven by structured span data from the API, not markdown parsing.
+
+### `{outputCol}_grounding` cell (opt-in)
+
+Auto-named from the output column (e.g., if `outputCol` is `my_results`, the grounding column is `my_results_grounding`). Created when the user checks "Include sources column" in the sidebar. Only written when grounding metadata is actually returned. Contains three sections as a `RichTextValue` with clickable source links:
+
+```
+Search queries: "query one", "query two"
+
+Sources (3):
+• Source Title A        ← clickable hyperlink
+• Source Title B        ← clickable hyperlink
+• Source Title C        ← clickable hyperlink
+
+Unverified:
+• "claim text with no source support"
+• "another ungrounded sentence"
+```
+
+For `code_execution` runs the column shows the code block(s) and output instead.
+
+The "Unverified" section is derived by finding text spans NOT covered by any `groundingSupports` entry — claims the model made without citation evidence.
+
+---
+
+## Type Changes
+
+### Add `GeminiGroundingSupport` and extend `GeminiGroundingMetadata` (`server/types.ts`)
+
+```typescript
+export interface GeminiGroundingSupport {
+  segment: {
+    startIndex: number;
+    endIndex: number;
+    text: string;
+  };
+  groundingChunkIndices: number[];
+  confidenceScores?: number[];
+}
+
+export interface GeminiGroundingMetadata {
+  webSearchQueries?: string[];
+  groundingChunks?: GeminiGroundingChunk[];
+  groundingSupports?: GeminiGroundingSupport[]; // NEW
+}
+```
+
+`groundingSupports` is nested inside `groundingMetadata` in the raw REST JSON, so the existing spread in `callGeminiAPI` picks it up automatically once the type is extended — no parser change needed.
+
+### Add `includeGrounding` to `RunConfig` (`shared/types.ts`)
+
+```typescript
+export interface RunConfig {
+  // ... existing fields
+  includeGrounding?: boolean;
+}
+```
+
+---
+
+## Architecture
+
+### Layer 1 — Pure helpers (testable, `api.ts`)
+
+Three small exported functions, each accepting `GeminiResponse` directly. No intermediate bundling type — `GeminiResponse` is already a robust interface.
+
+```typescript
+interface Citation {
+  startIndex: number;
+  endIndex: number;
+  sources: Array<{ uri: string; title: string }>;
+}
+
+interface Span {
+  startIndex: number;
+  endIndex: number;
+  text: string;
+}
+
+/** Resolve groundingSupports entries into Citation objects with sources joined from groundingChunks. */
+export function getCitations(response: GeminiResponse): Citation[]
+
+/** Find text regions in inferenceText not covered by any groundingSupports segment. */
+export function getUngroundedSpans(response: GeminiResponse): Span[]
+
+/** Return the flat list of all groundingChunks as { uri, title } pairs. */
+export function getAllSources(response: GeminiResponse): Array<{ uri: string; title: string }>
+```
+
+`getUngroundedSpans` is the non-trivial one — it sorts supports by `startIndex`, merges overlaps, and finds gaps. It is the primary reason this layer exists as pure testable code.
+
+### Layer 2 — GAS rendering (in `index.ts`, excluded from coverage)
+
+Two thin functions that call the pure helpers and translate to GAS types:
+
+```typescript
+function renderInference(response: GeminiResponse): GoogleAppsScript.Spreadsheet.RichTextValue {
+  const builder = SpreadsheetApp.newRichTextValue().setText(response.text);
+  getCitations(response).forEach(({ startIndex, endIndex, sources }) => {
+    if (sources[0]) builder.setLinkUrl(startIndex, endIndex, sources[0].uri);
+  });
+  return builder.build();
+}
+
+function renderGrounding(response: GeminiResponse): GoogleAppsScript.Spreadsheet.RichTextValue | null {
+  // Returns null if nothing to show
+  // Calls getUngroundedSpans, getAllSources on response
+  // Builds three-section RichTextValue (queries / sources with links / unverified)
+  // or code block format for code_execution
+}
+```
+
+No logic here worth testing — just mechanical translation from `GeminiResponse` to GAS types. All interesting decisions live in the pure helpers.
+
+---
+
+## Data Flow
+
+```
+runBatchAI
+  → runInference(...)                         → GeminiResponse | null
+  → renderInference(response)                 → RichTextValue          [GAS, index.ts]
+      calls getCitations(response)            → Citation[]             [pure, api.ts]
+  → outputCell.setRichTextValue(...)
+
+  if config.includeGrounding:
+    → renderGrounding(response)               → RichTextValue | null   [GAS, index.ts]
+        calls getAllSources(response)         → Source[]               [pure, api.ts]
+        calls getUngroundedSpans(response)    → Span[]                 [pure, api.ts]
+    → if non-null: groundingCell.setRichTextValue(...)
+```
+
+---
+
+## UI Change
+
+### `ConfigureAIRunPanel` (client)
+
+Add a checkbox below the tool selector. Label: `Include sources column ({outputCol}_grounding)`. The label updates dynamically to reflect the current output column name. Always visible — applies to all grounding tools and code execution alike. Bound to `includeGrounding` in the `RunConfig` assembled before calling `runBatchAI`.
+
+---
+
+## Column Naming
+
+The grounding column is always `config.outputCol + "_grounding"`. Auto-created in `runBatchAI` using the same inline pattern as the output column (check `headers`, append if missing, push name to `headers` array to keep subsequent rows in sync).
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|---|---|
+| Grounding tools active, no metadata returned | `{outputCol}` gets plain `RichTextValue` (no links); grounding cell left empty |
+| `includeGrounding` checked, `code_execution` active | Grounding cell shows code block + output instead of sources/queries |
+| `groundingSupports` absent but `groundingChunks` present | Citations skipped; grounding cell shows sources + queries only (no Unverified section) |
+| Multiple sources per span | First source URI used for the hyperlink; all sources appear in the grounding column |
+| Plain run (no tools) | `{outputCol}` written as plain `RichTextValue` (no links); grounding cell not written |
+
+---
+
+## Testing
+
+The pure helpers are fully unit-testable with Jest:
+
+- `getCitations` — given `groundingSupports` + `groundingChunks`, assert spans and resolved sources are correct
+- `getUngroundedSpans` — given full text with partial coverage, assert gaps are identified correctly; test overlapping supports, adjacent supports, fully covered text, fully uncovered text
+- `getAllSources` — given `groundingChunks`, assert flat list is correct; empty when no chunks
+
+`renderInference` and `renderGrounding` live in `index.ts` (excluded from coverage) — verified manually against a live sheet.
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `src/shared/types.ts` | Add `includeGrounding?: boolean` to `RunConfig` |
+| `src/server/types.ts` | Add `GeminiGroundingSupport`; add `groundingSupports` to `GeminiGroundingMetadata` |
+| `src/server/api.ts` | Add `getCitations`, `getUngroundedSpans`, `getAllSources` pure helpers; add `Citation` and `Span` interfaces |
+| `src/server/index.ts` | Add `renderInference`, `renderGrounding`; update `runBatchAI` to use both |
+| `src/client/panels/configure-ai-run.ts` | Add `includeGrounding` checkbox |
+| `__tests__/api.test.ts` | Add tests for the three pure helpers |

--- a/docs/plans/2026-03-05-grounding-metadata-presentation-refinements.md
+++ b/docs/plans/2026-03-05-grounding-metadata-presentation-refinements.md
@@ -1,0 +1,1175 @@
+# Grounding Metadata Presentation Refinements — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Introduce a `rich-text.ts` module as the canonical layer between `GeminiResponse` and Sheets cell content, then deliver five user-requested polish items: remove the "Unverified" section, hyperlink search queries to Google, move the grounding checkbox into the Tools field-group with conditional visibility, fix the code execution format in the grounding column, and render Gemini markdown (bold, italic, headings) in output cells.
+
+**Architecture:** New `src/server/rich-text.ts` owns all pure response-to-cell logic (`parseMarkdown`, private `getCitations`/`getAllSources`, `buildInferenceCellContent`, `buildGroundingCellContent`). `api.ts` is stripped back to a pure HTTP adapter. `index.ts` gets a single `toCellValue` GAS wrapper that converts `CellContent → RichTextValue` and replaces the two `render*` functions. The UI checkbox change is self-contained in `configure-ai-run.ts`.
+
+**Tech Stack:** TypeScript, Jest/jsdom, Google Apps Script (`SpreadsheetApp.newRichTextValue`, `SpreadsheetApp.newTextStyle`)
+
+---
+
+## Reference: current files
+
+- `src/server/api.ts` — currently exports `buildGeminiPayload`, `callGeminiAPI`, `invokeGemini`, `Citation`, `getCitations`, `getAllSources`, `Span`, `getUngroundedSpans`
+- `src/server/index.ts` — imports `getCitations`, `getUngroundedSpans`, `getAllSources` from `./api`; contains `renderInference` and `renderGrounding` (lines ~230-314), `runBatchAI` (line ~316)
+- `src/server/types.ts` — `GeminiResponse`, `GeminiGroundingMetadata`, `GeminiGroundingSupport`, `GeminiCodePair`
+- `src/client/panels/configure-ai-run.ts` — tools list initialized synchronously (lines ~45-49); checkbox initialized in async headers callback (lines ~82-88); `template()` has separate field-group for checkbox
+- `src/client/sidebar.css` — no `.grounding-hint` rule yet
+- `__tests__/api.test.ts` — tests for `getCitations` (~5 cases), `getAllSources` (~5 cases), `getUngroundedSpans` (~10 cases)
+- `__tests__/panels/configure-ai-run.test.ts` — `"includeGrounding checkbox"` describe block (6 tests)
+
+---
+
+## Task 1: Remove `getUngroundedSpans` and `Span` from `api.ts`
+
+**Files:**
+- Modify: `src/server/api.ts`
+- Modify: `src/server/index.ts`
+- Modify: `__tests__/api.test.ts`
+
+No new tests — this is pure deletion. Verified by running the test suite.
+
+### Step 1: Remove `Span` interface and `getUngroundedSpans` from `src/server/api.ts`
+
+Delete the `Span` interface (lines ~31-35):
+```typescript
+// DELETE:
+export interface Span {
+  startIndex: number;
+  endIndex: number;
+  text: string;
+}
+```
+
+Delete the entire `getUngroundedSpans` function and its JSDoc (lines ~143-190).
+
+Leave `Citation`, `getCitations`, `getAllSources` intact — they are removed in Task 3.
+
+### Step 2: Update `src/server/index.ts`
+
+**a)** Remove `getUngroundedSpans` from the import line:
+```typescript
+// BEFORE:
+import { getCitations, getUngroundedSpans, getAllSources } from "./api";
+
+// AFTER:
+import { getCitations, getAllSources } from "./api";
+```
+
+**b)** In `renderGrounding`, remove the `unverified` variable, update the null guard, and delete the Unverified section push:
+
+```typescript
+// BEFORE (lines ~259-288):
+const unverified = getUngroundedSpans(response);
+if (!sources.length && !queries.length && !unverified.length && !codePairs.length) {
+  return null;
+}
+// ...
+if (unverified.length) {
+  sections.push(`Unverified:\n${unverified.map((s) => `• "${s.text}"`).join("\n")}`);
+}
+
+// AFTER:
+// (delete unverified line, simplify null guard, delete unverified section push)
+if (!sources.length && !queries.length && !codePairs.length) {
+  return null;
+}
+```
+
+### Step 3: Remove `getUngroundedSpans` tests from `__tests__/api.test.ts`
+
+**a)** Remove `getUngroundedSpans` from the import line.
+
+**b)** Delete the entire `describe("getUngroundedSpans", ...)` block (~10 tests, lines ~364-511).
+
+### Step 4: Run tests
+
+```bash
+npm test
+```
+
+Expected: all pass (fewer tests — the `getUngroundedSpans` suite is gone).
+
+### Step 5: Typecheck
+
+```bash
+npm run typecheck
+```
+
+Expected: passes.
+
+### Step 6: Commit
+
+```bash
+git add src/server/api.ts src/server/index.ts __tests__/api.test.ts
+git commit -m "refactor: remove getUngroundedSpans — Unverified section dropped from grounding column"
+```
+
+---
+
+## Task 2: Create `src/server/rich-text.ts` with `CellContent`/`TextRange` and all pure cell-building logic
+
+**Files:**
+- Create: `src/server/rich-text.ts`
+- Create: `__tests__/rich-text.test.ts`
+
+This task introduces the new module with full TDD. All five user refinements (remove Unverified, query hyperlinks, code execution format, markdown rendering, and the groundwork for checkbox UX) are implemented here as pure logic that never touches GAS globals.
+
+### Core interfaces
+
+```typescript
+// CellContent describes everything needed to build one Sheets cell.
+// text: the full string content (markdown stripped, if applicable).
+// ranges: character ranges that carry links and/or text styles.
+//
+// A single TextRange may carry both url and bold/italic — toCellValue in
+// index.ts will call setLinkUrl and setTextStyle separately for the range.
+export interface TextRange {
+  startIndex: number; // inclusive
+  endIndex: number;   // exclusive
+  bold?: boolean;
+  italic?: boolean;
+  url?: string;
+}
+
+export interface CellContent {
+  text: string;
+  ranges: TextRange[];
+}
+```
+
+### Private helpers (not exported)
+
+**`parseMarkdown`** strips `**bold**`, `*italic*`, `# Heading` from text, returns:
+- `cleanText` — markers removed
+- `ranges` — `TextRange[]` with `bold`/`italic` flags, positions in `cleanText`
+- `mapIndex(originalIdx)` — remaps a character index in the original text to `cleanText`
+
+**`getCitations`** (moved from `api.ts`) resolves `groundingSupports` into `{ startIndex, endIndex, sources }[]`.
+
+**`getAllSources`** (moved from `api.ts`) returns flat `{ uri, title }[]` from `groundingChunks`.
+
+### Public functions
+
+**`buildInferenceCellContent(response: GeminiResponse): CellContent`**
+
+Steps:
+1. Call `parseMarkdown(response.text)` → `{ cleanText, ranges: mdRanges, mapIndex }`
+2. Call `getCitations(response)`, sort by `startIndex`, merge overlapping ranges (keeping first source URI), remap `startIndex`/`endIndex` through `mapIndex`
+3. Skip merged ranges where `cleanStart >= cleanEnd`
+4. Return `{ text: cleanText, ranges: [...mdRanges, ...citationRanges] }`
+
+**`buildGroundingCellContent(response: GeminiResponse): CellContent | null`**
+
+Steps:
+1. `sources = getAllSources(response)`, `queries = response.groundingMetadata?.webSearchQueries ?? []`, `codePairs = response.codePairs ?? []`
+2. If all empty → return `null`
+3. Build `sections: string[]`:
+   - If `codePairs.length > 0`: for each pair, push `Code (lang):\n{code}\n\nOutput:\n{output}` — plain text, no markdown fences (they render literally in Sheets)
+   - Else: if `queries.length`, push `Search queries: "${q1}", "${q2}"`; if `sources.length`, push `Sources (N):\n• Title1\n• Title2`
+4. `fullText = sections.join("\n\n")`
+5. Build `ranges: TextRange[]`:
+   - For each query: find `"${query}"` in fullText starting from the queries section header; add `{ startIndex, endIndex, url: "https://www.google.com/search?q=${encodeURIComponent(query)}" }`
+   - For each source: find `• ${title}` within the Sources section boundaries; add `{ startIndex: bulletIdx+2, endIndex: bulletIdx+2+title.length, url: source.uri }`
+6. Return `{ text: fullText, ranges }`
+
+### Step 1: Write the failing tests in `__tests__/rich-text.test.ts`
+
+```typescript
+/// <reference types="node" />
+import type { GeminiResponse } from "../src/server/types";
+import {
+  buildInferenceCellContent,
+  buildGroundingCellContent,
+  type CellContent,
+  type TextRange,
+} from "../src/server/rich-text";
+
+// ---- helpers ----
+
+function makeResponse(overrides: Partial<GeminiResponse> = {}): GeminiResponse {
+  return { text: "Hello world.", ...overrides };
+}
+
+function makeGroundedResponse(overrides: Partial<GeminiResponse> = {}): GeminiResponse {
+  return {
+    text: "Paris is the capital of France.",
+    groundingMetadata: {
+      groundingChunks: [
+        { web: { uri: "https://example.com/paris", title: "Paris - Wikipedia" } },
+      ],
+      groundingSupports: [
+        { segment: { startIndex: 0, endIndex: 31 }, groundingChunkIndices: [0] },
+      ],
+      webSearchQueries: ["capital of France"],
+    },
+    ...overrides,
+  };
+}
+
+// ============================================================
+// buildInferenceCellContent
+// ============================================================
+
+describe("buildInferenceCellContent", () => {
+  it("returns plain text with no ranges for a simple response", () => {
+    const result = buildInferenceCellContent(makeResponse({ text: "Hello world." }));
+    expect(result.text).toBe("Hello world.");
+    expect(result.ranges).toHaveLength(0);
+  });
+
+  it("strips **bold** markers and produces a bold range", () => {
+    const result = buildInferenceCellContent(makeResponse({ text: "The **sky** is blue." }));
+    expect(result.text).toBe("The sky is blue.");
+    const bold = result.ranges.find((r) => r.bold);
+    expect(bold).toEqual({ startIndex: 4, endIndex: 7, bold: true });
+  });
+
+  it("strips *italic* markers and produces an italic range", () => {
+    const result = buildInferenceCellContent(makeResponse({ text: "A *quick* test." }));
+    expect(result.text).toBe("A quick test.");
+    const italic = result.ranges.find((r) => r.italic);
+    expect(italic).toEqual({ startIndex: 2, endIndex: 7, italic: true });
+  });
+
+  it("strips ## heading prefix and produces a bold range", () => {
+    const result = buildInferenceCellContent(
+      makeResponse({ text: "## Section Title\nBody text." }),
+    );
+    expect(result.text).toBe("Section Title\nBody text.");
+    expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 13, bold: true });
+  });
+
+  it("adds url range for a citation, remapped through markdown position map", () => {
+    // "The **sky** is blue." → cleanText "The sky is blue." (len 16)
+    // groundingSupport: segment 0..15 (covers "The **sky** is" in original)
+    // original idx 0 → clean 0, original idx 15 → clean 11
+    const response = makeResponse({
+      text: "The **sky** is blue.",
+      groundingMetadata: {
+        groundingChunks: [{ web: { uri: "https://example.com", title: "Example" } }],
+        groundingSupports: [{ segment: { startIndex: 0, endIndex: 15 }, groundingChunkIndices: [0] }],
+        webSearchQueries: [],
+      },
+    });
+    const result = buildInferenceCellContent(response);
+    const link = result.ranges.find((r) => r.url);
+    expect(link).toBeDefined();
+    expect(link?.url).toBe("https://example.com");
+    // remapped: 0→0, 15→11
+    expect(link?.startIndex).toBe(0);
+    expect(link?.endIndex).toBe(11);
+  });
+
+  it("merges overlapping citation ranges and keeps the first URI", () => {
+    const response = makeResponse({
+      text: "Hello world.",
+      groundingMetadata: {
+        groundingChunks: [
+          { web: { uri: "https://a.com", title: "A" } },
+          { web: { uri: "https://b.com", title: "B" } },
+        ],
+        groundingSupports: [
+          { segment: { startIndex: 0, endIndex: 8 }, groundingChunkIndices: [0] },
+          { segment: { startIndex: 5, endIndex: 12 }, groundingChunkIndices: [1] },
+        ],
+        webSearchQueries: [],
+      },
+    });
+    const result = buildInferenceCellContent(response);
+    const links = result.ranges.filter((r) => r.url);
+    expect(links).toHaveLength(1);
+    expect(links[0].startIndex).toBe(0);
+    expect(links[0].endIndex).toBe(12);
+    expect(links[0].url).toBe("https://a.com");
+  });
+
+  it("skips citations with no sources", () => {
+    const response = makeResponse({
+      text: "Hello world.",
+      groundingMetadata: {
+        groundingChunks: [],
+        groundingSupports: [{ segment: { startIndex: 0, endIndex: 5 }, groundingChunkIndices: [] }],
+        webSearchQueries: [],
+      },
+    });
+    const result = buildInferenceCellContent(response);
+    expect(result.ranges.filter((r) => r.url)).toHaveLength(0);
+  });
+
+  it("returns text with no ranges when groundingMetadata is absent", () => {
+    const result = buildInferenceCellContent(makeResponse({ text: "Plain text." }));
+    expect(result.ranges.filter((r) => r.url)).toHaveLength(0);
+  });
+});
+
+// ============================================================
+// buildGroundingCellContent
+// ============================================================
+
+describe("buildGroundingCellContent", () => {
+  it("returns null when response has no grounding data", () => {
+    expect(buildGroundingCellContent(makeResponse())).toBeNull();
+  });
+
+  it("returns null when groundingMetadata has empty arrays", () => {
+    const response = makeResponse({
+      groundingMetadata: { groundingChunks: [], groundingSupports: [], webSearchQueries: [] },
+    });
+    expect(buildGroundingCellContent(response)).toBeNull();
+  });
+
+  it("includes search query text and a Google Search url range", () => {
+    const response = makeGroundedResponse();
+    const result = buildGroundingCellContent(response)!;
+    expect(result.text).toContain('"capital of France"');
+    const queryLink = result.ranges.find((r) =>
+      r.url?.startsWith("https://www.google.com/search"),
+    );
+    expect(queryLink).toBeDefined();
+    expect(queryLink?.url).toBe(
+      "https://www.google.com/search?q=capital%20of%20France",
+    );
+    // The link should cover the quoted query text
+    const quotedQuery = '"capital of France"';
+    const idx = result.text.indexOf(quotedQuery);
+    expect(queryLink?.startIndex).toBe(idx);
+    expect(queryLink?.endIndex).toBe(idx + quotedQuery.length);
+  });
+
+  it("includes source title text and a url range pointing to the source URI", () => {
+    const response = makeGroundedResponse();
+    const result = buildGroundingCellContent(response)!;
+    expect(result.text).toContain("Paris - Wikipedia");
+    const sourceLink = result.ranges.find((r) => r.url?.startsWith("https://example.com/paris"));
+    expect(sourceLink).toBeDefined();
+    const titleText = "Paris - Wikipedia";
+    const idx = result.text.indexOf(titleText);
+    expect(sourceLink?.startIndex).toBe(idx);
+    expect(sourceLink?.endIndex).toBe(idx + titleText.length);
+  });
+
+  it("does not include an Unverified section", () => {
+    const response = makeGroundedResponse();
+    const result = buildGroundingCellContent(response)!;
+    expect(result.text).not.toContain("Unverified");
+  });
+
+  it("formats code execution as plain text without markdown fences", () => {
+    const response = makeResponse({
+      codePairs: [
+        {
+          code: { language: "PYTHON", code: "print(1+1)" },
+          result: { outcome: "OUTCOME_OK", output: "2\n" },
+        },
+      ],
+    });
+    const result = buildGroundingCellContent(response)!;
+    expect(result.text).toContain("Code (python):");
+    expect(result.text).toContain("print(1+1)");
+    expect(result.text).toContain("Output:");
+    expect(result.text).toContain("2\n");
+    expect(result.text).not.toContain("```");
+    expect(result.ranges).toHaveLength(0);
+  });
+
+  it("handles multiple sources with individual url ranges", () => {
+    const response = makeResponse({
+      groundingMetadata: {
+        groundingChunks: [
+          { web: { uri: "https://a.com", title: "Site A" } },
+          { web: { uri: "https://b.com", title: "Site B" } },
+        ],
+        groundingSupports: [],
+        webSearchQueries: [],
+      },
+    });
+    const result = buildGroundingCellContent(response)!;
+    const links = result.ranges.filter((r) => r.url);
+    expect(links).toHaveLength(2);
+    expect(links.map((r) => r.url)).toEqual(
+      expect.arrayContaining(["https://a.com", "https://b.com"]),
+    );
+  });
+
+  it("handles multiple search queries with individual url ranges", () => {
+    const response = makeResponse({
+      groundingMetadata: {
+        groundingChunks: [],
+        groundingSupports: [],
+        webSearchQueries: ["query one", "query two"],
+      },
+    });
+    const result = buildGroundingCellContent(response)!;
+    const links = result.ranges.filter((r) => r.url?.includes("google.com"));
+    expect(links).toHaveLength(2);
+    expect(links[0].url).toBe("https://www.google.com/search?q=query%20one");
+    expect(links[1].url).toBe("https://www.google.com/search?q=query%20two");
+  });
+
+  it("returns only code section — no search/source sections — when codePairs present", () => {
+    const response = makeResponse({
+      groundingMetadata: {
+        groundingChunks: [{ web: { uri: "https://x.com", title: "X" } }],
+        groundingSupports: [],
+        webSearchQueries: ["something"],
+      },
+      codePairs: [
+        {
+          code: { language: "PYTHON", code: "x=1" },
+          result: { outcome: "OUTCOME_OK", output: "1" },
+        },
+      ],
+    });
+    const result = buildGroundingCellContent(response)!;
+    expect(result.text).not.toContain("Search queries");
+    expect(result.text).not.toContain("Sources");
+    expect(result.text).toContain("Code");
+  });
+});
+
+// ============================================================
+// parseMarkdown (tested indirectly, but sanity-check edge cases here)
+// ============================================================
+
+describe("buildInferenceCellContent markdown edge cases", () => {
+  it("does not treat unmatched * as italic", () => {
+    const result = buildInferenceCellContent(makeResponse({ text: "Price: $5 * tax" }));
+    expect(result.text).toBe("Price: $5 * tax");
+    expect(result.ranges.filter((r) => r.italic)).toHaveLength(0);
+  });
+
+  it("handles # heading at the very start", () => {
+    const result = buildInferenceCellContent(makeResponse({ text: "# Title" }));
+    expect(result.text).toBe("Title");
+    expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 5, bold: true });
+  });
+
+  it("handles multiple bold spans", () => {
+    const result = buildInferenceCellContent(makeResponse({ text: "**A** and **B**" }));
+    expect(result.text).toBe("A and B");
+    const bold = result.ranges.filter((r) => r.bold);
+    expect(bold).toHaveLength(2);
+    expect(bold[0]).toEqual({ startIndex: 0, endIndex: 1, bold: true });
+    expect(bold[1]).toEqual({ startIndex: 6, endIndex: 7, bold: true });
+  });
+});
+```
+
+### Step 2: Run to confirm failures
+
+```bash
+npx jest __tests__/rich-text.test.ts
+```
+
+Expected: FAIL — module not found.
+
+### Step 3: Create `src/server/rich-text.ts`
+
+```typescript
+/**
+ * rich-text.ts — Pure TypeScript layer between GeminiResponse and Sheets cell content.
+ *
+ * Exports CellContent and TextRange interfaces + two builder functions.
+ * All helpers are private. No GAS globals — fully testable with Jest.
+ *
+ * GAS rendering (toCellValue) lives in index.ts which is excluded from coverage.
+ */
+
+import type { GeminiResponse, GeminiGroundingSupport } from "./types";
+
+// ---- Public interfaces ----
+
+/** A character range within a CellContent's text that carries link and/or style info. */
+export interface TextRange {
+  startIndex: number; // inclusive
+  endIndex: number;   // exclusive
+  bold?: boolean;
+  italic?: boolean;
+  url?: string;
+}
+
+/** Everything needed to construct a Sheets RichTextValue for one cell. */
+export interface CellContent {
+  text: string;
+  ranges: TextRange[];
+}
+
+// ---- Private helpers ----
+
+interface ParsedMarkdown {
+  cleanText: string;
+  /** Style spans (bold/italic) in cleanText coordinates. */
+  ranges: TextRange[];
+  /** Maps a character index in the original text to the corresponding index in cleanText. */
+  mapIndex: (originalIndex: number) => number;
+}
+
+/**
+ * Strip **bold**, *italic*, and # heading markers from text.
+ * Returns the clean string, styled ranges (in cleanText coordinates),
+ * and a function to remap original character indices to cleanText indices.
+ * Unmatched markers are left verbatim.
+ */
+function parseMarkdown(text: string): ParsedMarkdown {
+  const ranges: TextRange[] = [];
+  // posMap[i] = position in cleanText for original character i.
+  const posMap = new Array<number>(text.length + 1).fill(0);
+  const cleanParts: string[] = [];
+  let cleanLen = 0;
+  let i = 0;
+
+  while (i < text.length) {
+    // **bold** — must be checked before single *
+    if (text[i] === "*" && text[i + 1] === "*") {
+      const closeIdx = text.indexOf("**", i + 2);
+      if (closeIdx > i + 2) {
+        posMap[i] = cleanLen;
+        posMap[i + 1] = cleanLen;
+        const spanStart = cleanLen;
+        const content = text.slice(i + 2, closeIdx);
+        for (let j = 0; j < content.length; j++) {
+          posMap[i + 2 + j] = cleanLen + j;
+          cleanParts.push(content[j]);
+        }
+        cleanLen += content.length;
+        posMap[closeIdx] = cleanLen;
+        posMap[closeIdx + 1] = cleanLen;
+        ranges.push({ startIndex: spanStart, endIndex: cleanLen, bold: true });
+        i = closeIdx + 2;
+        continue;
+      }
+    }
+
+    // *italic* — single * with a matching closing *
+    if (text[i] === "*" && text[i + 1] !== "*") {
+      const closeIdx = text.indexOf("*", i + 1);
+      if (closeIdx > i + 1 && text[closeIdx + 1] !== "*") {
+        posMap[i] = cleanLen;
+        const spanStart = cleanLen;
+        const content = text.slice(i + 1, closeIdx);
+        for (let j = 0; j < content.length; j++) {
+          posMap[i + 1 + j] = cleanLen + j;
+          cleanParts.push(content[j]);
+        }
+        cleanLen += content.length;
+        posMap[closeIdx] = cleanLen;
+        ranges.push({ startIndex: spanStart, endIndex: cleanLen, italic: true });
+        i = closeIdx + 1;
+        continue;
+      }
+    }
+
+    // # Heading — only at the start of text or after a newline
+    if (text[i] === "#" && (i === 0 || text[i - 1] === "\n")) {
+      let level = 0;
+      while (i + level < text.length && text[i + level] === "#") level++;
+      if (level >= 1 && level <= 6 && text[i + level] === " ") {
+        const prefixLen = level + 1; // e.g. "## " = 3 chars
+        for (let j = 0; j < prefixLen; j++) posMap[i + j] = cleanLen;
+        const lineEnd = text.indexOf("\n", i + prefixLen);
+        const end = lineEnd === -1 ? text.length : lineEnd;
+        const content = text.slice(i + prefixLen, end);
+        const spanStart = cleanLen;
+        for (let j = 0; j < content.length; j++) {
+          posMap[i + prefixLen + j] = cleanLen + j;
+          cleanParts.push(content[j]);
+        }
+        cleanLen += content.length;
+        ranges.push({ startIndex: spanStart, endIndex: cleanLen, bold: true });
+        i = end;
+        continue;
+      }
+    }
+
+    // Plain character — pass through verbatim
+    posMap[i] = cleanLen;
+    cleanParts.push(text[i]);
+    cleanLen++;
+    i++;
+  }
+  posMap[text.length] = cleanLen;
+
+  const cleanText = cleanParts.join("");
+  const mapIndex = (idx: number): number =>
+    posMap[Math.min(Math.max(0, idx), text.length)];
+
+  return { cleanText, ranges, mapIndex };
+}
+
+interface CitationRange {
+  startIndex: number;
+  endIndex: number;
+  sources: Array<{ uri: string; title: string }>;
+}
+
+/** Resolve groundingSupports entries into citation ranges with sources. */
+function getCitations(response: GeminiResponse): CitationRange[] {
+  const supports = response.groundingMetadata?.groundingSupports ?? [];
+  const chunks = response.groundingMetadata?.groundingChunks ?? [];
+  return supports.map((s: GeminiGroundingSupport) => ({
+    startIndex: s.segment.startIndex,
+    endIndex: s.segment.endIndex,
+    sources: s.groundingChunkIndices
+      .map((i) => {
+        const chunk = chunks[i];
+        return chunk?.web ?? chunk?.retrievedContext ?? null;
+      })
+      .filter((src): src is { uri: string; title: string } => src !== null),
+  }));
+}
+
+/** Return all grounding sources as a flat { uri, title } array. */
+function getAllSources(response: GeminiResponse): Array<{ uri: string; title: string }> {
+  return (response.groundingMetadata?.groundingChunks ?? [])
+    .map((chunk) => chunk.web ?? chunk.retrievedContext ?? null)
+    .filter((src): src is { uri: string; title: string } => src !== null);
+}
+
+// ---- Public builders ----
+
+/**
+ * Build a CellContent for the AI inference output column.
+ * Strips markdown, applies bold/italic ranges, and hyperlinks cited text
+ * to the first source URI for each support segment.
+ */
+export function buildInferenceCellContent(response: GeminiResponse): CellContent {
+  const { cleanText, ranges: mdRanges, mapIndex } = parseMarkdown(response.text);
+
+  // Sort citations and merge overlapping ranges (Gemini can return overlapping supports).
+  const citations = getCitations(response).sort((a, b) => a.startIndex - b.startIndex);
+  const merged: Array<{ startIndex: number; endIndex: number; url: string }> = [];
+  for (const { startIndex, endIndex, sources } of citations) {
+    if (!sources[0]) continue;
+    const cleanStart = mapIndex(startIndex);
+    const cleanEnd = mapIndex(endIndex);
+    if (cleanStart >= cleanEnd) continue;
+    const last = merged[merged.length - 1];
+    if (last && cleanStart < last.endIndex) {
+      last.endIndex = Math.max(last.endIndex, cleanEnd);
+    } else {
+      merged.push({ startIndex: cleanStart, endIndex: cleanEnd, url: sources[0].uri });
+    }
+  }
+
+  const citationRanges: TextRange[] = merged.map(({ startIndex, endIndex, url }) => ({
+    startIndex,
+    endIndex,
+    url,
+  }));
+
+  return { text: cleanText, ranges: [...mdRanges, ...citationRanges] };
+}
+
+/**
+ * Build a CellContent for the grounding metadata column.
+ * Returns null when there is no grounding data to show (caller should skip the cell).
+ *
+ * Sections:
+ * - Code execution: plain-text code/output pairs (no markdown fences)
+ * - OR: Search queries (hyperlinked to Google Search) + Sources (hyperlinked titles)
+ */
+export function buildGroundingCellContent(response: GeminiResponse): CellContent | null {
+  const sources = getAllSources(response);
+  const queries = response.groundingMetadata?.webSearchQueries ?? [];
+  const codePairs = response.codePairs ?? [];
+
+  if (!sources.length && !queries.length && !codePairs.length) {
+    return null;
+  }
+
+  const sections: string[] = [];
+
+  if (codePairs.length > 0) {
+    // Plain-text format — markdown fences render literally in Sheets cells.
+    codePairs.forEach(({ code, result }) => {
+      const lang = code.language ? `(${code.language.toLowerCase()})` : "";
+      sections.push(`Code ${lang}:\n${code.code}\n\nOutput:\n${result.output}`);
+    });
+    return { text: sections.join("\n\n"), ranges: [] };
+  }
+
+  if (queries.length) {
+    sections.push(`Search queries: ${queries.map((q) => `"${q}"`).join(", ")}`);
+  }
+  if (sources.length) {
+    sections.push(
+      `Sources (${sources.length}):\n${sources.map((s) => `• ${s.title}`).join("\n")}`,
+    );
+  }
+
+  const fullText = sections.join("\n\n");
+  const ranges: TextRange[] = [];
+
+  // Hyperlink each quoted query to a Google Search.
+  if (queries.length) {
+    const queriesHeader = "Search queries: ";
+    const queriesSectionStart = fullText.indexOf(queriesHeader);
+    if (queriesSectionStart >= 0) {
+      queries.forEach((q) => {
+        const quoted = `"${q}"`;
+        const idx = fullText.indexOf(quoted, queriesSectionStart);
+        if (idx !== -1) {
+          const url = `https://www.google.com/search?q=${encodeURIComponent(q)}`;
+          ranges.push({ startIndex: idx, endIndex: idx + quoted.length, url });
+        }
+      });
+    }
+  }
+
+  // Hyperlink source titles within the Sources section only.
+  if (sources.length) {
+    const sourcesHeader = `Sources (${sources.length}):`;
+    const sourceSectionStart = fullText.indexOf(sourcesHeader);
+    const sourceSectionEnd =
+      sourceSectionStart >= 0
+        ? (() => {
+            const next = fullText.indexOf("\n\n", sourceSectionStart + sourcesHeader.length);
+            return next !== -1 ? next : fullText.length;
+          })()
+        : -1;
+
+    if (sourceSectionStart >= 0) {
+      sources.forEach(({ uri, title }) => {
+        const bullet = `• ${title}`;
+        const idx = fullText.indexOf(bullet, sourceSectionStart);
+        if (idx !== -1 && idx < sourceSectionEnd) {
+          ranges.push({ startIndex: idx + 2, endIndex: idx + 2 + title.length, url: uri });
+        }
+      });
+    }
+  }
+
+  return { text: fullText, ranges };
+}
+```
+
+### Step 4: Run tests
+
+```bash
+npx jest __tests__/rich-text.test.ts
+```
+
+Expected: all tests pass.
+
+### Step 5: Run full test suite
+
+```bash
+npm test
+```
+
+Expected: all pass.
+
+### Step 6: Typecheck
+
+```bash
+npm run typecheck
+```
+
+Expected: passes.
+
+### Step 7: Commit
+
+```bash
+git add src/server/rich-text.ts __tests__/rich-text.test.ts
+git commit -m "feat: add rich-text.ts — pure CellContent/TextRange builders for inference and grounding cells"
+```
+
+---
+
+## Task 3: Strip `api.ts` to HTTP adapter — move `getCitations`/`getAllSources` tests to `rich-text.test.ts`
+
+**Files:**
+- Modify: `src/server/api.ts`
+- Modify: `__tests__/api.test.ts`
+
+`getCitations` and `getAllSources` are now private in `rich-text.ts`. Remove them from `api.ts` and their tests from `api.test.ts`. The `Citation` type becomes an internal detail of `rich-text.ts`.
+
+**Note:** `rich-text.test.ts` already tests `getCitations`/`getAllSources` indirectly through `buildInferenceCellContent` and `buildGroundingCellContent`. No new tests needed here.
+
+### Step 1: Remove from `src/server/api.ts`
+
+Delete:
+- `Citation` interface (lines ~25-29)
+- `getCitations` function and its JSDoc (lines ~203-220)
+- `getAllSources` function and its JSDoc (lines ~192-201)
+- `GeminiGroundingSupport` import (it is no longer used in api.ts after removing `getCitations`)
+
+After removal, `api.ts` exports only: `buildGeminiPayload`, `callGeminiAPI`, `invokeGemini`.
+
+### Step 2: Remove from `__tests__/api.test.ts`
+
+**a)** Remove `getCitations` and `getAllSources` from the import line.
+
+**b)** Delete the entire `describe("getCitations", ...)` block.
+
+**c)** Delete the entire `describe("getAllSources", ...)` block.
+
+### Step 3: Run tests
+
+```bash
+npm test
+```
+
+Expected: all pass.
+
+### Step 4: Typecheck
+
+```bash
+npm run typecheck
+```
+
+Expected: passes.
+
+### Step 5: Commit
+
+```bash
+git add src/server/api.ts __tests__/api.test.ts
+git commit -m "refactor: strip api.ts to pure HTTP adapter — getCitations/getAllSources moved to rich-text.ts"
+```
+
+---
+
+## Task 4: Update `index.ts` — `toCellValue` wrapper + wire `runBatchAI` to `rich-text.ts`
+
+**Files:**
+- Modify: `src/server/index.ts`
+
+No new tests — `index.ts` is excluded from coverage. Verified by typecheck + build.
+
+### Step 1: Update imports
+
+**a)** Replace the `api.ts` grounding import:
+```typescript
+// REMOVE:
+import { getCitations, getAllSources } from "./api";  // (whatever remains after Task 3)
+
+// ADD:
+import { buildInferenceCellContent, buildGroundingCellContent } from "./rich-text";
+```
+
+The `runInference` import from `./inference` stays as-is.
+
+### Step 2: Replace `renderInference` and `renderGrounding` with `toCellValue`
+
+Delete both `renderInference` and `renderGrounding` functions entirely. Add `toCellValue` in their place:
+
+```typescript
+/**
+ * Convert a pure CellContent descriptor into a GAS RichTextValue.
+ * Each TextRange may carry url (setLinkUrl) and/or bold/italic (setTextStyle) — both are applied.
+ */
+function toCellValue(content: import("./rich-text").CellContent): GoogleAppsScript.Spreadsheet.RichTextValue {
+  const builder = SpreadsheetApp.newRichTextValue().setText(content.text);
+  content.ranges.forEach(({ startIndex, endIndex, bold, italic, url }) => {
+    if (bold || italic) {
+      const style = SpreadsheetApp.newTextStyle();
+      if (bold) style.setBold(true);
+      if (italic) style.setItalic(true);
+      builder.setTextStyle(startIndex, endIndex, style.build());
+    }
+    if (url) builder.setLinkUrl(startIndex, endIndex, url);
+  });
+  return builder.build();
+}
+```
+
+**Note on the import:** add `CellContent` to the `rich-text` import line at the top of the file:
+```typescript
+import { buildInferenceCellContent, buildGroundingCellContent, type CellContent } from "./rich-text";
+```
+
+Then use `CellContent` as the parameter type:
+```typescript
+function toCellValue(content: CellContent): GoogleAppsScript.Spreadsheet.RichTextValue {
+```
+
+### Step 3: Update `runBatchAI` to use `buildInferenceCellContent`/`buildGroundingCellContent`/`toCellValue`
+
+In the per-row try/catch block (lines ~422-434), replace:
+```typescript
+// BEFORE:
+sheet.getRange(realRowIndex, outputIdx + 1).setRichTextValue(renderInference(result));
+if (config.includeGrounding && groundingIdx >= 0) {
+  const groundingValue = renderGrounding(result);
+  if (groundingValue !== null) {
+    sheet.getRange(realRowIndex, groundingIdx + 1).setRichTextValue(groundingValue);
+  }
+}
+```
+
+With:
+```typescript
+// AFTER:
+sheet.getRange(realRowIndex, outputIdx + 1).setRichTextValue(toCellValue(buildInferenceCellContent(result)));
+
+if (config.includeGrounding && groundingIdx >= 0) {
+  const groundingContent = buildGroundingCellContent(result);
+  if (groundingContent !== null) {
+    sheet.getRange(realRowIndex, groundingIdx + 1).setRichTextValue(toCellValue(groundingContent));
+  }
+}
+```
+
+The fallback in the catch block stays as-is:
+```typescript
+} catch (_e) {
+  sheet.getRange(realRowIndex, outputIdx + 1).setValue(result.text);
+}
+```
+
+### Step 4: Typecheck
+
+```bash
+npm run typecheck
+```
+
+Expected: passes.
+
+### Step 5: Build
+
+```bash
+npm run build
+```
+
+Expected: clean build, no warnings.
+
+### Step 6: Run full test suite
+
+```bash
+npm test
+```
+
+Expected: all pass.
+
+### Step 7: Commit
+
+```bash
+git add src/server/index.ts
+git commit -m "refactor: replace renderInference/renderGrounding with toCellValue(buildInferenceCellContent/buildGroundingCellContent)"
+```
+
+---
+
+## Task 5: Grounding checkbox UX — move into Tools group, conditional visibility
+
+**Files:**
+- Modify: `src/client/panels/configure-ai-run.ts`
+- Modify: `src/client/sidebar.css`
+- Modify: `__tests__/panels/configure-ai-run.test.ts`
+
+### Step 1: Write failing tests
+
+Read `__tests__/panels/configure-ai-run.test.ts` first to understand `mountAndLoad`, `applyPreset`, and the existing 6 tests in the `"includeGrounding checkbox"` describe block.
+
+Add these tests after the existing 6 in that describe block:
+
+```typescript
+it("hides the grounding group when no tools are selected", async () => {
+  const { container } = await mountAndLoad();
+  const group = container.querySelector<HTMLElement>("#include-grounding-group");
+  expect(group?.style.display).toBe("none");
+});
+
+it("shows the grounding group when a tool is selected", async () => {
+  const { container } = await mountAndLoad();
+  container.querySelector<HTMLElement>("#tools-list .tag")?.click();
+  const group = container.querySelector<HTMLElement>("#include-grounding-group");
+  expect(group?.style.display).toBe("block");
+});
+
+it("shows the grounding group on mount when tools are pre-selected in savedState", async () => {
+  const { container } = await mountAndLoad(undefined, {
+    userPromptCols: ["col_a"],
+    driveFileCols: [],
+    systemPromptCol: "",
+    outputCol: "ai_inference",
+    tools: ["google_search"],
+    includeGrounding: false,
+  });
+  const group = container.querySelector<HTMLElement>("#include-grounding-group");
+  expect(group?.style.display).toBe("block");
+});
+
+it("hides the grounding group again when all tools are deselected", async () => {
+  const { container } = await mountAndLoad();
+  const tag = container.querySelector<HTMLElement>("#tools-list .tag")!;
+  tag.click(); // select
+  tag.click(); // deselect
+  const group = container.querySelector<HTMLElement>("#include-grounding-group");
+  expect(group?.style.display).toBe("none");
+});
+```
+
+Also update the existing `"restores includeGrounding from savedState"` test to include a tool (so the group is visible when restoring):
+
+```typescript
+it("restores includeGrounding from savedState", async () => {
+  const { container } = await mountAndLoad(undefined, {
+    userPromptCols: ["col_a"],
+    driveFileCols: [],
+    systemPromptCol: "",
+    outputCol: "ai_inference",
+    tools: ["google_search"],   // ← add this
+    includeGrounding: true,
+  });
+  const cb = container.querySelector<HTMLInputElement>("#include-grounding-cb")!;
+  expect(cb.checked).toBe(true);
+});
+```
+
+### Step 2: Run to confirm failures
+
+```bash
+npx jest __tests__/panels/configure-ai-run.test.ts -t "includeGrounding"
+```
+
+Expected: 4 new tests FAIL (`#include-grounding-group` not found or always visible).
+
+### Step 3: Update `template()` in `configure-ai-run.ts`
+
+Move the checkbox inside the Tools field-group. Replace:
+
+```html
+<!-- REMOVE: -->
+<div class="field-group">
+  <span class="field-label">Tools <span class="optional">(optional)</span></span>
+  <div id="tools-list" class="tag-list"></div>
+</div>
+<div class="field-group">
+  <label class="checkbox-label">
+    <input type="checkbox" id="include-grounding-cb" />
+    Include sources column (<span id="grounding-col-name">_grounding</span>)
+  </label>
+</div>
+```
+
+With:
+
+```html
+<!-- REPLACE with: -->
+<div class="field-group">
+  <span class="field-label">Tools <span class="optional">(optional)</span></span>
+  <div id="tools-list" class="tag-list"></div>
+  <div id="include-grounding-group" style="display:none">
+    <label class="grounding-hint">
+      <input type="checkbox" id="include-grounding-cb" />
+      Include sources column (<span id="grounding-col-name">_grounding</span>)
+    </label>
+  </div>
+</div>
+```
+
+### Step 4: Move checkbox initialization to synchronous scope in `mount()`
+
+The checkbox is now outside the async headers callback — initialize it synchronously alongside `this.toolsList`.
+
+**a)** Delete the `this.includeGroundingCb` initialization block from inside `getSheetHeaders().then()` (the lines that read the `#include-grounding-cb` element and set `checked`).
+
+**b)** After the `this.toolsList = new TagList(...)` block, add:
+
+```typescript
+this.includeGroundingCb =
+  container.querySelector<HTMLInputElement>("#include-grounding-cb");
+if (this.includeGroundingCb && preset.includeGrounding) {
+  this.includeGroundingCb.checked = true;
+}
+
+const updateGroundingVisibility = (): void => {
+  const group = container.querySelector<HTMLElement>("#include-grounding-group");
+  if (group) {
+    group.style.display = (this.toolsList?.getValue().length ?? 0) > 0 ? "block" : "none";
+  }
+};
+updateGroundingVisibility();
+container.querySelector("#tools-list")?.addEventListener("click", updateGroundingVisibility);
+```
+
+**c)** Keep `updateGroundingLabel` in the async `getSheetHeaders().then()` callback — it depends on `this.outputColList` which is initialized there.
+
+### Step 5: Add `.grounding-hint` CSS to `src/client/sidebar.css`
+
+Add after the `.field-group` rule (read the file first to find the right location):
+
+```css
+.grounding-hint {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    color: var(--text-secondary);
+    margin-top: 8px;
+    cursor: pointer;
+}
+```
+
+### Step 6: Run tests
+
+```bash
+npx jest __tests__/panels/configure-ai-run.test.ts
+```
+
+Expected: all pass.
+
+### Step 7: Typecheck
+
+```bash
+npm run typecheck
+```
+
+Expected: passes.
+
+### Step 8: Run full suite
+
+```bash
+npm test
+```
+
+Expected: all pass.
+
+### Step 9: Commit
+
+```bash
+git add src/client/panels/configure-ai-run.ts src/client/sidebar.css __tests__/panels/configure-ai-run.test.ts
+git commit -m "feat: move grounding checkbox into Tools section with conditional visibility"
+```
+
+---
+
+## Task 6: Full verification
+
+### Step 1: Coverage
+
+```bash
+npm run test:coverage
+```
+
+Expected: all pass, per-file thresholds met.
+
+**Note:** `src/server/rich-text.ts` is a new file. Check if the per-file coverage threshold in `jest.config.cjs` needs a new entry for it. If coverage is already above threshold from the tests written in Task 2, no change needed. If the threshold file has explicit per-file overrides, add `rich-text.ts` there.
+
+### Step 2: Build
+
+```bash
+npm run build
+```
+
+Expected: clean build, no warnings.
+
+### Step 3: Lint and format check
+
+```bash
+npm run lint && npm run format:check
+```
+
+Expected: no issues. If lint flags explicit return types on the new functions, add them. If Prettier flags formatting in `rich-text.ts`, run `npm run format` then re-check.
+
+### Step 4: Typecheck
+
+```bash
+npm run typecheck
+```
+
+Expected: passes.

--- a/docs/plans/2026-03-05-grounding-metadata-presentation.md
+++ b/docs/plans/2026-03-05-grounding-metadata-presentation.md
@@ -1,0 +1,890 @@
+# Grounding Metadata Presentation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Render Gemini grounding metadata into the spreadsheet — inline source hyperlinks in the output cell via `RichTextValue`, and an optional `{outputCol}_grounding` column with full provenance (search queries, clickable source list, unverified claims).
+
+**Architecture:** Three pure helpers (`getCitations`, `getUngroundedSpans`, `getAllSources`) live in `api.ts` and are fully unit-tested. Two GAS renderers (`renderInference`, `renderGrounding`) live in `index.ts` and call those helpers to build `RichTextValue` objects. `runBatchAI` uses `setRichTextValue` instead of `setValue`. A checkbox in `ConfigureAIRunPanel` gates the grounding column via `RunConfig.includeGrounding`.
+
+**Tech Stack:** TypeScript, Jest/jsdom, Google Apps Script (`SpreadsheetApp.newRichTextValue`)
+
+---
+
+## Reference: `GeminiResponse` shape (already exists in `src/server/types.ts`)
+
+```typescript
+interface GeminiGroundingChunk {
+  web?: { uri: string; title: string };
+  retrievedContext?: { uri: string; title: string };
+}
+interface GeminiGroundingMetadata {
+  webSearchQueries?: string[];
+  groundingChunks?: GeminiGroundingChunk[];
+  // groundingSupports added in Task 1
+}
+interface GeminiResponse {
+  text: string;
+  groundingMetadata?: GeminiGroundingMetadata;
+  codePairs?: GeminiCodePair[];
+}
+```
+
+---
+
+### Task 1: Add `GeminiGroundingSupport` type and `includeGrounding` to `RunConfig`
+
+**Files:**
+- Modify: `src/server/types.ts`
+- Modify: `src/shared/types.ts`
+
+No tests — pure type changes. TypeScript enforces correctness at compile time.
+
+**Step 1: Add `GeminiGroundingSupport` to `src/server/types.ts`**
+
+Add this interface after `GeminiGroundingChunk` (around line 39), then add `groundingSupports` to `GeminiGroundingMetadata`:
+
+```typescript
+export interface GeminiGroundingSupport {
+  segment: {
+    startIndex: number;
+    endIndex: number;
+    text: string;
+  };
+  groundingChunkIndices: number[];
+  confidenceScores?: number[];
+}
+```
+
+Update `GeminiGroundingMetadata`:
+
+```typescript
+export interface GeminiGroundingMetadata {
+  webSearchQueries?: string[];
+  groundingChunks?: GeminiGroundingChunk[];
+  groundingSupports?: GeminiGroundingSupport[];
+}
+```
+
+**Step 2: Add `includeGrounding` to `RunConfig` in `src/shared/types.ts`**
+
+```typescript
+export interface RunConfig {
+  userPromptCols: string[];
+  driveFileCols?: string[];
+  systemPromptCol?: string;
+  outputCol: string;
+  rowRange?: { start: number; end: number };
+  tools?: ToolId[];
+  /** When true, runBatchAI writes a {outputCol}_grounding column with source attribution. */
+  includeGrounding?: boolean;
+}
+```
+
+**Step 3: Typecheck**
+
+```bash
+npm run typecheck
+```
+Expected: passes. `callGeminiAPI` already spreads `groundingMetadata` from the raw JSON, so `groundingSupports` will be captured automatically — no parser change needed.
+
+**Step 4: Commit**
+
+```bash
+git add src/server/types.ts src/shared/types.ts
+git commit -m "feat: add GeminiGroundingSupport type and RunConfig.includeGrounding"
+```
+
+---
+
+### Task 2: Add `getCitations` to `api.ts`
+
+**Files:**
+- Modify: `src/server/api.ts`
+- Modify: `__tests__/api.test.ts`
+
+**Step 1: Write the failing tests**
+
+Add a new describe block at the end of `__tests__/api.test.ts`. Update the import line to include the new exports:
+
+```typescript
+import { buildGeminiPayload, callGeminiAPI, invokeGemini, getCitations } from "../src/server/api";
+import type { GeminiResponse } from "../src/server/types";
+```
+
+```typescript
+describe("getCitations", () => {
+  it("returns empty array when no groundingMetadata", () => {
+    expect(getCitations({ text: "hello" })).toEqual([]);
+  });
+
+  it("returns empty array when groundingSupports is absent", () => {
+    expect(
+      getCitations({
+        text: "hello",
+        groundingMetadata: {
+          groundingChunks: [{ web: { uri: "https://a.com", title: "A" } }],
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("maps a single support entry to a citation with resolved sources", () => {
+    const response: GeminiResponse = {
+      text: "The sky is blue.",
+      groundingMetadata: {
+        groundingChunks: [
+          { web: { uri: "https://a.com", title: "Source A" } },
+          { web: { uri: "https://b.com", title: "Source B" } },
+        ],
+        groundingSupports: [
+          {
+            segment: { startIndex: 4, endIndex: 10, text: "sky is" },
+            groundingChunkIndices: [0, 1],
+          },
+        ],
+      },
+    };
+    const citations = getCitations(response);
+    expect(citations).toHaveLength(1);
+    expect(citations[0].startIndex).toBe(4);
+    expect(citations[0].endIndex).toBe(10);
+    expect(citations[0].sources).toEqual([
+      { uri: "https://a.com", title: "Source A" },
+      { uri: "https://b.com", title: "Source B" },
+    ]);
+  });
+
+  it("resolves retrievedContext chunks (url_context) the same way", () => {
+    const response: GeminiResponse = {
+      text: "Some claim.",
+      groundingMetadata: {
+        groundingChunks: [
+          { retrievedContext: { uri: "https://c.com", title: "Source C" } },
+        ],
+        groundingSupports: [
+          {
+            segment: { startIndex: 0, endIndex: 4, text: "Some" },
+            groundingChunkIndices: [0],
+          },
+        ],
+      },
+    };
+    expect(getCitations(response)[0].sources[0]).toEqual({
+      uri: "https://c.com",
+      title: "Source C",
+    });
+  });
+
+  it("skips chunk indices that point to chunks with neither web nor retrievedContext", () => {
+    const response: GeminiResponse = {
+      text: "text",
+      groundingMetadata: {
+        groundingChunks: [{}],
+        groundingSupports: [
+          {
+            segment: { startIndex: 0, endIndex: 4, text: "text" },
+            groundingChunkIndices: [0],
+          },
+        ],
+      },
+    };
+    expect(getCitations(response)[0].sources).toEqual([]);
+  });
+});
+```
+
+**Step 2: Run to confirm failures**
+
+```bash
+npx jest __tests__/api.test.ts -t "getCitations"
+```
+Expected: FAIL — `getCitations` not exported.
+
+**Step 3: Add `Citation` interface and `getCitations` to `src/server/api.ts`**
+
+Add the `Citation` interface and type import before `buildGeminiPayload`. Update the import at the top to include the new types:
+
+```typescript
+import type {
+  GeminiInlineData,
+  GeminiRequest,
+  GeminiResponse,
+  GeminiCodePair,
+  GeminiGroundingSupport,
+} from "./types";
+
+export interface Citation {
+  startIndex: number;
+  endIndex: number;
+  sources: Array<{ uri: string; title: string }>;
+}
+```
+
+Add after `invokeGemini`:
+
+```typescript
+/**
+ * Resolve groundingSupports entries into Citation objects with sources
+ * joined from groundingChunks by index. Pure — no GAS globals.
+ */
+export function getCitations(response: GeminiResponse): Citation[] {
+  const supports = response.groundingMetadata?.groundingSupports ?? [];
+  const chunks = response.groundingMetadata?.groundingChunks ?? [];
+  return supports.map((s: GeminiGroundingSupport) => ({
+    startIndex: s.segment.startIndex,
+    endIndex: s.segment.endIndex,
+    sources: s.groundingChunkIndices
+      .map((i) => {
+        const chunk = chunks[i];
+        return chunk?.web ?? chunk?.retrievedContext ?? null;
+      })
+      .filter((src): src is { uri: string; title: string } => src !== null),
+  }));
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+npx jest __tests__/api.test.ts -t "getCitations"
+```
+Expected: all pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/server/api.ts __tests__/api.test.ts
+git commit -m "feat: add getCitations pure helper to api.ts"
+```
+
+---
+
+### Task 3: Add `getUngroundedSpans` to `api.ts`
+
+**Files:**
+- Modify: `src/server/api.ts`
+- Modify: `__tests__/api.test.ts`
+
+**Step 1: Write the failing tests**
+
+Update the import line:
+
+```typescript
+import { buildGeminiPayload, callGeminiAPI, invokeGemini, getCitations, getUngroundedSpans } from "../src/server/api";
+```
+
+```typescript
+describe("getUngroundedSpans", () => {
+  it("returns empty array when no groundingMetadata", () => {
+    expect(getUngroundedSpans({ text: "hello" })).toEqual([]);
+  });
+
+  it("returns empty array when groundingSupports is absent", () => {
+    expect(
+      getUngroundedSpans({
+        text: "hello",
+        groundingMetadata: { groundingChunks: [] },
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns the full text as ungrounded when groundingSupports is empty array", () => {
+    const spans = getUngroundedSpans({
+      text: "Nothing is grounded.",
+      groundingMetadata: { groundingSupports: [] },
+    });
+    expect(spans).toEqual([]);
+  });
+
+  it("finds a gap before the first support", () => {
+    const spans = getUngroundedSpans({
+      text: "Preamble. Cited claim.",
+      groundingMetadata: {
+        groundingSupports: [
+          { segment: { startIndex: 10, endIndex: 22, text: "Cited claim." }, groundingChunkIndices: [0] },
+        ],
+      },
+    });
+    expect(spans).toHaveLength(1);
+    expect(spans[0].text).toBe("Preamble.");
+    expect(spans[0].startIndex).toBe(0);
+    expect(spans[0].endIndex).toBe(10);
+  });
+
+  it("finds a gap after the last support", () => {
+    const spans = getUngroundedSpans({
+      text: "Cited claim. Trailing remark.",
+      groundingMetadata: {
+        groundingSupports: [
+          { segment: { startIndex: 0, endIndex: 12, text: "Cited claim." }, groundingChunkIndices: [0] },
+        ],
+      },
+    });
+    expect(spans).toHaveLength(1);
+    expect(spans[0].text).toBe("Trailing remark.");
+  });
+
+  it("finds a gap between two non-overlapping supports", () => {
+    const spans = getUngroundedSpans({
+      text: "First. Gap text. Second.",
+      groundingMetadata: {
+        groundingSupports: [
+          { segment: { startIndex: 0, endIndex: 6, text: "First." }, groundingChunkIndices: [0] },
+          { segment: { startIndex: 17, endIndex: 24, text: "Second." }, groundingChunkIndices: [1] },
+        ],
+      },
+    });
+    expect(spans).toHaveLength(1);
+    expect(spans[0].text).toBe("Gap text.");
+  });
+
+  it("merges overlapping supports before finding gaps", () => {
+    // Two supports that overlap — should produce one merged covered region
+    const spans = getUngroundedSpans({
+      text: "AAAABBBBCCCC",
+      groundingMetadata: {
+        groundingSupports: [
+          { segment: { startIndex: 0, endIndex: 8, text: "AAAABBBB" }, groundingChunkIndices: [0] },
+          { segment: { startIndex: 4, endIndex: 12, text: "BBBBCCCC" }, groundingChunkIndices: [1] },
+        ],
+      },
+    });
+    expect(spans).toEqual([]); // fully covered
+  });
+
+  it("skips whitespace-only gaps", () => {
+    const spans = getUngroundedSpans({
+      text: "First.   Second.",
+      groundingMetadata: {
+        groundingSupports: [
+          { segment: { startIndex: 0, endIndex: 6, text: "First." }, groundingChunkIndices: [0] },
+          { segment: { startIndex: 9, endIndex: 16, text: "Second." }, groundingChunkIndices: [1] },
+        ],
+      },
+    });
+    expect(spans).toEqual([]); // gap is only whitespace
+  });
+});
+```
+
+**Step 2: Run to confirm failures**
+
+```bash
+npx jest __tests__/api.test.ts -t "getUngroundedSpans"
+```
+Expected: FAIL.
+
+**Step 3: Add `Span` interface and `getUngroundedSpans` to `src/server/api.ts`**
+
+Add `Span` interface alongside `Citation`:
+
+```typescript
+export interface Span {
+  startIndex: number;
+  endIndex: number;
+  text: string;
+}
+```
+
+Add after `getCitations`:
+
+```typescript
+/**
+ * Find regions of response.text NOT covered by any groundingSupports segment.
+ * These are claims the model made without citation evidence. Pure — no GAS globals.
+ */
+export function getUngroundedSpans(response: GeminiResponse): Span[] {
+  const supports = response.groundingMetadata?.groundingSupports;
+  if (!supports || supports.length === 0) return [];
+
+  // Sort by startIndex, then merge overlapping/adjacent intervals
+  const sorted = [...supports].sort(
+    (a, b) => a.segment.startIndex - b.segment.startIndex,
+  );
+  const merged: Array<{ start: number; end: number }> = [];
+  for (const s of sorted) {
+    const last = merged[merged.length - 1];
+    if (last && s.segment.startIndex <= last.end) {
+      last.end = Math.max(last.end, s.segment.endIndex);
+    } else {
+      merged.push({ start: s.segment.startIndex, end: s.segment.endIndex });
+    }
+  }
+
+  // Find gaps between merged covered intervals
+  const gaps: Span[] = [];
+  let cursor = 0;
+  for (const { start, end } of merged) {
+    if (cursor < start) {
+      const gapText = response.text.slice(cursor, start).trim();
+      if (gapText) gaps.push({ startIndex: cursor, endIndex: start, text: gapText });
+    }
+    cursor = end;
+  }
+  if (cursor < response.text.length) {
+    const tail = response.text.slice(cursor).trim();
+    if (tail) gaps.push({ startIndex: cursor, endIndex: response.text.length, text: tail });
+  }
+  return gaps;
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+npx jest __tests__/api.test.ts -t "getUngroundedSpans"
+```
+Expected: all pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/server/api.ts __tests__/api.test.ts
+git commit -m "feat: add getUngroundedSpans pure helper to api.ts"
+```
+
+---
+
+### Task 4: Add `getAllSources` to `api.ts`
+
+**Files:**
+- Modify: `src/server/api.ts`
+- Modify: `__tests__/api.test.ts`
+
+**Step 1: Write the failing tests**
+
+Update the import:
+
+```typescript
+import {
+  buildGeminiPayload, callGeminiAPI, invokeGemini,
+  getCitations, getUngroundedSpans, getAllSources,
+} from "../src/server/api";
+```
+
+```typescript
+describe("getAllSources", () => {
+  it("returns empty array when no groundingMetadata", () => {
+    expect(getAllSources({ text: "hello" })).toEqual([]);
+  });
+
+  it("returns empty array when groundingChunks is absent", () => {
+    expect(getAllSources({ text: "hello", groundingMetadata: {} })).toEqual([]);
+  });
+
+  it("returns web sources", () => {
+    const response: GeminiResponse = {
+      text: "text",
+      groundingMetadata: {
+        groundingChunks: [
+          { web: { uri: "https://a.com", title: "A" } },
+          { web: { uri: "https://b.com", title: "B" } },
+        ],
+      },
+    };
+    expect(getAllSources(response)).toEqual([
+      { uri: "https://a.com", title: "A" },
+      { uri: "https://b.com", title: "B" },
+    ]);
+  });
+
+  it("returns retrievedContext sources", () => {
+    const response: GeminiResponse = {
+      text: "text",
+      groundingMetadata: {
+        groundingChunks: [
+          { retrievedContext: { uri: "https://c.com", title: "C" } },
+        ],
+      },
+    };
+    expect(getAllSources(response)).toEqual([{ uri: "https://c.com", title: "C" }]);
+  });
+
+  it("skips chunks with neither web nor retrievedContext", () => {
+    const response: GeminiResponse = {
+      text: "text",
+      groundingMetadata: {
+        groundingChunks: [
+          { web: { uri: "https://a.com", title: "A" } },
+          {},
+        ],
+      },
+    };
+    expect(getAllSources(response)).toEqual([{ uri: "https://a.com", title: "A" }]);
+  });
+});
+```
+
+**Step 2: Run to confirm failures**
+
+```bash
+npx jest __tests__/api.test.ts -t "getAllSources"
+```
+Expected: FAIL.
+
+**Step 3: Add `getAllSources` to `src/server/api.ts`**
+
+Add after `getUngroundedSpans`:
+
+```typescript
+/**
+ * Return all grounding sources as a flat { uri, title } array.
+ * Covers both web (google_search) and retrievedContext (url_context) chunks.
+ * Pure — no GAS globals.
+ */
+export function getAllSources(
+  response: GeminiResponse,
+): Array<{ uri: string; title: string }> {
+  return (response.groundingMetadata?.groundingChunks ?? [])
+    .map((chunk) => chunk.web ?? chunk.retrievedContext ?? null)
+    .filter((src): src is { uri: string; title: string } => src !== null);
+}
+```
+
+**Step 4: Run all api tests**
+
+```bash
+npx jest __tests__/api.test.ts
+```
+Expected: all pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/server/api.ts __tests__/api.test.ts
+git commit -m "feat: add getAllSources pure helper to api.ts"
+```
+
+---
+
+### Task 5: Add `includeGrounding` checkbox to `ConfigureAIRunPanel`
+
+**Files:**
+- Modify: `src/client/panels/configure-ai-run.ts`
+- Modify: `__tests__/panels/configure-ai-run.test.ts`
+
+**Step 1: Write the failing tests**
+
+Add to `__tests__/panels/configure-ai-run.test.ts`. Find the existing `assembleRunConfig` describe block (or `handleRun`) and add:
+
+```typescript
+describe("includeGrounding checkbox", () => {
+  it("renders the include-grounding checkbox", async () => {
+    const { container } = await mountAndLoad();
+    expect(container.querySelector("#include-grounding-cb")).not.toBeNull();
+  });
+
+  it("assembleRunConfig includes includeGrounding: true when checkbox is checked", async () => {
+    const { container } = await mountAndLoad();
+    const cb = container.querySelector<HTMLInputElement>("#include-grounding-cb")!;
+    cb.checked = true;
+    container.querySelector<HTMLButtonElement>("#run-btn")!.click();
+    await Promise.resolve();
+    const config = (services.runBatchAI as jest.Mock).mock.calls[0]?.[0] as RunConfig | undefined;
+    expect(config?.includeGrounding).toBe(true);
+  });
+
+  it("assembleRunConfig omits includeGrounding when checkbox is unchecked", async () => {
+    const { container } = await mountAndLoad({ userPromptCols: ["col_a"], outputCol: "ai_inference" });
+    container.querySelector<HTMLInputElement>("#include-grounding-cb")!.checked = false;
+    container.querySelector<HTMLButtonElement>("#run-btn")!.click();
+    await Promise.resolve();
+    const config = (services.runBatchAI as jest.Mock).mock.calls[0]?.[0] as RunConfig | undefined;
+    expect(config?.includeGrounding).toBeFalsy();
+  });
+
+  it("unmount saves includeGrounding state", async () => {
+    const { container, panel } = await mountAndLoad();
+    container.querySelector<HTMLInputElement>("#include-grounding-cb")!.checked = true;
+    // Select required fields so unmount() doesn't return undefined
+    container.querySelectorAll<HTMLElement>("#user-prompt-cols .tag")[0]?.click();
+    const saved = panel.unmount();
+    expect(saved?.includeGrounding).toBe(true);
+  });
+
+  it("restores includeGrounding from savedState", async () => {
+    const { container } = await mountAndLoad(undefined, {
+      userPromptCols: ["col_a"],
+      driveFileCols: [],
+      systemPromptCol: "",
+      outputCol: "ai_inference",
+      includeGrounding: true,
+    });
+    const cb = container.querySelector<HTMLInputElement>("#include-grounding-cb")!;
+    expect(cb.checked).toBe(true);
+  });
+});
+```
+
+Note: the `runBatchAI` mock is already set up in the test file. The `mountAndLoad` helper needs `userPromptCols` and `outputCol` set for `assembleRunConfig` to succeed — use params to pre-select them, or click tags in the test.
+
+**Step 2: Run to confirm failures**
+
+```bash
+npx jest __tests__/panels/configure-ai-run.test.ts -t "includeGrounding"
+```
+Expected: FAIL.
+
+**Step 3: Update `configure-ai-run.ts`**
+
+**a) Extend `SavedState` type** — add `includeGrounding` to the omit list so it stays optional:
+
+```typescript
+export type SavedState = Required<Omit<RunConfig, "rowRange" | "tools" | "includeGrounding">> &
+  Pick<RunConfig, "rowRange" | "tools" | "includeGrounding">;
+```
+
+**b) Add private field:**
+
+```typescript
+private includeGroundingCb: HTMLInputElement | null = null;
+```
+
+**c) Wire it up in `mount()` — after the `toolsList` initialization:**
+
+```typescript
+this.includeGroundingCb = container.querySelector<HTMLInputElement>("#include-grounding-cb");
+if (this.includeGroundingCb && preset.includeGrounding) {
+  this.includeGroundingCb.checked = true;
+}
+```
+
+**d) Add dynamic label update** — inside the `getSheetHeaders().then(...)` success callback, after `outputColList` is initialized:
+
+```typescript
+const updateGroundingLabel = (): void => {
+  const val = this.outputColList?.getValue() ?? "";
+  const label = container.querySelector<HTMLElement>("#grounding-col-name");
+  if (label) label.textContent = val ? `${val}_grounding` : "_grounding";
+};
+updateGroundingLabel();
+container.querySelector("#output-col")?.addEventListener("click", updateGroundingLabel);
+```
+
+**e) Update `unmount()`:**
+
+```typescript
+return {
+  userPromptCols: this.userPromptList.getValue(),
+  driveFileCols: this.driveFileList?.getValue() ?? [],
+  systemPromptCol: this.systemPromptList?.getValue() ?? "",
+  outputCol: this.outputColList?.getValue() ?? "",
+  rowRange: this.rowRangeComp?.getValue(),
+  tools: (this.toolsList?.getValue() ?? []) as ToolId[],
+  includeGrounding: this.includeGroundingCb?.checked ?? false,
+};
+```
+
+**f) Update `assembleRunConfig()`** — add after `tools` resolution:
+
+```typescript
+const includeGrounding = this.includeGroundingCb?.checked ?? false;
+
+return {
+  userPromptCols,
+  driveFileCols: driveFileCols.length > 0 ? driveFileCols : undefined,
+  systemPromptCol,
+  outputCol,
+  rowRange,
+  tools: tools.length > 0 ? tools : undefined,
+  includeGrounding: includeGrounding || undefined,
+};
+```
+
+**g) Add to `template()`** — after the tools field-group, before row-range:
+
+```html
+<div class="field-group">
+  <label class="checkbox-label">
+    <input type="checkbox" id="include-grounding-cb" />
+    Include sources column (<span id="grounding-col-name">_grounding</span>)
+  </label>
+</div>
+```
+
+**Step 4: Run tests**
+
+```bash
+npx jest __tests__/panels/configure-ai-run.test.ts
+```
+Expected: all pass.
+
+**Step 5: Typecheck**
+
+```bash
+npm run typecheck
+```
+Expected: passes.
+
+**Step 6: Commit**
+
+```bash
+git add src/client/panels/configure-ai-run.ts __tests__/panels/configure-ai-run.test.ts
+git commit -m "feat: add includeGrounding checkbox to ConfigureAIRunPanel"
+```
+
+---
+
+### Task 6: Add renderers and update `runBatchAI` in `index.ts`
+
+**Files:**
+- Modify: `src/server/index.ts`
+
+No unit tests — `index.ts` is excluded from coverage (deeply coupled to SpreadsheetApp). Verified manually against a live sheet.
+
+**Step 1: Update imports in `src/server/index.ts`**
+
+Add the three helpers to the api import:
+
+```typescript
+import { getCitations, getUngroundedSpans, getAllSources } from "./api";
+```
+
+**Step 2: Add `renderInference` above `runBatchAI`**
+
+```typescript
+function renderInference(
+  response: import("./types").GeminiResponse,
+): GoogleAppsScript.Spreadsheet.RichTextValue {
+  const builder = SpreadsheetApp.newRichTextValue().setText(response.text);
+  getCitations(response).forEach(({ startIndex, endIndex, sources }) => {
+    if (sources[0]) builder.setLinkUrl(startIndex, endIndex, sources[0].uri);
+  });
+  return builder.build();
+}
+```
+
+**Step 3: Add `renderGrounding` above `runBatchAI`**
+
+```typescript
+function renderGrounding(
+  response: import("./types").GeminiResponse,
+): GoogleAppsScript.Spreadsheet.RichTextValue | null {
+  const sources = getAllSources(response);
+  const queries = response.groundingMetadata?.webSearchQueries ?? [];
+  const unverified = getUngroundedSpans(response);
+  const codePairs = response.codePairs ?? [];
+
+  if (!sources.length && !queries.length && !unverified.length && !codePairs.length) {
+    return null;
+  }
+
+  const sections: string[] = [];
+
+  if (codePairs.length > 0) {
+    codePairs.forEach(({ code, result }) => {
+      sections.push(
+        `Code:\n\`\`\`${code.language.toLowerCase()}\n${code.code}\n\`\`\`\n\nOutput:\n${result.output}`,
+      );
+    });
+  } else {
+    if (queries.length) {
+      sections.push(`Search queries: ${queries.map((q) => `"${q}"`).join(", ")}`);
+    }
+    if (sources.length) {
+      sections.push(
+        `Sources (${sources.length}):\n${sources.map((s) => `• ${s.title}`).join("\n")}`,
+      );
+    }
+    if (unverified.length) {
+      sections.push(
+        `Unverified:\n${unverified.map((s) => `• "${s.text}"`).join("\n")}`,
+      );
+    }
+  }
+
+  const fullText = sections.join("\n\n");
+  const builder = SpreadsheetApp.newRichTextValue().setText(fullText);
+
+  // Hyperlink each source title in the Sources section
+  sources.forEach(({ uri, title }) => {
+    const bullet = `• ${title}`;
+    let searchFrom = 0;
+    let idx = fullText.indexOf(bullet, searchFrom);
+    while (idx !== -1) {
+      builder.setLinkUrl(idx + 2, idx + 2 + title.length, uri); // +2 skips "• "
+      searchFrom = idx + bullet.length;
+      idx = fullText.indexOf(bullet, searchFrom);
+    }
+  });
+
+  return builder.build();
+}
+```
+
+**Step 4: Update the output column resolution block and row loop in `runBatchAI`**
+
+After the existing output column resolution (around line 281), add the grounding column resolution:
+
+```typescript
+// Resolve grounding column — create if not found (only when opted in)
+let groundingIdx = -1;
+const groundingColName = config.outputCol + "_grounding";
+if (config.includeGrounding) {
+  groundingIdx = headers.indexOf(groundingColName);
+  if (groundingIdx === -1) {
+    const newColIdx = sheet.getLastColumn() + 1;
+    sheet.getRange(1, newColIdx).setValue(groundingColName);
+    groundingIdx = newColIdx - 1;
+    headers.push(groundingColName); // keep in sync for subsequent rows
+  }
+}
+```
+
+Replace the row-writing block (currently lines 317–322):
+
+```typescript
+const result = runInference(userPrompts, driveLinks, systemPrompt, config.tools);
+if (result === null) continue;
+
+sheet.getRange(realRowIndex, outputIdx + 1).setRichTextValue(renderInference(result));
+
+if (config.includeGrounding && groundingIdx >= 0) {
+  const groundingValue = renderGrounding(result);
+  if (groundingValue !== null) {
+    sheet.getRange(realRowIndex, groundingIdx + 1).setRichTextValue(groundingValue);
+  }
+}
+
+processed++;
+SpreadsheetApp.flush();
+```
+
+**Step 5: Typecheck and full test run**
+
+```bash
+npm run typecheck && npm test
+```
+Expected: all pass.
+
+**Step 6: Commit**
+
+```bash
+git add src/server/index.ts
+git commit -m "feat: renderInference/renderGrounding in runBatchAI; RichTextValue output"
+```
+
+---
+
+### Task 7: Full verification
+
+**Step 1: Coverage**
+
+```bash
+npm run test:coverage
+```
+Expected: all pass, per-file thresholds met.
+
+**Step 2: Build**
+
+```bash
+npm run build
+```
+Expected: clean build.
+
+**Step 3: Lint and format**
+
+```bash
+npm run lint && npm run format:check
+```
+Expected: no issues.

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -115,5 +115,10 @@ module.exports = {
       branches: 70,
       functions: 100,
     },
+    "./src/server/rich-text.ts": {
+      statements: 94,
+      branches: 82,
+      functions: 100,
+    },
   },
 };

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -6,8 +6,8 @@ import { RowRange } from "../components/row-range";
 import { getSheetHeaders, runBatchAI } from "../services";
 import { TOOL_CATALOG } from "../tools";
 
-export type SavedState = Required<Omit<RunConfig, "rowRange" | "tools">> &
-  Pick<RunConfig, "rowRange" | "tools">;
+export type SavedState = Required<Omit<RunConfig, "rowRange" | "tools" | "includeGrounding">> &
+  Pick<RunConfig, "rowRange" | "tools" | "includeGrounding">;
 
 export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState> {
   private userPromptList: TagList | null = null;
@@ -16,6 +16,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
   private outputColList: SingleTagList | null = null;
   private rowRangeComp: RowRange | null = null;
   private toolsList: TagList | null = null;
+  private includeGroundingCb: HTMLInputElement | null = null;
   private nav: NavigationContext | null = null;
 
   mount(
@@ -37,6 +38,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
           outputCol: savedState.outputCol || undefined,
           rowRange: savedState.rowRange,
           tools: savedState.tools,
+          includeGrounding: savedState.includeGrounding,
         }
       : (params ?? {});
 
@@ -45,6 +47,20 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
       TOOL_CATALOG.map((t) => ({ label: t.name, value: t.id })),
       preset.tools ?? [],
     );
+
+    this.includeGroundingCb = container.querySelector<HTMLInputElement>("#include-grounding-cb");
+    if (this.includeGroundingCb && preset.includeGrounding) {
+      this.includeGroundingCb.checked = true;
+    }
+
+    const updateGroundingVisibility = (): void => {
+      const group = container.querySelector<HTMLElement>("#include-grounding-group");
+      if (group) {
+        group.style.display = (this.toolsList?.getValue().length ?? 0) > 0 ? "block" : "none";
+      }
+    };
+    updateGroundingVisibility();
+    container.querySelector("#tools-list")?.addEventListener("click", updateGroundingVisibility);
 
     getSheetHeaders().then(
       (headers) => {
@@ -77,6 +93,17 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
           preset.rowRange,
         );
 
+        const updateGroundingLabel = (): void => {
+          const val = this.outputColList?.getValue() ?? "";
+          const label = container.querySelector<HTMLElement>("#grounding-col-name");
+          if (label) label.textContent = val ? `${val}_grounding` : "_grounding";
+        };
+        updateGroundingLabel();
+        container.querySelector("#output-col")?.addEventListener("click", updateGroundingLabel);
+        container
+          .querySelector("#output-col input")
+          ?.addEventListener("input", updateGroundingLabel);
+
         container.querySelector<HTMLElement>("#config-form")!.style.display = "block";
         container
           .querySelector<HTMLButtonElement>("#run-btn")!
@@ -98,6 +125,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
       outputCol: this.outputColList?.getValue() ?? "",
       rowRange: this.rowRangeComp?.getValue(),
       tools: (this.toolsList?.getValue() ?? []) as ToolId[],
+      includeGrounding: this.includeGroundingCb?.checked ?? false,
     };
   }
 
@@ -147,6 +175,8 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
 
     const tools = (this.toolsList?.getValue() ?? []) as ToolId[];
 
+    const includeGrounding = this.includeGroundingCb?.checked ?? false;
+
     return {
       userPromptCols,
       driveFileCols: driveFileCols.length > 0 ? driveFileCols : undefined,
@@ -154,6 +184,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
       outputCol,
       rowRange,
       tools: tools.length > 0 ? tools : undefined,
+      includeGrounding: includeGrounding || undefined,
     };
   }
 
@@ -186,6 +217,12 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
         <div class="field-group">
           <span class="field-label">Tools <span class="optional">(optional)</span></span>
           <div id="tools-list" class="tag-list"></div>
+          <div id="include-grounding-group" style="display:none">
+            <label class="grounding-hint">
+              <input type="checkbox" id="include-grounding-cb" />
+              <span>Include sources column <span class="grounding-col-badge" id="grounding-col-name">_grounding</span></span>
+            </label>
+          </div>
         </div>
         <div class="field-group">
           <span class="field-label">Rows to process</span>

--- a/src/client/sidebar.css
+++ b/src/client/sidebar.css
@@ -260,6 +260,30 @@
             font-style: italic;
         }
 
+        .grounding-hint {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 11px;
+            color: var(--text-secondary);
+            margin-top: 10px;
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .grounding-col-badge {
+            display: inline-block;
+            font-family: "SFMono-Regular", "Consolas", monospace;
+            font-size: 10px;
+            background: #f1f3f4;
+            border: 1px solid var(--border-color);
+            border-radius: 3px;
+            padding: 1px 5px;
+            color: var(--text-main);
+            white-space: nowrap;
+            margin-left: 1px;
+        }
+
         /* ── Recipe list button hierarchy ── */
 
         .tool-btn-text {

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -9,7 +9,7 @@
 
 import { CONFIG } from "./config";
 import { TOOL_REGISTRY } from "./tools";
-import type { GeminiInlineData, GeminiRequest } from "./types";
+import type { GeminiInlineData, GeminiRequest, GeminiResponse, GeminiCodePair } from "./types";
 
 interface GeminiPart {
   text?: string;
@@ -58,9 +58,9 @@ export function buildGeminiPayload(req: GeminiRequest): Record<string, unknown> 
 }
 
 /**
- * Call the Gemini generateContent endpoint and return the response text.
+ * Call the Gemini generateContent endpoint and return the response as GeminiResponse.
  */
-export function callGeminiAPI(req: GeminiRequest): string {
+export function callGeminiAPI(req: GeminiRequest): GeminiResponse {
   const modelName = req.modelName ?? CONFIG.MODEL_NAME;
   const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent?key=${req.apiKey}`;
 
@@ -75,10 +75,40 @@ export function callGeminiAPI(req: GeminiRequest): string {
   const json = JSON.parse(response.getContentText()) as Record<string, unknown>;
 
   if (json.error) throw new Error((json.error as { message: string }).message);
-  const candidates = json.candidates as
-    | Array<{ content: { parts: Array<{ text: string }> } }>
+
+  const candidate = (json.candidates as Array<Record<string, unknown>> | undefined)?.[0];
+  const parts =
+    (candidate?.content as { parts?: Array<Record<string, unknown>> } | undefined)?.parts ?? [];
+
+  // Assemble text from all text parts (may be interspersed with code execution parts)
+  const textParts = parts
+    .filter((p): p is { text: string } => typeof p["text"] === "string")
+    .map((p) => p.text);
+  const text = textParts.join("\n\n") || "No response.";
+
+  // Extract consecutive executable_code + code_execution_result pairs (snake_case REST JSON)
+  const codePairs: GeminiCodePair[] = [];
+  for (let i = 0; i < parts.length - 1; i++) {
+    const curr = parts[i];
+    const next = parts[i + 1];
+    if (curr["executable_code"] !== undefined && next["code_execution_result"] !== undefined) {
+      codePairs.push({
+        code: curr["executable_code"] as GeminiCodePair["code"],
+        result: next["code_execution_result"] as GeminiCodePair["result"],
+      });
+      i++; // skip the result part — already consumed
+    }
+  }
+
+  const groundingMetadata = candidate?.["groundingMetadata"] as
+    | GeminiResponse["groundingMetadata"]
     | undefined;
-  return candidates?.[0]?.content?.parts?.[0]?.text ?? "No response.";
+
+  return {
+    text,
+    ...(groundingMetadata !== undefined && { groundingMetadata }),
+    ...(codePairs.length > 0 && { codePairs }),
+  };
 }
 
 /**
@@ -86,7 +116,7 @@ export function callGeminiAPI(req: GeminiRequest): string {
  * This is the preferred entry point for all production Gemini calls.
  * Throws if the API key property is not set.
  */
-export function invokeGemini(params: Omit<GeminiRequest, "apiKey">): string {
+export function invokeGemini(params: Omit<GeminiRequest, "apiKey">): GeminiResponse {
   const apiKey = PropertiesService.getScriptProperties().getProperty(CONFIG.API_KEY_PROPERTY);
   if (!apiKey) throw new Error(`${CONFIG.API_KEY_PROPERTY} script property not set`);
   return callGeminiAPI({ apiKey, ...params });

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -86,15 +86,15 @@ export function callGeminiAPI(req: GeminiRequest): GeminiResponse {
     .map((p) => p.text);
   const text = textParts.join("\n\n") || "No response.";
 
-  // Extract consecutive executable_code + code_execution_result pairs (snake_case REST JSON)
+  // Extract consecutive executableCode + codeExecutionResult pairs (camelCase REST JSON)
   const codePairs: GeminiCodePair[] = [];
   for (let i = 0; i < parts.length - 1; i++) {
     const curr = parts[i];
     const next = parts[i + 1];
-    if (curr["executable_code"] !== undefined && next["code_execution_result"] !== undefined) {
+    if (curr["executableCode"] !== undefined && next["codeExecutionResult"] !== undefined) {
       codePairs.push({
-        code: curr["executable_code"] as GeminiCodePair["code"],
-        result: next["code_execution_result"] as GeminiCodePair["result"],
+        code: curr["executableCode"] as GeminiCodePair["code"],
+        result: next["codeExecutionResult"] as GeminiCodePair["result"],
       });
       i++; // skip the result part — already consumed
     }

--- a/src/server/customFunctions.ts
+++ b/src/server/customFunctions.ts
@@ -40,7 +40,7 @@ export function SSI(userTexts: unknown, systemPrompt?: string, toolNames?: unkno
       systemPrompt: systemPrompt || undefined,
       userTexts: flattenArg(userTexts),
       tools: resolvedToolIds.length ? resolvedToolIds : undefined,
-    });
+    }).text;
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     return `[SSI Error: ${msg}]`;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -317,7 +317,7 @@ export function runBatchAI(config: RunConfig): void {
     const result = runInference(userPrompts, driveLinks, systemPrompt, config.tools);
     if (result === null) continue;
 
-    sheet.getRange(realRowIndex, outputIdx + 1).setValue(result);
+    sheet.getRange(realRowIndex, outputIdx + 1).setValue(result.text);
     processed++;
     SpreadsheetApp.flush();
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,6 +10,11 @@
 
 export { SSI } from "./customFunctions";
 import { runInference } from "./inference";
+import {
+  buildInferenceCellContent,
+  buildGroundingCellContent,
+  type CellContent,
+} from "./rich-text";
 import { checkDriveService, extractTextUniversal } from "./drive";
 import {
   extractId,
@@ -225,6 +230,20 @@ export function sampleRowsToEvaluation(): void {
 // 🧠 TOOL 4: AI BATCH PROCESSOR
 // ==========================================
 
+function toCellValue(content: CellContent): GoogleAppsScript.Spreadsheet.RichTextValue {
+  const builder = SpreadsheetApp.newRichTextValue().setText(content.text);
+  content.ranges.forEach(({ startIndex, endIndex, bold, italic, url }) => {
+    if (bold === true || italic === true) {
+      const style = SpreadsheetApp.newTextStyle();
+      if (bold === true) style.setBold(true);
+      if (italic === true) style.setItalic(true);
+      builder.setTextStyle(startIndex, endIndex, style.build());
+    }
+    if (url) builder.setLinkUrl(startIndex, endIndex, url);
+  });
+  return builder.build();
+}
+
 export function runBatchAI(config: RunConfig): void {
   const ss = SpreadsheetApp.getActiveSpreadsheet();
   const sheet = ss.getActiveSheet();
@@ -284,6 +303,20 @@ export function runBatchAI(config: RunConfig): void {
     const newColIdx = sheet.getLastColumn() + 1;
     sheet.getRange(1, newColIdx).setValue(config.outputCol);
     outputIdx = newColIdx - 1;
+    headers.push(config.outputCol); // keep in sync, matching grounding column pattern
+  }
+
+  // Resolve grounding column — create if not found (only when opted in)
+  let groundingIdx = -1;
+  const groundingColName = config.outputCol + "_grounding";
+  if (config.includeGrounding) {
+    groundingIdx = headers.indexOf(groundingColName);
+    if (groundingIdx === -1) {
+      const newColIdx = sheet.getLastColumn() + 1;
+      sheet.getRange(1, newColIdx).setValue(groundingColName);
+      groundingIdx = newColIdx - 1;
+      headers.push(groundingColName); // keep in sync for subsequent rows
+    }
   }
 
   // Determine row range
@@ -317,7 +350,24 @@ export function runBatchAI(config: RunConfig): void {
     const result = runInference(userPrompts, driveLinks, systemPrompt, config.tools);
     if (result === null) continue;
 
-    sheet.getRange(realRowIndex, outputIdx + 1).setValue(result.text);
+    try {
+      sheet
+        .getRange(realRowIndex, outputIdx + 1)
+        .setRichTextValue(toCellValue(buildInferenceCellContent(result)));
+
+      if (config.includeGrounding && groundingIdx >= 0) {
+        const groundingContent = buildGroundingCellContent(result);
+        if (groundingContent !== null) {
+          sheet
+            .getRange(realRowIndex, groundingIdx + 1)
+            .setRichTextValue(toCellValue(groundingContent));
+        }
+      }
+    } catch (_e) {
+      // Fall back to plain text if rich text rendering fails for this row.
+      sheet.getRange(realRowIndex, outputIdx + 1).setValue(result.text);
+    }
+
     processed++;
     SpreadsheetApp.flush();
   }

--- a/src/server/inference.ts
+++ b/src/server/inference.ts
@@ -47,7 +47,7 @@ export function runInference(
       userTexts,
       inlineData: inlineData.length ? inlineData : undefined,
       tools: tools?.length ? tools : undefined,
-    });
+    }).text;
   } catch (e) {
     return "Error: " + (e as Error).message;
   }

--- a/src/server/inference.ts
+++ b/src/server/inference.ts
@@ -9,7 +9,7 @@
 import { invokeGemini } from "./api";
 import { fetchAndEncodeFile } from "./drive";
 import { flattenArg, isValidDriveLink, extractId } from "./utils";
-import type { GeminiInlineData } from "./types";
+import type { GeminiInlineData, GeminiResponse } from "./types";
 import type { ToolId } from "../shared/types";
 
 /**
@@ -22,7 +22,7 @@ import type { ToolId } from "../shared/types";
  * @param systemPrompt Cell value for the system instruction. First non-empty
  *                     string is used. Omit or pass `undefined` to use the model default.
  * @param tools        Tool IDs to enable for this inference call.
- * @returns The model response string, an "Error: ..." string on failure,
+ * @returns The model response object, an object with "Error: ..." text on failure,
  *          or null if userPrompts is empty (signals caller to skip this row).
  */
 export function runInference(
@@ -30,7 +30,7 @@ export function runInference(
   driveLinks?: unknown,
   systemPrompt?: unknown,
   tools?: ToolId[],
-): string | null {
+): GeminiResponse | null {
   const userTexts = flattenArg(userPrompts);
   if (userTexts.length === 0) return null;
 
@@ -47,8 +47,8 @@ export function runInference(
       userTexts,
       inlineData: inlineData.length ? inlineData : undefined,
       tools: tools?.length ? tools : undefined,
-    }).text;
+    });
   } catch (e) {
-    return "Error: " + (e as Error).message;
+    return { text: "Error: " + (e as Error).message };
   }
 }

--- a/src/server/rich-text.ts
+++ b/src/server/rich-text.ts
@@ -1,0 +1,254 @@
+/**
+ * rich-text.ts — Pure TypeScript layer between GeminiResponse and Sheets cell content.
+ *
+ * Exports CellContent and TextRange interfaces + two builder functions.
+ * All helpers are private. No GAS globals — fully testable with Jest.
+ *
+ * GAS rendering (toCellValue) lives in index.ts which is excluded from coverage.
+ */
+
+import type { GeminiResponse, GeminiGroundingSupport } from "./types";
+
+// ---- Public interfaces ----
+
+/** A character range within a CellContent's text that carries link and/or style info. */
+export interface TextRange {
+  startIndex: number; // inclusive
+  endIndex: number; // exclusive
+  bold?: boolean;
+  italic?: boolean;
+  url?: string;
+}
+
+/** Everything needed to construct a Sheets RichTextValue for one cell. */
+export interface CellContent {
+  text: string;
+  ranges: TextRange[];
+}
+
+// ---- Private helpers ----
+
+interface ParsedMarkdown {
+  cleanText: string;
+  ranges: TextRange[];
+  mapIndex: (originalIndex: number) => number;
+}
+
+function parseMarkdown(text: string): ParsedMarkdown {
+  const ranges: TextRange[] = [];
+  const posMap = new Array<number>(text.length + 1).fill(0);
+  const cleanParts: string[] = [];
+  let cleanLen = 0;
+  let i = 0;
+
+  while (i < text.length) {
+    // **bold** — must be checked before single *
+    if (text[i] === "*" && text[i + 1] === "*") {
+      const closeIdx = text.indexOf("**", i + 2);
+      if (closeIdx > i + 2) {
+        posMap[i] = cleanLen;
+        posMap[i + 1] = cleanLen;
+        const spanStart = cleanLen;
+        const content = text.slice(i + 2, closeIdx);
+        for (let j = 0; j < content.length; j++) {
+          posMap[i + 2 + j] = cleanLen + j;
+          cleanParts.push(content[j]);
+        }
+        cleanLen += content.length;
+        posMap[closeIdx] = cleanLen;
+        posMap[closeIdx + 1] = cleanLen;
+        ranges.push({ startIndex: spanStart, endIndex: cleanLen, bold: true });
+        i = closeIdx + 2;
+        continue;
+      }
+    }
+
+    // *italic* — single * with a matching closing *
+    if (text[i] === "*" && text[i + 1] !== "*") {
+      const closeIdx = text.indexOf("*", i + 1);
+      if (closeIdx > i + 1 && text[closeIdx + 1] !== "*") {
+        posMap[i] = cleanLen;
+        const spanStart = cleanLen;
+        const content = text.slice(i + 1, closeIdx);
+        for (let j = 0; j < content.length; j++) {
+          posMap[i + 1 + j] = cleanLen + j;
+          cleanParts.push(content[j]);
+        }
+        cleanLen += content.length;
+        posMap[closeIdx] = cleanLen;
+        ranges.push({ startIndex: spanStart, endIndex: cleanLen, italic: true });
+        i = closeIdx + 1;
+        continue;
+      }
+    }
+
+    // # Heading — only at the start of text or after a newline
+    if (text[i] === "#" && (i === 0 || text[i - 1] === "\n")) {
+      let level = 0;
+      while (i + level < text.length && text[i + level] === "#") level++;
+      if (level >= 1 && level <= 6 && text[i + level] === " ") {
+        const prefixLen = level + 1;
+        for (let j = 0; j < prefixLen; j++) posMap[i + j] = cleanLen;
+        const lineEnd = text.indexOf("\n", i + prefixLen);
+        const end = lineEnd === -1 ? text.length : lineEnd;
+        const content = text.slice(i + prefixLen, end);
+        const spanStart = cleanLen;
+        for (let j = 0; j < content.length; j++) {
+          posMap[i + prefixLen + j] = cleanLen + j;
+          cleanParts.push(content[j]);
+        }
+        cleanLen += content.length;
+        ranges.push({ startIndex: spanStart, endIndex: cleanLen, bold: true });
+        i = end;
+        continue;
+      }
+    }
+
+    // Plain character
+    posMap[i] = cleanLen;
+    cleanParts.push(text[i]);
+    cleanLen++;
+    i++;
+  }
+  posMap[text.length] = cleanLen;
+
+  const cleanText = cleanParts.join("");
+  const mapIndex = (idx: number): number => posMap[Math.min(Math.max(0, idx), text.length)];
+
+  return { cleanText, ranges, mapIndex };
+}
+
+interface CitationRange {
+  startIndex: number;
+  endIndex: number;
+  sources: Array<{ uri: string; title: string }>;
+}
+
+function getCitations(response: GeminiResponse): CitationRange[] {
+  const supports = response.groundingMetadata?.groundingSupports ?? [];
+  const chunks = response.groundingMetadata?.groundingChunks ?? [];
+  return supports.map((s: GeminiGroundingSupport) => ({
+    startIndex: s.segment.startIndex,
+    endIndex: s.segment.endIndex,
+    sources: s.groundingChunkIndices
+      .map((idx) => {
+        const chunk = chunks[idx];
+        return chunk?.web ?? chunk?.retrievedContext ?? null;
+      })
+      .filter((src): src is { uri: string; title: string } => src !== null),
+  }));
+}
+
+function getAllSources(response: GeminiResponse): Array<{ uri: string; title: string }> {
+  return (response.groundingMetadata?.groundingChunks ?? [])
+    .map((chunk) => chunk.web ?? chunk.retrievedContext ?? null)
+    .filter((src): src is { uri: string; title: string } => src !== null);
+}
+
+// ---- Public builders ----
+
+export function buildInferenceCellContent(response: GeminiResponse): CellContent {
+  const { cleanText, ranges: mdRanges, mapIndex } = parseMarkdown(response.text);
+
+  // Sort citations and merge overlapping ranges (Gemini can return overlapping supports).
+  // When ranges overlap we keep the first source URI — the first support is generally
+  // the highest-confidence citation for the merged span.
+  const citations = getCitations(response).sort((a, b) => a.startIndex - b.startIndex);
+  const merged: Array<{ startIndex: number; endIndex: number; url: string }> = [];
+  for (const { startIndex, endIndex, sources } of citations) {
+    if (!sources[0]) continue;
+    const cleanStart = mapIndex(startIndex);
+    const cleanEnd = mapIndex(endIndex);
+    if (cleanStart >= cleanEnd) continue;
+    const last = merged[merged.length - 1];
+    if (last && cleanStart < last.endIndex) {
+      last.endIndex = Math.max(last.endIndex, cleanEnd);
+    } else {
+      merged.push({ startIndex: cleanStart, endIndex: cleanEnd, url: sources[0].uri });
+    }
+  }
+
+  const citationRanges: TextRange[] = merged.map(({ startIndex, endIndex, url }) => ({
+    startIndex,
+    endIndex,
+    url,
+  }));
+
+  return { text: cleanText, ranges: [...mdRanges, ...citationRanges] };
+}
+
+export function buildGroundingCellContent(response: GeminiResponse): CellContent | null {
+  const sources = getAllSources(response);
+  const queries = response.groundingMetadata?.webSearchQueries ?? [];
+  const codePairs = response.codePairs ?? [];
+
+  if (!sources.length && !queries.length && !codePairs.length) {
+    return null;
+  }
+
+  const sections: string[] = [];
+
+  if (codePairs.length > 0) {
+    codePairs.forEach(({ code, result }) => {
+      const lang = code.language ? `(${code.language.toLowerCase()})` : "";
+      sections.push(`Code ${lang}:\n${code.code}\n\nOutput:\n${result.output}`);
+    });
+    // code_execution and google_search are mutually exclusive in practice.
+    // When code pairs are present, grounding sources/queries are omitted from the cell
+    // to keep the output focused — code results are the primary artifact.
+    return { text: sections.join("\n\n"), ranges: [] };
+  }
+
+  if (queries.length) {
+    sections.push(`Search queries: ${queries.map((q) => `"${q}"`).join(", ")}`);
+  }
+  if (sources.length) {
+    sections.push(
+      `Sources (${sources.length}):\n${sources.map((s) => `\u2022 ${s.title}`).join("\n")}`,
+    );
+  }
+
+  const fullText = sections.join("\n\n");
+  const ranges: TextRange[] = [];
+
+  if (queries.length) {
+    const queriesHeader = "Search queries: ";
+    const queriesSectionStart = fullText.indexOf(queriesHeader);
+    if (queriesSectionStart >= 0) {
+      queries.forEach((q) => {
+        const quoted = `"${q}"`;
+        const idx = fullText.indexOf(quoted, queriesSectionStart);
+        if (idx !== -1) {
+          const url = `https://www.google.com/search?q=${encodeURIComponent(q)}`;
+          ranges.push({ startIndex: idx, endIndex: idx + quoted.length, url });
+        }
+      });
+    }
+  }
+
+  if (sources.length) {
+    const sourcesHeader = `Sources (${sources.length}):`;
+    const sourceSectionStart = fullText.indexOf(sourcesHeader);
+    const sourceSectionEnd =
+      sourceSectionStart >= 0
+        ? ((): number => {
+            const next = fullText.indexOf("\n\n", sourceSectionStart + sourcesHeader.length);
+            return next !== -1 ? next : fullText.length;
+          })()
+        : -1;
+
+    if (sourceSectionStart >= 0) {
+      let searchFrom = sourceSectionStart;
+      sources.forEach(({ uri, title }) => {
+        const bullet = `\u2022 ${title}`;
+        const idx = fullText.indexOf(bullet, searchFrom);
+        if (idx !== -1 && idx < sourceSectionEnd) {
+          ranges.push({ startIndex: idx + 2, endIndex: idx + 2 + title.length, url: uri });
+          searchFrom = idx + bullet.length; // advance past this occurrence
+        }
+      });
+    }
+  }
+
+  return { text: fullText, ranges };
+}

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -38,9 +38,20 @@ export interface GeminiGroundingChunk {
   retrievedContext?: { uri: string; title: string };
 }
 
+export interface GeminiGroundingSupport {
+  segment: {
+    startIndex: number;
+    endIndex: number;
+    text: string;
+  };
+  groundingChunkIndices: number[];
+  confidenceScores?: number[];
+}
+
 export interface GeminiGroundingMetadata {
   webSearchQueries?: string[];
   groundingChunks?: GeminiGroundingChunk[];
+  groundingSupports?: GeminiGroundingSupport[];
 }
 
 export interface GeminiCodePair {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -33,6 +33,34 @@ export interface GeminiGenerationConfig {
   responseMimeType?: string;
 }
 
+export interface GeminiGroundingChunk {
+  web?: { uri: string; title: string };
+  retrievedContext?: { uri: string; title: string };
+}
+
+export interface GeminiGroundingMetadata {
+  webSearchQueries?: string[];
+  groundingChunks?: GeminiGroundingChunk[];
+}
+
+export interface GeminiCodePair {
+  code: { language: string; code: string };
+  result: { outcome: string; output: string };
+}
+
+/**
+ * Structured representation of a Gemini generateContent response.
+ * Returned by callGeminiAPI and invokeGemini in place of a bare string.
+ */
+export interface GeminiResponse {
+  /** Assembled from all text parts in candidates[0].content.parts. */
+  text: string;
+  /** Present when google_search grounding was active. */
+  groundingMetadata?: GeminiGroundingMetadata;
+  /** Present when code_execution was active and code blocks were returned. */
+  codePairs?: GeminiCodePair[];
+}
+
 /**
  * Discriminated union for Gemini REST API tool payload construction.
  * External callers pass ToolId[] — this type is internal to buildGeminiPayload,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -27,6 +27,8 @@ export interface RunConfig {
   rowRange?: { start: number; end: number };
   /** Tool IDs to enable for every row in this run. */
   tools?: ToolId[];
+  /** When true, runBatchAI writes a {outputCol}_grounding column with source attribution. */
+  includeGrounding?: boolean;
 }
 
 // ── Recipes ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

**Scaffolding (original PR #35):**
- Added `GeminiResponse` type (`GeminiGroundingMetadata`, `GeminiGroundingChunk`, `GeminiCodePair`) to `server/types.ts`
- `callGeminiAPI` now returns `GeminiResponse` — assembles text from all parts, preserves grounding metadata and code execution pairs (camelCase `executableCode`/`codeExecutionResult` keys)
- `invokeGemini` and `runInference` updated to propagate `GeminiResponse` up the call chain

**Rich cell text and grounding presentation (PR #36):**
- Introduces `src/server/rich-text.ts` — pure TypeScript module (no GAS globals) that translates `GeminiResponse` into `CellContent`/`TextRange` descriptors; `toCellValue` in `index.ts` converts these to `RichTextValue`
- Strips `api.ts` back to a pure HTTP adapter; `getCitations`/`getAllSources` are private helpers in `rich-text.ts`
- `buildInferenceCellContent`: strips Gemini markdown (`**bold**`, `*italic*`, `# Heading`) from output cells, remaps citation offsets through the position map, hyperlinks cited text to source URIs
- `buildGroundingCellContent`: hyperlinks search queries to Google Search; hyperlinks source titles to their URIs; formats code execution as plain text (no markdown fences)
- Grounding checkbox moved inside the Tools field-group, hidden by default, shown only when one or more tools are selected; column name displayed as a code badge
- `RunConfig.includeGrounding` and `{outputCol}_grounding` column creation

## Test plan

- [ ] `npm test` — 247 tests, all pass
- [ ] `npm run test:coverage` — per-file thresholds met (including `rich-text.ts`)
- [ ] `npm run build` — clean build
- [ ] `npm run lint && npm run format:check` — no issues
- [ ] Manual: enable Google Search tool, run AI batch — output cell has bold/italic formatting; cited text is hyperlinked to source URLs
- [ ] Manual: check "Include sources column" (only visible when a tool is selected) — `{outputCol}_grounding` column created with hyperlinked queries and source titles
- [ ] Manual: enable Code Execution tool — grounding column shows plain-text code + output; output cell renders markdown formatting
- [ ] Manual: `SSI` custom function still returns plain text (no regression)