### PR TITLE
fix: downgrade documents scope to readonly

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -14,7 +14,7 @@
   "oauthScopes": [
     "https://www.googleapis.com/auth/spreadsheets.currentonly",
     "https://www.googleapis.com/auth/drive",
-    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/documents.readonly",
     "https://www.googleapis.com/auth/script.external_request",
     "https://www.googleapis.com/auth/script.container.ui"
   ]


### PR DESCRIPTION
## Summary

- Narrows the Google Docs OAuth scope from `documents` (full read/write) to `documents.readonly`
- Removes "See, edit, create, and delete all your Google Docs documents" from the consent screen, replacing it with "View your Google Docs documents"
- No code changes — only `appsscript.json` is modified

## Why this is safe

`DocumentApp` is used in exactly one place (`drive.ts`): reading text via `.getBody().getText()`. It never creates, modifies, or deletes a document.

The OCR flow **does** create and delete a temporary Google Doc, but those operations go through the Drive Advanced Service (`Drive.Files.create` / `Drive.Files.remove`), which is covered by the existing `drive` scope — not the `documents` scope.

## Manual testing checklist

After deploying to a test Apps Script project (`npm run deploy`):

**Re-authorize with the new scope** (required — existing authorizations cache the old scope):
1. In the Apps Script editor, go to **Project Settings > OAuth scopes** and confirm `documents.readonly` appears instead of `documents`
2. Revoke the current authorization: **Run > Review permissions > Remove access**, then re-open the sheet and authorize fresh
3. Confirm the consent screen now shows "View your Google Docs documents" (not "edit, create, and delete")

**Tool 2 — Extract Text (Google Doc source):**
4. Paste a Drive link to a Google Doc in the sheet and run Extract Text → confirm text is extracted correctly

**Tool 2 — Extract Text (PDF/image source, OCR path):**
5. Paste a Drive link to a PDF or image and run Extract Text → confirm OCR text is returned (this exercises `Drive.Files.create` + `DocumentApp.openById` + `Drive.Files.remove`)
6. Confirm no "authorization required" errors are thrown

**Tool 4 — Run AI (text mode):**
7. Run a batch AI job in text mode → confirm results populate normally

**Tool 4 — Run AI (file/Drive mode):**
8. Run a batch AI job pointing at Drive files → confirm results populate normally
