### PR TITLE
Add MAX_OUTPUT_TOKENS default cap to prevent runaway API costs

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -117,6 +117,24 @@ describe("buildGeminiPayload", () => {
     const payload = buildGeminiPayload(req);
     expect((payload.generationConfig as any).temperature).toBe(0.5);
   });
+
+  it("applies CONFIG.MAX_OUTPUT_TOKENS as default maxOutputTokens when no generationConfig is provided", () => {
+    const payload = buildGeminiPayload(baseReq);
+    expect((payload.generationConfig as any).maxOutputTokens).toBe(CONFIG.MAX_OUTPUT_TOKENS);
+  });
+
+  it("applies CONFIG.MAX_OUTPUT_TOKENS as default when generationConfig omits maxOutputTokens", () => {
+    const req: GeminiRequest = { ...baseReq, generationConfig: { temperature: 0.7 } };
+    const payload = buildGeminiPayload(req);
+    expect((payload.generationConfig as any).maxOutputTokens).toBe(CONFIG.MAX_OUTPUT_TOKENS);
+    expect((payload.generationConfig as any).temperature).toBe(0.7);
+  });
+
+  it("uses caller-supplied maxOutputTokens over CONFIG default", () => {
+    const req: GeminiRequest = { ...baseReq, generationConfig: { maxOutputTokens: 512 } };
+    const payload = buildGeminiPayload(req);
+    expect((payload.generationConfig as any).maxOutputTokens).toBe(512);
+  });
 });
 
 // ── callGeminiAPI tests ────────────────────────────────────────

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -31,9 +31,10 @@ export function buildGeminiPayload(req: GeminiRequest): Record<string, unknown> 
     contents: [{ role: "user", parts }],
   };
 
-  if (req.generationConfig) {
-    payload.generationConfig = req.generationConfig;
-  }
+  payload.generationConfig = {
+    maxOutputTokens: CONFIG.MAX_OUTPUT_TOKENS,
+    ...req.generationConfig,
+  };
 
   if (req.tools && req.tools.length > 0) {
     const entries = req.tools.map((id) => TOOL_REGISTRY[id]);

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -10,4 +10,5 @@ export const CONFIG: AppConfig = {
   API_KEY_PROPERTY: "GEMINI_API_KEY",
   MODEL_NAME: "gemini-3.1-flash-lite-preview",
   MAX_FILE_SIZE_BYTES: 25 * 1024 * 1024,
+  MAX_OUTPUT_TOKENS: 1024,
 };

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -14,6 +14,7 @@ export interface AppConfig {
   API_KEY_PROPERTY: string;
   MODEL_NAME: string;
   MAX_FILE_SIZE_BYTES: number;
+  MAX_OUTPUT_TOKENS: number;
 }
 
 export interface GeminiInlineData {


### PR DESCRIPTION
## Summary

- Adds `MAX_OUTPUT_TOKENS: 1024` to `AppConfig` and `CONFIG` in `config.ts`
- `buildGeminiPayload` now always includes `maxOutputTokens` as a default via `generationConfig` spread — callers can still override it, but no request runs uncapped
- 3 new tests covering: default applied when no generationConfig, default applied when generationConfig omits it, caller override respected

## Test plan
- [ ] `npm test` passes (257 tests)
- [ ] `npm run typecheck` clean
- [ ] `npm run lint` clean
- [ ] Verify Gemini responses are capped at ~1024 tokens in a live run

🤖 Generated with [Claude Code](https://claude.com/claude-code)