### PR TITLE
fix: normalise absent startIndex to 0 in getCitations

### DIFF
--- a/__tests__/rich-text.test.ts
+++ b/__tests__/rich-text.test.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-import type { GeminiResponse } from "../src/server/types";
+import type { GeminiGroundingSupport, GeminiResponse } from "../src/server/types";
 import { buildInferenceCellContent, buildGroundingCellContent } from "../src/server/rich-text";
 
 // ---- helpers ----
@@ -373,5 +373,29 @@ describe("buildInferenceCellContent markdown edge cases", () => {
     expect(citation).toBeDefined();
     expect(citation!.startIndex).toBe(0);
     expect(citation!.endIndex).toBe(8); // "the docs" = 8 chars
+  });
+});
+
+describe("buildInferenceCellContent grounding — missing startIndex", () => {
+  it("treats absent startIndex as 0 (proto3 default omission)", () => {
+    const response = makeResponse({
+      text: "Paris is the capital.",
+      groundingMetadata: {
+        groundingChunks: [{ web: { uri: "https://example.com", title: "Example" } }],
+        groundingSupports: [
+          // startIndex intentionally omitted — simulates Gemini proto3 behaviour
+          {
+            segment: { endIndex: 5, text: "Paris" },
+            groundingChunkIndices: [0],
+          } as unknown as GeminiGroundingSupport,
+        ],
+        webSearchQueries: [],
+      },
+    });
+    const result = buildInferenceCellContent(response);
+    const citation = result.ranges.find((r) => r.url === "https://example.com");
+    expect(citation).toBeDefined();
+    expect(citation!.startIndex).toBe(0);
+    expect(citation!.endIndex).toBe(5);
   });
 });

--- a/src/server/rich-text.ts
+++ b/src/server/rich-text.ts
@@ -205,7 +205,7 @@ function getCitations(response: GeminiResponse): CitationRange[] {
   const supports = response.groundingMetadata?.groundingSupports ?? [];
   const chunks = response.groundingMetadata?.groundingChunks ?? [];
   return supports.map((s: GeminiGroundingSupport) => ({
-    startIndex: s.segment.startIndex,
+    startIndex: s.segment.startIndex ?? 0, // Gemini omits startIndex when it is 0 (proto3 default)
     endIndex: s.segment.endIndex,
     sources: s.groundingChunkIndices
       .map((idx) => {


### PR DESCRIPTION
## Summary

- Gemini omits `startIndex` from grounding segment when its value is 0 (proto3 default omission). This caused `setRichTextValue` to receive an undefined index, throw, and silently fall back to plain text — also dropping the grounding column write entirely.
- Fix: normalise with `?? 0` at the parse boundary in `getCitations`.
- Added test that passes a segment with no `startIndex` field and asserts the citation range starts at 0.

## Test plan
- [ ] Run AI inference with `google_search` tool enabled on a prompt whose first grounding segment starts at position 0 — verify grounding citations render as hyperlinks (no silent fallback to plain text)
- [ ] `npx jest __tests__/rich-text.test.ts` — all 28 tests pass including new proto3 case

🤖 Generated with [Claude Code](https://claude.com/claude-code)