### PR TITLE
fix: allow deselecting tags in SingleTagList

### DIFF
--- a/src/client/components/single-tag-list.ts
+++ b/src/client/components/single-tag-list.ts
@@ -13,10 +13,11 @@ export class SingleTagList {
   }
 
   private selectOnly(clicked: HTMLButtonElement): void {
+    const wasSelected = clicked.classList.contains("selected");
     this.container.querySelectorAll<HTMLButtonElement>(".tag").forEach((t) => {
       t.classList.remove("selected");
     });
-    clicked.classList.add("selected");
+    if (!wasSelected) clicked.classList.add("selected");
   }
 
   private render(headers: string[], opts: SingleTagListOpts): void {


### PR DESCRIPTION
## Summary
- Clicking an already-selected tag in `SingleTagList` (system prompt, AI output columns) had no effect — `selectOnly()` always re-added the `selected` class
- Fixed by capturing `wasSelected` before clearing all tags, then only re-adding if it was not previously selected
- Matches the toggle semantics already used by `TagList`

## Test plan
- [ ] Open the Run AI panel and click a tag for System prompt — verify it selects
- [ ] Click the same tag again — verify it deselects
- [ ] Repeat for AI output column tags
- [ ] Verify User prompt / Drive file / Tools tag lists still toggle as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)