### PR TITLE
feat: redesign Drive file handling with Workspace support and accurate size limits

### DIFF
--- a/__tests__/drive.test.ts
+++ b/__tests__/drive.test.ts
@@ -11,7 +11,9 @@ const mockUi = {
 };
 
 (globalThis as any).Drive = {
-  Files: {},
+  Files: {
+    export: jest.fn(),
+  },
 };
 
 (globalThis as any).DriveApp = {
@@ -22,18 +24,28 @@ const mockUi = {
   openById: jest.fn(),
 };
 
+(globalThis as any).SpreadsheetApp = {
+  openById: jest.fn(),
+};
+
 (globalThis as any).Utilities = {
   base64Encode: jest.fn().mockReturnValue("base64data=="),
+  Charset: { UTF_8: "UTF-8" },
 };
 
 (globalThis as any).MimeType = {
   GOOGLE_DOCS: "application/vnd.google-apps.document",
+  GOOGLE_SHEETS: "application/vnd.google-apps.spreadsheet",
   PDF: "application/pdf",
 };
 
 // ── Import after mocks ─────────────────────────────────────────
 
-import { checkDriveService, extractTextUniversal, fetchAndEncodeFile } from "../src/server/drive";
+import {
+  checkDriveService,
+  extractTextUniversal,
+  prepareDriveAttachments,
+} from "../src/server/drive";
 
 // ── Tests ──────────────────────────────────────────────────────
 
@@ -136,30 +148,199 @@ describe("extractTextUniversal", () => {
   });
 });
 
-describe("fetchAndEncodeFile", () => {
-  beforeEach(() => jest.clearAllMocks());
-
-  it("returns mime_type and base64-encoded data for a valid file", () => {
-    const mockFile = {
-      getMimeType: () => "application/pdf",
-      getSize: () => 1024,
-      getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+describe("prepareDriveAttachments", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (globalThis as any).Drive = {
+      Files: { export: jest.fn() },
     };
-    (DriveApp.getFileById as jest.Mock).mockReturnValue(mockFile);
-
-    const result = fetchAndEncodeFile("file123");
-    expect(result.mime_type).toBe("application/pdf");
-    expect(result.data).toBe("base64data=="); // matches Utilities mock in this file
   });
 
-  it("throws when file exceeds 25MB", () => {
-    const mockFile = {
-      getMimeType: () => "application/pdf",
-      getSize: () => 30 * 1024 * 1024,
-      getBlob: () => ({ getBytes: () => [] }),
-    };
-    (DriveApp.getFileById as jest.Mock).mockReturnValue(mockFile);
+  it("returns empty array for empty input", () => {
+    expect(prepareDriveAttachments([])).toEqual([]);
+  });
 
-    expect(() => fetchAndEncodeFile("bigfile")).toThrow("File too large");
+  it("encodes a PDF by fetching its blob directly", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/pdf",
+      getSize: () => 1024,
+      getName: () => "report.pdf",
+      getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+    });
+
+    const result = prepareDriveAttachments(["pdfId"]);
+    expect(result).toHaveLength(1);
+    expect(result[0].mime_type).toBe("application/pdf");
+    expect(result[0].data).toBe("base64data==");
+  });
+
+  it("encodes an image by fetching its blob directly", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "image/png",
+      getSize: () => 512,
+      getName: () => "photo.png",
+      getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+    });
+
+    const result = prepareDriveAttachments(["imgId"]);
+    expect(result).toHaveLength(1);
+    expect(result[0].mime_type).toBe("image/png");
+  });
+
+  it("encodes a video by fetching its blob directly", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "video/mp4",
+      getSize: () => 1024,
+      getName: () => "clip.mp4",
+      getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+    });
+
+    const result = prepareDriveAttachments(["videoId"]);
+    expect(result).toHaveLength(1);
+    expect(result[0].mime_type).toBe("video/mp4");
+  });
+
+  it("encodes an audio file by fetching its blob directly", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "audio/mpeg",
+      getSize: () => 512,
+      getName: () => "audio.mp3",
+      getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+    });
+
+    const result = prepareDriveAttachments(["audioId"]);
+    expect(result).toHaveLength(1);
+    expect(result[0].mime_type).toBe("audio/mpeg");
+  });
+
+  it("exports a Google Doc as PDF", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/vnd.google-apps.document",
+      getName: () => "doc.gdoc",
+    });
+    (Drive.Files.export as jest.Mock).mockReturnValue({
+      getBytes: () => [1, 2, 3],
+    });
+
+    const result = prepareDriveAttachments(["docId"]);
+    expect(result).toHaveLength(1);
+    expect(result[0].mime_type).toBe("application/pdf");
+    expect(Drive.Files.export).toHaveBeenCalledWith("docId", "application/pdf");
+  });
+
+  it("exports each sheet of a Google Sheets file as a separate CSV part", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/vnd.google-apps.spreadsheet",
+      getName: () => "data.gsheet",
+    });
+    const mockSheet1 = {
+      getName: () => "Sheet1",
+      getDataRange: () => ({
+        getValues: () => [
+          ["a", "b"],
+          ["1", "2"],
+        ],
+      }),
+    };
+    const mockSheet2 = {
+      getName: () => "Sheet2",
+      getDataRange: () => ({
+        getValues: () => [
+          ["x", "y"],
+          ["3", "4"],
+        ],
+      }),
+    };
+    (SpreadsheetApp.openById as jest.Mock).mockReturnValue({
+      getSheets: () => [mockSheet1, mockSheet2],
+    });
+
+    const result = prepareDriveAttachments(["sheetId"]);
+    expect(result).toHaveLength(2);
+    expect(result[0].mime_type).toBe("text/csv");
+    expect(result[1].mime_type).toBe("text/csv");
+    expect(Utilities.base64Encode).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws a descriptive error for unsupported file types", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/zip",
+      getName: () => "archive.zip",
+    });
+
+    expect(() => prepareDriveAttachments(["zipId"])).toThrow("Unsupported file type");
+  });
+
+  it("throws pre-flight error for PDF exceeding raw size threshold before downloading blob", () => {
+    // 36MB raw * 4/3 = 48MB encoded > 47MB INLINE_MAX_PDF_BYTES
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/pdf",
+      getSize: () => 36 * 1024 * 1024,
+      getName: () => "big.pdf",
+    });
+
+    expect(() => prepareDriveAttachments(["bigPdfId"])).toThrow("File too large");
+    // blob should NOT have been fetched
+    expect(DriveApp.getFileById("bigPdfId").getBlob).toBeUndefined();
+  });
+
+  it("throws per-PDF error mentioning Files API when encoded PDF exceeds 47MB", () => {
+    const ALMOST_PREFLIGHT = Math.floor((47 * 1024 * 1024) / (4 / 3)) - 1;
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/pdf",
+      getSize: () => ALMOST_PREFLIGHT,
+      getName: () => "large.pdf",
+      getBlob: () => ({ getBytes: () => new Array(ALMOST_PREFLIGHT).fill(0) }),
+    });
+    // Return a data string whose .length exceeds INLINE_MAX_PDF_BYTES
+    (Utilities.base64Encode as jest.Mock).mockReturnValue("x".repeat(48 * 1024 * 1024));
+
+    expect(() => prepareDriveAttachments(["largePdfId"])).toThrow(/PDF.*too large|too large.*PDF/i);
+  });
+
+  it("throws total request error mentioning Files API when combined encoded size exceeds 95MB", () => {
+    // Two images, each fine individually, combined > 95MB encoded
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "image/jpeg",
+      getSize: () => 1024,
+      getName: () => "img.jpg",
+      getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+    });
+    (Utilities.base64Encode as jest.Mock).mockReturnValue(
+      "x".repeat(50 * 1024 * 1024), // 50MB each → 100MB total > 95MB
+    );
+
+    expect(() => prepareDriveAttachments(["img1", "img2"])).toThrow(/combined|total/i);
+  });
+
+  it("error messages reference the Gemini Files API escape hatch", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/pdf",
+      getSize: () => 36 * 1024 * 1024,
+      getName: () => "big.pdf",
+    });
+
+    expect(() => prepareDriveAttachments(["bigPdfId"])).toThrow(/Files API/i);
+  });
+
+  it("returns combined parts from multiple files of different types", () => {
+    (DriveApp.getFileById as jest.Mock)
+      .mockReturnValueOnce({
+        getMimeType: () => "application/pdf",
+        getSize: () => 1024,
+        getName: () => "doc.pdf",
+        getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+      })
+      .mockReturnValueOnce({
+        getMimeType: () => "image/png",
+        getSize: () => 512,
+        getName: () => "chart.png",
+        getBlob: () => ({ getBytes: () => [4, 5, 6] }),
+      });
+
+    const result = prepareDriveAttachments(["pdfId", "imgId"]);
+    expect(result).toHaveLength(2);
+    expect(result[0].mime_type).toBe("application/pdf");
+    expect(result[1].mime_type).toBe("image/png");
   });
 });

--- a/__tests__/drive.test.ts
+++ b/__tests__/drive.test.ts
@@ -215,18 +215,17 @@ describe("prepareDriveAttachments", () => {
   });
 
   it("exports a Google Doc as PDF", () => {
+    const mockGetAs = jest.fn().mockReturnValue({ getBytes: () => [1, 2, 3] });
     (DriveApp.getFileById as jest.Mock).mockReturnValue({
       getMimeType: () => "application/vnd.google-apps.document",
       getName: () => "doc.gdoc",
-    });
-    (Drive.Files.export as jest.Mock).mockReturnValue({
-      getBytes: () => [1, 2, 3],
+      getAs: mockGetAs,
     });
 
     const result = prepareDriveAttachments(["docId"]);
     expect(result).toHaveLength(1);
     expect(result[0].mime_type).toBe("application/pdf");
-    expect(Drive.Files.export).toHaveBeenCalledWith("docId", "application/pdf");
+    expect(mockGetAs).toHaveBeenCalledWith("application/pdf");
   });
 
   it("exports each sheet of a Google Sheets file as a separate CSV part", () => {
@@ -321,7 +320,7 @@ describe("prepareDriveAttachments", () => {
       getName: () => "big.pdf",
     });
 
-    expect(() => prepareDriveAttachments(["bigPdfId"])).toThrow(/Files API/i);
+    expect(() => prepareDriveAttachments(["bigPdfId"])).toThrow(/breaking up/i);
   });
 
   it("returns combined parts from multiple files of different types", () => {

--- a/__tests__/drive.test.ts
+++ b/__tests__/drive.test.ts
@@ -262,6 +262,68 @@ describe("prepareDriveAttachments", () => {
     expect(Utilities.base64Encode).toHaveBeenCalledTimes(2);
   });
 
+  it("encodes correct CSV content for each sheet independently", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/vnd.google-apps.spreadsheet",
+      getName: () => "data.gsheet",
+    });
+    (SpreadsheetApp.openById as jest.Mock).mockReturnValue({
+      getSheets: () => [
+        {
+          getName: () => "Sheet1",
+          getDataRange: () => ({
+            getValues: () => [
+              ["name", "age"],
+              ["Alice", 30],
+            ],
+          }),
+        },
+        {
+          getName: () => "Sheet2",
+          getDataRange: () => ({ getValues: () => [["city"], ["Boston"]] }),
+        },
+      ],
+    });
+
+    // Capture actual CSV strings passed to base64Encode
+    const encoded: string[] = [];
+    (Utilities.base64Encode as jest.Mock).mockImplementation((csv: string) => {
+      encoded.push(csv);
+      return "base64data==";
+    });
+
+    prepareDriveAttachments(["sheetId"]);
+
+    expect(encoded).toHaveLength(2);
+    expect(encoded[0]).toBe('"name","age"\n"Alice","30"');
+    expect(encoded[1]).toBe('"city"\n"Boston"');
+  });
+
+  it("escapes double quotes in CSV cell values", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/vnd.google-apps.spreadsheet",
+      getName: () => "data.gsheet",
+    });
+    (SpreadsheetApp.openById as jest.Mock).mockReturnValue({
+      getSheets: () => [
+        {
+          getName: () => "Sheet1",
+          getDataRange: () => ({ getValues: () => [['He said "hello"', "normal"]] }),
+        },
+      ],
+    });
+
+    const encoded: string[] = [];
+    (Utilities.base64Encode as jest.Mock).mockImplementation((csv: string) => {
+      encoded.push(csv);
+      return "base64data==";
+    });
+
+    prepareDriveAttachments(["sheetId"]);
+
+    expect(encoded[0]).toBe('"He said ""hello""","normal"');
+  });
+
   it("throws a descriptive error for unsupported file types", () => {
     (DriveApp.getFileById as jest.Mock).mockReturnValue({
       getMimeType: () => "application/zip",

--- a/__tests__/drive.test.ts
+++ b/__tests__/drive.test.ts
@@ -151,6 +151,7 @@ describe("extractTextUniversal", () => {
 describe("prepareDriveAttachments", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (Utilities.base64Encode as jest.Mock).mockReturnValue("base64data==");
     (globalThis as any).Drive = {
       Files: { export: jest.fn() },
     };

--- a/__tests__/drive.test.ts
+++ b/__tests__/drive.test.ts
@@ -295,8 +295,8 @@ describe("prepareDriveAttachments", () => {
     prepareDriveAttachments(["sheetId"]);
 
     expect(encoded).toHaveLength(2);
-    expect(encoded[0]).toBe('"name","age"\n"Alice","30"');
-    expect(encoded[1]).toBe('"city"\n"Boston"');
+    expect(encoded[0]).toBe('Sheet: Sheet1\n"name","age"\n"Alice","30"');
+    expect(encoded[1]).toBe('Sheet: Sheet2\n"city"\n"Boston"');
   });
 
   it("escapes double quotes in CSV cell values", () => {
@@ -321,7 +321,7 @@ describe("prepareDriveAttachments", () => {
 
     prepareDriveAttachments(["sheetId"]);
 
-    expect(encoded[0]).toBe('"He said ""hello""","normal"');
+    expect(encoded[0]).toBe('Sheet: Sheet1\n"He said ""hello""","normal"');
   });
 
   it("throws a descriptive error for unsupported file types", () => {

--- a/__tests__/inference.test.ts
+++ b/__tests__/inference.test.ts
@@ -26,6 +26,20 @@
   base64Encode: jest.fn().mockReturnValue("encoded=="),
 };
 
+(globalThis as any).Drive = {
+  Files: { export: jest.fn() },
+};
+
+(globalThis as any).SpreadsheetApp = {
+  openById: jest.fn(),
+};
+
+(globalThis as any).MimeType = {
+  GOOGLE_DOCS: "application/vnd.google-apps.document",
+  GOOGLE_SHEETS: "application/vnd.google-apps.spreadsheet",
+  PDF: "application/pdf",
+};
+
 // ── Import after mocks ─────────────────────────────────────────
 
 import { runInference } from "../src/server/inference";

--- a/appsscript.json
+++ b/appsscript.json
@@ -12,7 +12,7 @@
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
   "oauthScopes": [
-    "https://www.googleapis.com/auth/spreadsheets.currentonly",
+    "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/drive",
     "https://www.googleapis.com/auth/documents",
     "https://www.googleapis.com/auth/script.external_request",

--- a/docs/plans/2026-03-17-drive-file-handling-redesign-plan.md
+++ b/docs/plans/2026-03-17-drive-file-handling-redesign-plan.md
@@ -1,0 +1,662 @@
+# Drive File Handling Redesign Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace `fetchAndEncodeFile` with a correct, aggregate-aware `prepareDriveAttachments` pipeline that supports Google Docs, Google Sheets, video, and audio, and enforces accurate base64-adjusted size limits.
+
+**Architecture:** A private `exportAndEncodeFile` handles per-file MIME routing and encoding; a public `prepareDriveAttachments` orchestrates all files for a row and enforces both size validation tiers. `runInference` is updated to call the new public function. Config constants replace the stale single threshold.
+
+**Tech Stack:** TypeScript, Google Apps Script (DriveApp, SpreadsheetApp, Drive Advanced Service, Utilities), Jest + ts-jest
+
+**Design doc:** `docs/plans/2026-03-17-drive-file-handling-redesign.md`
+
+---
+
+### Task 1: Update `config.ts` and `types.ts`
+
+**Files:**
+- Modify: `src/server/config.ts`
+- Modify: `src/server/types.ts`
+
+**Step 1: Replace `MAX_FILE_SIZE_BYTES` in `AppConfig` (`types.ts`)**
+
+In `src/server/types.ts`, find the `AppConfig` interface and replace the single field with three:
+
+```typescript
+export interface AppConfig {
+  API_KEY_PROPERTY: string;
+  MODEL_NAME: string;
+  /**
+   * Inline data size limits for the Gemini REST API.
+   * Source: https://ai.google.dev/gemini-api/docs/file-input-methods#method-comparison
+   *
+   * - Total request ceiling: 100MB (post-encoded, all inline_data parts combined)
+   * - Per-PDF ceiling: 50MB (post-encoded, per individual PDF file)
+   * - Base64 encoding expands raw file size by exactly 4/3
+   *
+   * We apply a 5% safety buffer to both ceilings to account for:
+   *   1. JSON envelope overhead (prompt text, mime_type fields, etc.)
+   *   2. Exported file size uncertainty (Docs/Sheets native size before export is unknown)
+   *
+   * For files exceeding these limits, consider the Gemini Files API (up to 2GB,
+   * no base64 overhead): https://ai.google.dev/api/files
+   */
+  INLINE_MAX_TOTAL_BYTES: number;  // 95MB (100MB ceiling × 0.95)
+  INLINE_MAX_PDF_BYTES: number;    // 47MB (50MB ceiling × 0.95)
+  INLINE_PREFLIGHT_FACTOR: number; // exact base64 expansion ratio (4/3)
+  MAX_OUTPUT_TOKENS: number;
+}
+```
+
+**Step 2: Update `config.ts` with new constants**
+
+Replace the `MAX_FILE_SIZE_BYTES` line in `src/server/config.ts`:
+
+```typescript
+export const CONFIG: AppConfig = {
+  API_KEY_PROPERTY: "GEMINI_API_KEY",
+  MODEL_NAME: "gemini-3.1-flash-lite-preview",
+  INLINE_MAX_TOTAL_BYTES: 95 * 1024 * 1024,   // 95MB (100MB ceiling × 0.95)
+  INLINE_MAX_PDF_BYTES:   47 * 1024 * 1024,   // 47MB (50MB ceiling × 0.95)
+  INLINE_PREFLIGHT_FACTOR: 4 / 3,             // exact base64 expansion ratio
+  MAX_OUTPUT_TOKENS: 1024,
+};
+```
+
+**Step 3: Run typecheck to catch all references to the old constant**
+
+```bash
+npm run typecheck
+```
+
+Expected: errors pointing at any remaining `MAX_FILE_SIZE_BYTES` references (will be fixed in later tasks).
+
+**Step 4: Commit**
+
+```bash
+git add src/server/config.ts src/server/types.ts
+git commit -m "refactor: replace MAX_FILE_SIZE_BYTES with three inline limit constants"
+```
+
+---
+
+### Task 2: Write failing tests for `prepareDriveAttachments`
+
+**Files:**
+- Modify: `__tests__/drive.test.ts`
+
+These tests will fail until Task 3 is complete. That is expected.
+
+**Step 1: Expand the mock setup at the top of `drive.test.ts`**
+
+The existing mocks cover `DriveApp`, `DocumentApp`, `Utilities`, and `MimeType`. Add `SpreadsheetApp`, extend `MimeType` with `GOOGLE_SHEETS`, and add `Utilities.Charset`. Replace the entire mock block at the top of the file (before any imports):
+
+```typescript
+const mockAlert = jest.fn();
+const mockUi = {
+  alert: mockAlert,
+  ButtonSet: { OK: "OK" },
+};
+
+(globalThis as any).Drive = {
+  Files: {
+    export: jest.fn(),
+  },
+};
+
+(globalThis as any).DriveApp = {
+  getFileById: jest.fn(),
+};
+
+(globalThis as any).DocumentApp = {
+  openById: jest.fn(),
+};
+
+(globalThis as any).SpreadsheetApp = {
+  openById: jest.fn(),
+};
+
+(globalThis as any).Utilities = {
+  base64Encode: jest.fn().mockReturnValue("base64data=="),
+  Charset: { UTF_8: "UTF-8" },
+};
+
+(globalThis as any).MimeType = {
+  GOOGLE_DOCS: "application/vnd.google-apps.document",
+  GOOGLE_SHEETS: "application/vnd.google-apps.spreadsheet",
+  PDF: "application/pdf",
+};
+```
+
+**Step 2: Update the import line**
+
+Replace the import at line 36:
+
+```typescript
+import { checkDriveService, extractTextUniversal, prepareDriveAttachments } from "../src/server/drive";
+```
+
+(`fetchAndEncodeFile` is removed; `prepareDriveAttachments` is the new public function.)
+
+**Step 3: Replace the `fetchAndEncodeFile` describe block with `prepareDriveAttachments` tests**
+
+Delete the existing `describe("fetchAndEncodeFile", ...)` block and add:
+
+```typescript
+describe("prepareDriveAttachments", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (globalThis as any).Drive = {
+      Files: { export: jest.fn() },
+    };
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(prepareDriveAttachments([])).toEqual([]);
+  });
+
+  it("encodes a PDF by fetching its blob directly", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/pdf",
+      getSize: () => 1024,
+      getName: () => "report.pdf",
+      getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+    });
+
+    const result = prepareDriveAttachments(["pdfId"]);
+    expect(result).toHaveLength(1);
+    expect(result[0].mime_type).toBe("application/pdf");
+    expect(result[0].data).toBe("base64data==");
+  });
+
+  it("encodes an image by fetching its blob directly", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "image/png",
+      getSize: () => 512,
+      getName: () => "photo.png",
+      getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+    });
+
+    const result = prepareDriveAttachments(["imgId"]);
+    expect(result).toHaveLength(1);
+    expect(result[0].mime_type).toBe("image/png");
+  });
+
+  it("encodes a video by fetching its blob directly", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "video/mp4",
+      getSize: () => 1024,
+      getName: () => "clip.mp4",
+      getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+    });
+
+    const result = prepareDriveAttachments(["videoId"]);
+    expect(result).toHaveLength(1);
+    expect(result[0].mime_type).toBe("video/mp4");
+  });
+
+  it("encodes an audio file by fetching its blob directly", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "audio/mpeg",
+      getSize: () => 512,
+      getName: () => "audio.mp3",
+      getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+    });
+
+    const result = prepareDriveAttachments(["audioId"]);
+    expect(result).toHaveLength(1);
+    expect(result[0].mime_type).toBe("audio/mpeg");
+  });
+
+  it("exports a Google Doc as PDF", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/vnd.google-apps.document",
+      getName: () => "doc.gdoc",
+    });
+    (Drive.Files.export as jest.Mock).mockReturnValue({
+      getBytes: () => [1, 2, 3],
+    });
+
+    const result = prepareDriveAttachments(["docId"]);
+    expect(result).toHaveLength(1);
+    expect(result[0].mime_type).toBe("application/pdf");
+    expect(Drive.Files.export).toHaveBeenCalledWith("docId", "application/pdf");
+  });
+
+  it("exports each sheet of a Google Sheets file as a separate CSV part", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/vnd.google-apps.spreadsheet",
+      getName: () => "data.gsheet",
+    });
+    const mockSheet1 = {
+      getName: () => "Sheet1",
+      getDataRange: () => ({ getValues: () => [["a", "b"], ["1", "2"]] }),
+    };
+    const mockSheet2 = {
+      getName: () => "Sheet2",
+      getDataRange: () => ({ getValues: () => [["x", "y"], ["3", "4"]] }),
+    };
+    (SpreadsheetApp.openById as jest.Mock).mockReturnValue({
+      getSheets: () => [mockSheet1, mockSheet2],
+    });
+
+    const result = prepareDriveAttachments(["sheetId"]);
+    expect(result).toHaveLength(2);
+    expect(result[0].mime_type).toBe("text/csv");
+    expect(result[1].mime_type).toBe("text/csv");
+    expect(Utilities.base64Encode).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws a descriptive error for unsupported file types", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/zip",
+      getName: () => "archive.zip",
+    });
+
+    expect(() => prepareDriveAttachments(["zipId"])).toThrow(
+      "Unsupported file type"
+    );
+  });
+
+  it("throws pre-flight error for PDF exceeding raw size threshold before downloading blob", () => {
+    // 36MB raw * 4/3 = 48MB encoded > 47MB INLINE_MAX_PDF_BYTES
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/pdf",
+      getSize: () => 36 * 1024 * 1024,
+      getName: () => "big.pdf",
+    });
+
+    expect(() => prepareDriveAttachments(["bigPdfId"])).toThrow(
+      "File too large"
+    );
+    // blob should NOT have been fetched
+    expect(DriveApp.getFileById("bigPdfId").getBlob).toBeUndefined();
+  });
+
+  it("throws per-PDF error mentioning Files API when encoded PDF exceeds 47MB", () => {
+    // Simulate a PDF that passes raw pre-flight but whose encoded form is just over limit.
+    // We mock base64Encode to return a large string by making getBytes() large.
+    // Easier: just set getSize() just under preflight but mock encoded data as large.
+    // Simplest approach: set size just below preflight threshold, then override base64Encode.
+    const ALMOST_PREFLIGHT = Math.floor((47 * 1024 * 1024) / (4 / 3)) - 1;
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/pdf",
+      getSize: () => ALMOST_PREFLIGHT,
+      getName: () => "large.pdf",
+      getBlob: () => ({ getBytes: () => new Array(ALMOST_PREFLIGHT).fill(0) }),
+    });
+    // Return a data string whose .length exceeds INLINE_MAX_PDF_BYTES
+    (Utilities.base64Encode as jest.Mock).mockReturnValue(
+      "x".repeat(48 * 1024 * 1024)
+    );
+
+    expect(() => prepareDriveAttachments(["largePdfId"])).toThrow(
+      /PDF.*too large|too large.*PDF/i
+    );
+  });
+
+  it("throws total request error mentioning Files API when combined encoded size exceeds 95MB", () => {
+    // Two images, each fine individually, combined > 95MB encoded
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "image/jpeg",
+      getSize: () => 1024,
+      getName: () => "img.jpg",
+      getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+    });
+    (Utilities.base64Encode as jest.Mock).mockReturnValue(
+      "x".repeat(50 * 1024 * 1024) // 50MB each → 100MB total > 95MB
+    );
+
+    expect(() => prepareDriveAttachments(["img1", "img2"])).toThrow(
+      /combined|total/i
+    );
+  });
+
+  it("error messages reference the Gemini Files API escape hatch", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/pdf",
+      getSize: () => 36 * 1024 * 1024,
+      getName: () => "big.pdf",
+    });
+
+    expect(() => prepareDriveAttachments(["bigPdfId"])).toThrow(
+      /Files API/i
+    );
+  });
+
+  it("returns combined parts from multiple files of different types", () => {
+    (DriveApp.getFileById as jest.Mock)
+      .mockReturnValueOnce({
+        getMimeType: () => "application/pdf",
+        getSize: () => 1024,
+        getName: () => "doc.pdf",
+        getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+      })
+      .mockReturnValueOnce({
+        getMimeType: () => "image/png",
+        getSize: () => 512,
+        getName: () => "chart.png",
+        getBlob: () => ({ getBytes: () => [4, 5, 6] }),
+      });
+
+    const result = prepareDriveAttachments(["pdfId", "imgId"]);
+    expect(result).toHaveLength(2);
+    expect(result[0].mime_type).toBe("application/pdf");
+    expect(result[1].mime_type).toBe("image/png");
+  });
+});
+```
+
+**Step 4: Run the new tests to verify they fail**
+
+```bash
+npx jest __tests__/drive.test.ts --no-coverage
+```
+
+Expected: `prepareDriveAttachments` tests fail with "not exported" or similar. `checkDriveService` and `extractTextUniversal` tests should still pass.
+
+**Step 5: Commit failing tests**
+
+```bash
+git add __tests__/drive.test.ts
+git commit -m "test: add failing tests for prepareDriveAttachments (TDD)"
+```
+
+---
+
+### Task 3: Implement `exportAndEncodeFile` and `prepareDriveAttachments` in `drive.ts`
+
+**Files:**
+- Modify: `src/server/drive.ts`
+
+**Step 1: Add the private `exportAndEncodeFile` function**
+
+This handles per-file MIME routing. Add after the existing imports in `drive.ts`:
+
+```typescript
+/**
+ * Route a single Drive file by MIME type, export or fetch its content,
+ * and return base64-encoded inline data parts ready for Gemini.
+ *
+ * Returns an array because Google Sheets files produce one part per sheet.
+ * All other types return a single-element array.
+ *
+ * Does NOT perform size validation — that is the responsibility of
+ * prepareDriveAttachments, which sees the full set of files for a row.
+ */
+function exportAndEncodeFile(fileId: string): GeminiInlineData[] {
+  const file = DriveApp.getFileById(fileId);
+  const mimeType = file.getMimeType();
+
+  if (mimeType === MimeType.GOOGLE_DOCS) {
+    const pdfBlob = Drive.Files.export(fileId, "application/pdf");
+    return [
+      {
+        mime_type: "application/pdf",
+        data: Utilities.base64Encode(pdfBlob.getBytes()),
+      },
+    ];
+  }
+
+  if (mimeType === MimeType.GOOGLE_SHEETS) {
+    const ss = SpreadsheetApp.openById(fileId);
+    return ss.getSheets().map((sheet) => {
+      const values = sheet.getDataRange().getValues();
+      const csv = values
+        .map((row) =>
+          row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(",")
+        )
+        .join("\n");
+      return {
+        mime_type: "text/csv",
+        data: Utilities.base64Encode(csv, Utilities.Charset.UTF_8),
+      };
+    });
+  }
+
+  if (
+    mimeType === MimeType.PDF ||
+    mimeType.startsWith("image/") ||
+    mimeType.startsWith("video/") ||
+    mimeType.startsWith("audio/")
+  ) {
+    return [
+      {
+        mime_type: mimeType,
+        data: Utilities.base64Encode(file.getBlob().getBytes()),
+      },
+    ];
+  }
+
+  throw new Error(
+    `Unsupported file type: ${mimeType} (${file.getName()}). ` +
+      `Supported types: Google Docs, Google Sheets, PDF, image/*, video/*, audio/*.`
+  );
+}
+```
+
+**Step 2: Add the public `prepareDriveAttachments` function**
+
+Add after `exportAndEncodeFile`:
+
+```typescript
+/**
+ * Prepare all Drive file attachments for a single Gemini inference call.
+ *
+ * Fetches and encodes each file, then enforces two size validation tiers:
+ *
+ * Tier 1 — Per-PDF pre-flight (checked before blob download):
+ *   Raw file size × INLINE_PREFLIGHT_FACTOR must not exceed INLINE_MAX_PDF_BYTES.
+ *   Skipped for Workspace exports (exported size is unknown before export).
+ *
+ * Tier 2 — Total request check (checked after all files are encoded):
+ *   Sum of all encoded part lengths must not exceed INLINE_MAX_TOTAL_BYTES.
+ *
+ * For files exceeding inline limits, consider the Gemini Files API (up to 2GB,
+ * no base64 overhead): https://ai.google.dev/api/files
+ * TODO: implement uploadToFilesAPI() and route oversized files here instead of throwing.
+ */
+export function prepareDriveAttachments(fileIds: string[]): GeminiInlineData[] {
+  if (fileIds.length === 0) return [];
+
+  const parts: GeminiInlineData[] = [];
+
+  for (const fileId of fileIds) {
+    const file = DriveApp.getFileById(fileId);
+    const mimeType = file.getMimeType();
+
+    // Tier 1 pre-flight: check raw size for binary file types before downloading blob.
+    // Workspace exports (Docs/Sheets) are skipped — exported size is unknown pre-export.
+    if (
+      mimeType === MimeType.PDF ||
+      mimeType.startsWith("image/") ||
+      mimeType.startsWith("video/") ||
+      mimeType.startsWith("audio/")
+    ) {
+      const estimatedEncodedSize = file.getSize() * CONFIG.INLINE_PREFLIGHT_FACTOR;
+      if (mimeType === MimeType.PDF && estimatedEncodedSize > CONFIG.INLINE_MAX_PDF_BYTES) {
+        throw new Error(
+          `File too large: "${file.getName()}" (~${Math.round(file.getSize() / 1024 / 1024)}MB raw). ` +
+            `PDFs must be under ~${Math.round(CONFIG.INLINE_MAX_PDF_BYTES / CONFIG.INLINE_PREFLIGHT_FACTOR / 1024 / 1024)}MB raw ` +
+            `(${Math.round(CONFIG.INLINE_MAX_PDF_BYTES / 1024 / 1024)}MB encoded). ` +
+            `Consider the Gemini Files API for large payloads: https://ai.google.dev/api/files`
+        );
+      }
+    }
+
+    parts.push(...exportAndEncodeFile(fileId));
+  }
+
+  // Tier 1 post-encode: verify each individual PDF part is within its per-file limit.
+  for (const part of parts) {
+    if (part.mime_type === "application/pdf" && part.data.length > CONFIG.INLINE_MAX_PDF_BYTES) {
+      throw new Error(
+        `PDF too large after encoding (~${Math.round(part.data.length / 1024 / 1024)}MB encoded, ` +
+          `limit ${Math.round(CONFIG.INLINE_MAX_PDF_BYTES / 1024 / 1024)}MB). ` +
+          `Consider the Gemini Files API for large payloads: https://ai.google.dev/api/files`
+      );
+    }
+  }
+
+  // Tier 2: verify total combined encoded size across all parts.
+  const totalEncodedBytes = parts.reduce((sum, part) => sum + part.data.length, 0);
+  if (totalEncodedBytes > CONFIG.INLINE_MAX_TOTAL_BYTES) {
+    throw new Error(
+      `Attachments too large: combined encoded size is ~${Math.round(totalEncodedBytes / 1024 / 1024)}MB, ` +
+        `exceeds ${Math.round(CONFIG.INLINE_MAX_TOTAL_BYTES / 1024 / 1024)}MB inline limit. ` +
+        `Consider the Gemini Files API for large payloads: https://ai.google.dev/api/files`
+    );
+  }
+
+  return parts;
+}
+```
+
+**Step 3: Remove `fetchAndEncodeFile` from `drive.ts`**
+
+Delete the entire `fetchAndEncodeFile` export (lines 72–81 in the original file). It is replaced by the new functions.
+
+**Step 4: Run tests**
+
+```bash
+npx jest __tests__/drive.test.ts --no-coverage
+```
+
+Expected: all `prepareDriveAttachments` tests pass. `checkDriveService` and `extractTextUniversal` tests still pass.
+
+**Step 5: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: one remaining error — `inference.ts` still imports the deleted `fetchAndEncodeFile`. Fix in the next task.
+
+**Step 6: Commit**
+
+```bash
+git add src/server/drive.ts
+git commit -m "feat: add prepareDriveAttachments with MIME routing and size validation"
+```
+
+---
+
+### Task 4: Update `runInference` and its tests
+
+**Files:**
+- Modify: `src/server/inference.ts`
+- Modify: `__tests__/inference.test.ts`
+
+**Step 1: Update the import in `inference.ts`**
+
+Replace:
+```typescript
+import { fetchAndEncodeFile } from "./drive";
+```
+With:
+```typescript
+import { prepareDriveAttachments } from "./drive";
+```
+
+**Step 2: Replace the `inlineData` assembly block in `runInference`**
+
+Replace:
+```typescript
+const inlineData: GeminiInlineData[] =
+  driveLinks !== undefined
+    ? flattenArg(driveLinks)
+        .filter(isValidDriveLink)
+        .map((link) => fetchAndEncodeFile(extractId(link)))
+    : [];
+```
+With:
+```typescript
+const inlineData: GeminiInlineData[] =
+  driveLinks !== undefined
+    ? prepareDriveAttachments(
+        flattenArg(driveLinks).filter(isValidDriveLink).map(extractId)
+      )
+    : [];
+```
+
+Also remove the `GeminiInlineData` import from `inference.ts` if it is now unused (it was only used for the type annotation on the `inlineData` variable, which TypeScript can now infer).
+
+**Step 3: Update the mock setup in `inference.test.ts`**
+
+The existing DriveApp mock returns a PDF file with `getSize: () => 1000` — this is compatible with the new pre-flight check (1000 bytes is well under the limit). No structural change needed.
+
+However, the `Drive.Files.export` mock must exist since `prepareDriveAttachments` calls `DriveApp.getFileById` which may hit the export path. Add it to the globals block at the top of `inference.test.ts` (before imports):
+
+```typescript
+(globalThis as any).Drive = {
+  Files: { export: jest.fn() },
+};
+
+(globalThis as any).SpreadsheetApp = {
+  openById: jest.fn(),
+};
+
+(globalThis as any).MimeType = {
+  GOOGLE_DOCS: "application/vnd.google-apps.document",
+  GOOGLE_SHEETS: "application/vnd.google-apps.spreadsheet",
+  PDF: "application/pdf",
+};
+```
+
+**Step 4: Run all tests**
+
+```bash
+npm test
+```
+
+Expected: all 262+ tests pass (plus the new drive tests).
+
+**Step 5: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: clean.
+
+**Step 6: Commit**
+
+```bash
+git add src/server/inference.ts __tests__/inference.test.ts
+git commit -m "refactor: wire runInference to prepareDriveAttachments"
+```
+
+---
+
+### Task 5: Final verification
+
+**Step 1: Run full test suite with coverage**
+
+```bash
+npm run test:coverage
+```
+
+Expected: all tests pass, per-file coverage thresholds met.
+
+**Step 2: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: no errors.
+
+**Step 3: Build**
+
+```bash
+npm run build
+```
+
+Expected: clean build to `dist/`.
+
+**Step 4: Commit design doc (if not already committed)**
+
+```bash
+git add docs/plans/2026-03-17-drive-file-handling-redesign.md docs/plans/2026-03-17-drive-file-handling-redesign-plan.md
+git commit -m "docs: add drive file handling redesign spec and implementation plan"
+```

--- a/docs/plans/2026-03-17-drive-file-handling-redesign.md
+++ b/docs/plans/2026-03-17-drive-file-handling-redesign.md
@@ -1,0 +1,160 @@
+# Drive File Handling Redesign
+
+**Date:** 2026-03-17
+**Status:** Design complete, pending implementation
+
+## Problem
+
+The current `fetchAndEncodeFile` function has four compounding shortcomings:
+
+1. **Stale size limit.** Hard-capped at 25MB — an old conservative number, not the actual Gemini API limit.
+2. **Wrong measurement.** Checks raw file size against a post-encoded limit. Base64 encoding expands file size by exactly 4/3, so the check is inaccurate.
+3. **No aggregate validation.** The limit applies to the total request payload, not per file. Multiple attachments per row can silently combine to exceed the limit.
+4. **No Google Workspace support.** Google Docs and Sheets return unsupported MIME types (`application/vnd.google-apps.document` / `.spreadsheet`) — Gemini rejects them as inline data.
+
+## Goals
+
+1. Support Google Docs (export as PDF) and Google Sheets (export each sheet as a separate CSV inline part)
+2. Support video and audio MIME types via blob encoding
+3. Raise inline size limits to match what the Gemini REST API actually accepts
+4. Enforce limits correctly: post-encoded, aggregate across all attachments in a row
+5. Surface clear, actionable error messages
+6. Document the Gemini Files API as the escape hatch for files exceeding inline limits
+
+## Out of Scope
+
+- Implementing the Gemini Files API (see escape hatch section below)
+- Rebuilding `extractTextUniversal` (text extraction feature will be redesigned separately)
+
+## API Limits
+
+Source: https://ai.google.dev/gemini-api/docs/file-input-methods#method-comparison
+
+| Limit | Value | Notes |
+|---|---|---|
+| Total request ceiling | 100MB | Post-encoded (base64), all `inline_data` parts combined |
+| Per-PDF ceiling | 50MB | Post-encoded, per individual PDF file |
+| Base64 expansion | 4/3 | Exact ratio; `Utilities.base64Encode()` produces compact output (no line breaks) |
+
+We apply a **5% safety buffer** to both ceilings to account for:
+- JSON envelope overhead (prompt text, `mime_type` fields, etc.)
+- Exported file size uncertainty (Docs/Sheets native size does not predict exported PDF/CSV size)
+
+Effective buffered thresholds:
+- Total: **95MB post-encoded** (~71MB raw)
+- Per-PDF: **47MB post-encoded** (~35MB raw)
+
+## File Type Routing
+
+| MIME type | Handling |
+|---|---|
+| `application/vnd.google-apps.document` | Export as PDF via `Drive.Files.export` → single inline part |
+| `application/vnd.google-apps.spreadsheet` | Export each sheet as CSV via `Drive.Files.export` with `gid` → one inline part per sheet |
+| `application/pdf` | Fetch blob directly → single inline part |
+| `image/*` | Fetch blob directly → single inline part |
+| `video/*` | Fetch blob directly → single inline part |
+| `audio/*` | Fetch blob directly → single inline part |
+| Everything else | Throw descriptive error: `"Unsupported file type: [mime_type]"` |
+
+Note: video and audio files are the most likely types to exceed inline size limits in practice. They are the primary real-world trigger for the Files API escape hatch.
+
+## Size Validation
+
+Two independent check tiers, both run inside `prepareDriveAttachments` after all files are encoded. Both operate on post-encoded size (`rawBytes * 4/3`).
+
+**Tier 1 — Per-PDF check:**
+- For each encoded part whose `mime_type` is `application/pdf`
+- Encoded size must be ≤ `INLINE_MAX_PDF_BYTES` (47MB)
+- Pre-flight shortcut for binary files: if `file.getSize() * INLINE_PREFLIGHT_FACTOR > INLINE_MAX_PDF_BYTES`, throw before downloading the blob
+- Pre-flight is skipped for Workspace exports (exported size is unknown before export)
+- Error: `"File too large: [name] (~[X]MB raw). PDFs must be under ~35MB raw / 47MB encoded. Consider the Gemini Files API for large payloads."`
+
+**Tier 2 — Total request check:**
+- Sum of all encoded `GeminiInlineData` parts must be ≤ `INLINE_MAX_TOTAL_BYTES` (95MB)
+- Error: `"Attachments too large: combined encoded size is ~[X]MB, exceeds 95MB inline limit. Consider the Gemini Files API for large payloads."`
+
+Both tiers must pass. A request with two 30MB raw PDFs each passes Tier 1 individually but may fail Tier 2 when combined.
+
+## Function Signatures
+
+### Public
+
+```typescript
+// drive.ts
+export function prepareDriveAttachments(fileIds: string[]): GeminiInlineData[]
+```
+
+Takes all Drive file IDs for a row. Routes each file by MIME type, encodes all parts, runs both size validation tiers, returns the combined `GeminiInlineData[]` ready for a Gemini request. Throws on unsupported types, size violations, or Drive errors.
+
+### Private
+
+```typescript
+// drive.ts (internal)
+function exportAndEncodeFile(fileId: string): GeminiInlineData[]
+```
+
+Routes a single file by MIME type. Exports Workspace formats, fetches blobs for binary types, encodes to base64. Always returns an array — single-item for most types, one item per sheet for Sheets. No size checks here; that responsibility belongs to `prepareDriveAttachments`.
+
+## Files API Escape Hatch
+
+The Gemini Files API supports uploads up to 2GB with no base64 overhead. It is the correct solution for files exceeding inline limits.
+
+It is **not implemented** in this iteration. When either size check fails, the error message directs users to the Files API. A `// TODO` comment at the throw site marks the exact seam where routing logic would be added.
+
+Reference: https://ai.google.dev/api/files
+
+The recommended community threshold for routing to the Files API is files > ~20MB raw, as inline data becomes inefficient at that scale.
+
+## Change Surface
+
+| File | Change |
+|---|---|
+| `src/server/config.ts` | Replace `MAX_FILE_SIZE_BYTES` with three new constants (see below) |
+| `src/server/types.ts` | Remove `MAX_FILE_SIZE_BYTES` from `AppConfig` interface |
+| `src/server/drive.ts` | Remove `fetchAndEncodeFile`; add `prepareDriveAttachments` (public) and `exportAndEncodeFile` (private) |
+| `src/server/inference.ts` | Replace `.map(fetchAndEncodeFile)` chain with single `prepareDriveAttachments(fileIds)` call |
+
+`checkDriveService` and `extractTextUniversal` in `drive.ts` are unchanged.
+
+## Config Changes
+
+```typescript
+/**
+ * Inline data size limits for the Gemini REST API.
+ * Source: https://ai.google.dev/gemini-api/docs/file-input-methods#method-comparison
+ *
+ * - Total request ceiling: 100MB (post-encoded, all inline_data parts combined)
+ * - Per-PDF ceiling: 50MB (post-encoded, per individual PDF file)
+ * - Base64 encoding expands raw file size by exactly 4/3
+ *
+ * We apply a 5% safety buffer to both ceilings to account for:
+ *   1. JSON envelope overhead (prompt text, mime_type fields, etc.)
+ *   2. Exported file size uncertainty (Docs/Sheets native size before export is unknown)
+ *
+ * For files exceeding these limits, consider the Gemini Files API (up to 2GB,
+ * no base64 overhead): https://ai.google.dev/api/files
+ */
+INLINE_MAX_TOTAL_BYTES: 95 * 1024 * 1024,   // 95MB (100MB ceiling × 0.95)
+INLINE_MAX_PDF_BYTES:   47 * 1024 * 1024,   // 47MB (50MB ceiling × 0.95)
+INLINE_PREFLIGHT_FACTOR: 4 / 3,             // exact base64 expansion ratio
+```
+
+## runInference Change
+
+```typescript
+// before
+const inlineData: GeminiInlineData[] =
+  driveLinks !== undefined
+    ? flattenArg(driveLinks)
+        .filter(isValidDriveLink)
+        .map((link) => fetchAndEncodeFile(extractId(link)))
+    : [];
+
+// after
+const inlineData: GeminiInlineData[] =
+  driveLinks !== undefined
+    ? prepareDriveAttachments(
+        flattenArg(driveLinks).filter(isValidDriveLink).map(extractId)
+      )
+    : [];
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -222,23 +222,23 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -575,18 +575,49 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/config-helpers": {
@@ -616,9 +647,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.4.tgz",
-      "integrity": "sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -629,7 +660,7 @@
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.3",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -656,6 +687,24 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -673,10 +722,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@eslint/js": {
-      "version": "9.39.3",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
-      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -789,9 +851,9 @@
       }
     },
     "node_modules/@google/clasp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@google/clasp/-/clasp-3.2.0.tgz",
-      "integrity": "sha512-2RDjrVip6qY29WucVobrEmb1evRllmZ1l4xMltxcQ98KkKtA3fZM24jh30DgdXrLyCe4oqPGuBh69jJwFbrwTg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@google/clasp/-/clasp-3.3.0.tgz",
+      "integrity": "sha512-0OTjAHes2tJ2z0THECx6xYLB4DaChnQLwwAm3PnzAJUTLwDrW81biaP04K9UKMXea5DqvbuDmveNEZlQhi1Vzg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -833,9 +895,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1982,9 +2044,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2098,9 +2160,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
-      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
       ],
@@ -2112,9 +2174,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
-      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
       ],
@@ -2126,9 +2188,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
@@ -2140,9 +2202,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
-      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
       ],
@@ -2154,9 +2216,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
-      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
       ],
@@ -2168,9 +2230,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
-      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
       ],
@@ -2182,13 +2244,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
-      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2196,13 +2261,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
-      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2210,13 +2278,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
-      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2224,13 +2295,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
-      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2238,13 +2312,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
-      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2252,13 +2329,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
-      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2266,13 +2346,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
-      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2280,13 +2363,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
-      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2294,13 +2380,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2308,13 +2397,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
-      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2322,13 +2414,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
-      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2336,13 +2431,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2350,13 +2448,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
-      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2364,9 +2465,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
-      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
       "cpu": [
         "x64"
       ],
@@ -2378,9 +2479,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
-      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
       "cpu": [
         "arm64"
       ],
@@ -2392,9 +2493,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
-      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
       "cpu": [
         "arm64"
       ],
@@ -2406,9 +2507,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
-      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
       ],
@@ -2420,9 +2521,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
       "cpu": [
         "x64"
       ],
@@ -2434,9 +2535,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
       ],
@@ -2621,13 +2722,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
-      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -2683,17 +2784,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
-      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
+      "integrity": "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/type-utils": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/type-utils": "8.57.1",
+        "@typescript-eslint/utils": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.4.0"
@@ -2706,22 +2807,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.56.1",
+        "@typescript-eslint/parser": "^8.57.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
-      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
+      "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2737,14 +2838,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
-      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
+      "integrity": "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.56.1",
-        "@typescript-eslint/types": "^8.56.1",
+        "@typescript-eslint/tsconfig-utils": "^8.57.1",
+        "@typescript-eslint/types": "^8.57.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2759,14 +2860,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
-      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
+      "integrity": "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1"
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2777,9 +2878,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
-      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
+      "integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2794,15 +2895,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
-      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
+      "integrity": "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1",
+        "@typescript-eslint/utils": "8.57.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.4.0"
       },
@@ -2819,9 +2920,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
-      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
+      "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2833,16 +2934,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
-      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
+      "integrity": "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.56.1",
-        "@typescript-eslint/tsconfig-utils": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/project-service": "8.57.1",
+        "@typescript-eslint/tsconfig-utils": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2860,56 +2961,17 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
-      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.1.tgz",
+      "integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1"
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2924,13 +2986,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
-      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
+      "integrity": "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/types": "8.57.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2977,9 +3039,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3403,11 +3465,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3431,13 +3496,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.10.8",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
+      "integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bignumber.js": {
@@ -3476,14 +3544,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -3667,9 +3737,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001769",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
-      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+      "version": "1.0.30001780",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
+      "integrity": "sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==",
       "dev": true,
       "funding": [
         {
@@ -4199,43 +4269,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/data-urls/node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/data-urls/node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/data-urls/node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -4316,9 +4349,9 @@
       "license": "MIT"
     },
     "node_modules/dedent": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
-      "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -4480,16 +4513,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/domexception/node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4523,9 +4546,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.286",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "version": "1.5.313",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
+      "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4784,25 +4807,25 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.3",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
-      "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.3",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -4821,7 +4844,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -4904,6 +4927,24 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/eslint/node_modules/chalk": {
@@ -5004,6 +5045,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint/node_modules/p-locate": {
@@ -5272,13 +5326,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -5487,9 +5541,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5704,9 +5758,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5829,6 +5883,37 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/globals": {
@@ -6072,9 +6157,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
-      "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6411,9 +6496,9 @@
       }
     },
     "node_modules/inquirer-autocomplete-standalone/node_modules/@types/node": {
-      "version": "20.19.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
-      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6539,9 +6624,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7076,9 +7161,9 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8553,9 +8638,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -8653,43 +8738,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/jsdom/node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/jsdom/node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/jsdom/node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/jsesc": {
@@ -8845,19 +8893,18 @@
       "license": "MIT"
     },
     "node_modules/lint-staged": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
-      "integrity": "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==",
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.2",
+        "commander": "^14.0.3",
         "listr2": "^9.0.5",
-        "micromatch": "^4.0.8",
-        "nano-spawn": "^2.0.0",
-        "pidtree": "^0.6.0",
+        "picomatch": "^4.0.3",
         "string-argv": "^0.3.2",
-        "yaml": "^2.8.1"
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -8877,19 +8924,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/lint-staged/node_modules/pidtree": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "pidtree": "bin/pidtree.js"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/listr2": {
@@ -8937,14 +8971,14 @@
       }
     },
     "node_modules/listr2/node_modules/cli-truncate": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
-      "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "slice-ansi": "^7.1.0",
-        "string-width": "^8.0.0"
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
       },
       "engines": {
         "node": ">=20"
@@ -8954,14 +8988,14 @@
       }
     },
     "node_modules/listr2/node_modules/cli-truncate/node_modules/string-width": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.1.tgz",
-      "integrity": "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "strip-ansi": "^7.1.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
         "node": ">=20"
@@ -8987,30 +9021,30 @@
       }
     },
     "node_modules/listr2/node_modules/slice-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^5.0.0"
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/listr2/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -9220,13 +9254,13 @@
       }
     },
     "node_modules/log-update/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -9444,16 +9478,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -9467,11 +9504,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -9491,19 +9528,6 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/nano-spawn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
-      "integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
       }
     },
     "node_modules/natural-compare": {
@@ -9558,6 +9582,31 @@
         }
       }
     },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9566,9 +9615,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -9631,6 +9680,24 @@
         "node": ">= 4"
       }
     },
+    "node_modules/npm-run-all/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/npm-run-all/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/npm-run-all/node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -9681,6 +9748,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/npm-run-all/node_modules/path-key": {
@@ -9953,13 +10033,13 @@
       }
     },
     "node_modules/ora/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -10170,9 +10250,9 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -10180,16 +10260,16 @@
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -10859,13 +10939,13 @@
       "license": "MIT"
     },
     "node_modules/rimraf": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
-      "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "glob": "^13.0.0",
+        "glob": "^13.0.3",
         "package-json-from-dist": "^1.0.1"
       },
       "bin": {
@@ -10878,55 +10958,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rimraf/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/rimraf/node_modules/glob": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.2.tgz",
-      "integrity": "sha512-035InabNu/c1lW0tzPhAgapKctblppqsKKG9ZaNzbr+gXwWMjXoiyGSyB9sArzrjG7jY+zntRq5ZSUYemrnWVQ==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.1.2",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -10936,9 +10977,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
-      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10952,31 +10993,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.57.1",
-        "@rollup/rollup-android-arm64": "4.57.1",
-        "@rollup/rollup-darwin-arm64": "4.57.1",
-        "@rollup/rollup-darwin-x64": "4.57.1",
-        "@rollup/rollup-freebsd-arm64": "4.57.1",
-        "@rollup/rollup-freebsd-x64": "4.57.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
-        "@rollup/rollup-linux-arm64-musl": "4.57.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
-        "@rollup/rollup-linux-loong64-musl": "4.57.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-musl": "4.57.1",
-        "@rollup/rollup-openbsd-x64": "4.57.1",
-        "@rollup/rollup-openharmony-arm64": "4.57.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
-        "@rollup/rollup-win32-x64-gnu": "4.57.1",
-        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -11472,9 +11513,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -11614,13 +11655,13 @@
       }
     },
     "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -11804,6 +11845,47 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -11868,11 +11950,17 @@
       }
     },
     "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
@@ -12137,9 +12225,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -12309,11 +12397,14 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",
@@ -12353,14 +12444,17 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -9,6 +9,8 @@ import type { AppConfig } from "./types";
 export const CONFIG: AppConfig = {
   API_KEY_PROPERTY: "GEMINI_API_KEY",
   MODEL_NAME: "gemini-3.1-flash-lite-preview",
-  MAX_FILE_SIZE_BYTES: 25 * 1024 * 1024,
+  INLINE_MAX_TOTAL_BYTES: 95 * 1024 * 1024, // 95MB (100MB ceiling × 0.95)
+  INLINE_MAX_PDF_BYTES: 47 * 1024 * 1024, // 47MB (50MB ceiling × 0.95)
+  INLINE_PREFLIGHT_FACTOR: 4 / 3, // exact base64 expansion ratio
   MAX_OUTPUT_TOKENS: 1024,
 };

--- a/src/server/drive.ts
+++ b/src/server/drive.ts
@@ -66,16 +66,138 @@ export function extractTextUniversal(fileId: string): string {
 }
 
 /**
- * Fetch a Drive file by ID and return it as base64-encoded inline data
- * ready for the Gemini API. Throws if the file exceeds the 25MB limit.
+ * Route a single Drive file by MIME type, export or fetch its content,
+ * and return base64-encoded inline data parts ready for Gemini.
+ *
+ * Returns an array because Google Sheets files produce one part per sheet.
+ * All other types return a single-element array.
+ *
+ * Does NOT perform size validation — that is the responsibility of
+ * prepareDriveAttachments, which sees the full set of files for a row.
  */
-export function fetchAndEncodeFile(fileId: string): GeminiInlineData {
-  const file = DriveApp.getFileById(fileId);
-  if (file.getSize() > CONFIG.MAX_FILE_SIZE_BYTES) {
-    throw new Error("File too large (>25MB).");
+function exportAndEncodeFile(
+  fileId: string,
+  file: GoogleAppsScript.Drive.File,
+): GeminiInlineData[] {
+  const mimeType = file.getMimeType();
+
+  if (mimeType === MimeType.GOOGLE_DOCS) {
+    const pdfBlob = Drive.Files.export(
+      fileId,
+      "application/pdf",
+    ) as unknown as GoogleAppsScript.Base.Blob;
+    return [
+      {
+        mime_type: "application/pdf",
+        data: Utilities.base64Encode(pdfBlob.getBytes()),
+      },
+    ];
   }
-  return {
-    mime_type: file.getMimeType(),
-    data: Utilities.base64Encode(file.getBlob().getBytes()),
-  };
+
+  if (mimeType === MimeType.GOOGLE_SHEETS) {
+    const ss = SpreadsheetApp.openById(fileId);
+    return ss.getSheets().map((sheet) => {
+      const values = sheet.getDataRange().getValues();
+      const csv = values
+        .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(","))
+        .join("\n");
+      return {
+        mime_type: "text/csv",
+        data: Utilities.base64Encode(csv, Utilities.Charset.UTF_8),
+      };
+    });
+  }
+
+  if (
+    mimeType === MimeType.PDF ||
+    mimeType.startsWith("image/") ||
+    mimeType.startsWith("video/") ||
+    mimeType.startsWith("audio/")
+  ) {
+    return [
+      {
+        mime_type: mimeType,
+        data: Utilities.base64Encode(file.getBlob().getBytes()),
+      },
+    ];
+  }
+
+  throw new Error(
+    `Unsupported file type: ${mimeType} (${file.getName()}). ` +
+      `Supported types: Google Docs, Google Sheets, PDF, image/*, video/*, audio/*.`,
+  );
+}
+
+/**
+ * Prepare all Drive file attachments for a single Gemini inference call.
+ *
+ * Fetches and encodes each file, then enforces two size validation tiers:
+ *
+ * Tier 1 — Per-PDF pre-flight (checked before blob download):
+ *   Raw file size × INLINE_PREFLIGHT_FACTOR must not exceed INLINE_MAX_PDF_BYTES.
+ *   Skipped for Workspace exports (exported size is unknown before export).
+ *
+ * Tier 1 post-encode — Per-PDF ceiling:
+ *   Each encoded PDF part must not exceed INLINE_MAX_PDF_BYTES.
+ *
+ * Tier 2 — Total request check (checked after all files are encoded):
+ *   Sum of all encoded part lengths must not exceed INLINE_MAX_TOTAL_BYTES.
+ *
+ * For files exceeding inline limits, consider the Gemini Files API (up to 2GB,
+ * no base64 overhead): https://ai.google.dev/api/files
+ * TODO: implement uploadToFilesAPI() and route oversized files here instead of throwing.
+ */
+export function prepareDriveAttachments(fileIds: string[]): GeminiInlineData[] {
+  if (fileIds.length === 0) return [];
+
+  const parts: GeminiInlineData[] = [];
+
+  for (const fileId of fileIds) {
+    const file = DriveApp.getFileById(fileId);
+    const mimeType = file.getMimeType();
+
+    // Tier 1 pre-flight: check raw size for binary file types before downloading blob.
+    // Workspace exports (Docs/Sheets) are skipped — exported size is unknown pre-export.
+    if (
+      mimeType === MimeType.PDF ||
+      mimeType.startsWith("image/") ||
+      mimeType.startsWith("video/") ||
+      mimeType.startsWith("audio/")
+    ) {
+      const estimatedEncodedSize = file.getSize() * CONFIG.INLINE_PREFLIGHT_FACTOR;
+      if (mimeType === MimeType.PDF && estimatedEncodedSize > CONFIG.INLINE_MAX_PDF_BYTES) {
+        throw new Error(
+          `File too large: "${file.getName()}" (~${Math.round(file.getSize() / 1024 / 1024)}MB raw). ` +
+            `PDFs must be under ~${Math.round(CONFIG.INLINE_MAX_PDF_BYTES / CONFIG.INLINE_PREFLIGHT_FACTOR / 1024 / 1024)}MB raw ` +
+            `(${Math.round(CONFIG.INLINE_MAX_PDF_BYTES / 1024 / 1024)}MB encoded). ` +
+            `Consider the Gemini Files API for large payloads: https://ai.google.dev/api/files`,
+        );
+      }
+    }
+
+    parts.push(...exportAndEncodeFile(fileId, file));
+  }
+
+  // Tier 1 post-encode: verify each individual PDF part is within its per-file limit.
+  for (const part of parts) {
+    if (part.mime_type === "application/pdf" && part.data.length > CONFIG.INLINE_MAX_PDF_BYTES) {
+      throw new Error(
+        `PDF too large after encoding (~${Math.round(part.data.length / 1024 / 1024)}MB encoded, ` +
+          `limit ${Math.round(CONFIG.INLINE_MAX_PDF_BYTES / 1024 / 1024)}MB). ` +
+          `Consider the Gemini Files API for large payloads: https://ai.google.dev/api/files`,
+      );
+    }
+  }
+
+  // Tier 2: verify total combined encoded size across all parts.
+  const totalEncodedBytes = parts.reduce((sum, part) => sum + part.data.length, 0);
+  if (totalEncodedBytes > CONFIG.INLINE_MAX_TOTAL_BYTES) {
+    throw new Error(
+      `Attachments too large: combined encoded size is ~${Math.round(totalEncodedBytes / 1024 / 1024)}MB, ` +
+        `exceeds ${Math.round(CONFIG.INLINE_MAX_TOTAL_BYTES / 1024 / 1024)}MB inline limit. ` +
+        `Consider the Gemini Files API for large payloads: https://ai.google.dev/api/files`,
+    );
+  }
+
+  return parts;
 }

--- a/src/server/drive.ts
+++ b/src/server/drive.ts
@@ -82,10 +82,9 @@ function exportAndEncodeFile(
   const mimeType = file.getMimeType();
 
   if (mimeType === MimeType.GOOGLE_DOCS) {
-    const pdfBlob = Drive.Files.export(
-      fileId,
-      "application/pdf",
-    ) as unknown as GoogleAppsScript.Base.Blob;
+    // file.getAs() handles the Drive export correctly (includes alt=media internally).
+    // Drive.Files.export() alone returns metadata, not content.
+    const pdfBlob = file.getAs("application/pdf");
     return [
       {
         mime_type: "application/pdf",
@@ -175,7 +174,7 @@ export function prepareDriveAttachments(fileIds: string[]): GeminiInlineData[] {
           `File too large: "${file.getName()}" (~${Math.round(file.getSize() / 1024 / 1024)}MB raw). ` +
             `PDFs must be under ~${Math.round(CONFIG.INLINE_MAX_PDF_BYTES / CONFIG.INLINE_PREFLIGHT_FACTOR / 1024 / 1024)}MB raw ` +
             `(${Math.round(CONFIG.INLINE_MAX_PDF_BYTES / 1024 / 1024)}MB encoded). ` +
-            `Consider the Gemini Files API for large payloads: https://ai.google.dev/api/files`,
+            `consider breaking up the file into smaller components`,
         );
       }
       if (mimeType !== MimeType.PDF && estimatedEncodedSize > CONFIG.INLINE_MAX_TOTAL_BYTES) {
@@ -183,7 +182,7 @@ export function prepareDriveAttachments(fileIds: string[]): GeminiInlineData[] {
           `File too large: "${file.getName()}" (~${Math.round(file.getSize() / 1024 / 1024)}MB raw). ` +
             `Estimated encoded size (~${Math.round(estimatedEncodedSize / 1024 / 1024)}MB) exceeds the ` +
             `${Math.round(CONFIG.INLINE_MAX_TOTAL_BYTES / 1024 / 1024)}MB inline total limit. ` +
-            `Consider the Gemini Files API for large payloads: https://ai.google.dev/api/files`,
+            `consider breaking up the file into smaller components`,
         );
       }
     }
@@ -197,7 +196,7 @@ export function prepareDriveAttachments(fileIds: string[]): GeminiInlineData[] {
       throw new Error(
         `PDF too large after encoding (~${Math.round(part.data.length / 1024 / 1024)}MB encoded, ` +
           `limit ${Math.round(CONFIG.INLINE_MAX_PDF_BYTES / 1024 / 1024)}MB). ` +
-          `Consider the Gemini Files API for large payloads: https://ai.google.dev/api/files`,
+          `consider breaking up the file into smaller components`,
       );
     }
   }
@@ -208,7 +207,7 @@ export function prepareDriveAttachments(fileIds: string[]): GeminiInlineData[] {
     throw new Error(
       `Attachments too large: combined encoded size is ~${Math.round(totalEncodedBytes / 1024 / 1024)}MB, ` +
         `exceeds ${Math.round(CONFIG.INLINE_MAX_TOTAL_BYTES / 1024 / 1024)}MB inline limit. ` +
-        `Consider the Gemini Files API for large payloads: https://ai.google.dev/api/files`,
+        `consider breaking up the file into smaller components`,
     );
   }
 

--- a/src/server/drive.ts
+++ b/src/server/drive.ts
@@ -101,9 +101,12 @@ function exportAndEncodeFile(
     const ss = SpreadsheetApp.openById(fileId);
     return ss.getSheets().map((sheet) => {
       const values = sheet.getDataRange().getValues();
-      const csv = values
-        .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(","))
-        .join("\n");
+      const csv = [
+        `Sheet: ${sheet.getName()}`,
+        ...values.map((row) =>
+          row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(","),
+        ),
+      ].join("\n");
       return {
         mime_type: "text/csv",
         data: Utilities.base64Encode(csv, Utilities.Charset.UTF_8),

--- a/src/server/drive.ts
+++ b/src/server/drive.ts
@@ -95,6 +95,10 @@ function exportAndEncodeFile(
   }
 
   if (mimeType === MimeType.GOOGLE_SHEETS) {
+    // SpreadsheetApp is used here intentionally: Drive.Files.export only exports the
+    // first sheet as CSV. Per-sheet export requires SpreadsheetApp to enumerate sheets
+    // and get each sheet's values directly. This is a data-access use of SpreadsheetApp,
+    // not a UI concern, so the index.ts-only rule does not apply here.
     const ss = SpreadsheetApp.openById(fileId);
     return ss.getSheets().map((sheet) => {
       const values = sheet.getDataRange().getValues();
@@ -133,11 +137,12 @@ function exportAndEncodeFile(
  *
  * Fetches and encodes each file, then enforces two size validation tiers:
  *
- * Tier 1 — Per-PDF pre-flight (checked before blob download):
- *   Raw file size × INLINE_PREFLIGHT_FACTOR must not exceed INLINE_MAX_PDF_BYTES.
- *   Skipped for Workspace exports (exported size is unknown before export).
+ * Tier 1 — Pre-flight (checked before blob download, binary types only):
+ *   - PDF: estimated encoded size must not exceed INLINE_MAX_PDF_BYTES.
+ *   - image/video/audio: estimated encoded size must not exceed INLINE_MAX_TOTAL_BYTES.
+ *   - Workspace files (Docs/Sheets) are skipped here — exported size is unknown pre-export.
  *
- * Tier 1 post-encode — Per-PDF ceiling:
+ * Tier 1 post-encode — Per-PDF ceiling (covers native PDFs and Docs exported as PDF):
  *   Each encoded PDF part must not exceed INLINE_MAX_PDF_BYTES.
  *
  * Tier 2 — Total request check (checked after all files are encoded):
@@ -170,6 +175,14 @@ export function prepareDriveAttachments(fileIds: string[]): GeminiInlineData[] {
           `File too large: "${file.getName()}" (~${Math.round(file.getSize() / 1024 / 1024)}MB raw). ` +
             `PDFs must be under ~${Math.round(CONFIG.INLINE_MAX_PDF_BYTES / CONFIG.INLINE_PREFLIGHT_FACTOR / 1024 / 1024)}MB raw ` +
             `(${Math.round(CONFIG.INLINE_MAX_PDF_BYTES / 1024 / 1024)}MB encoded). ` +
+            `Consider the Gemini Files API for large payloads: https://ai.google.dev/api/files`,
+        );
+      }
+      if (mimeType !== MimeType.PDF && estimatedEncodedSize > CONFIG.INLINE_MAX_TOTAL_BYTES) {
+        throw new Error(
+          `File too large: "${file.getName()}" (~${Math.round(file.getSize() / 1024 / 1024)}MB raw). ` +
+            `Estimated encoded size (~${Math.round(estimatedEncodedSize / 1024 / 1024)}MB) exceeds the ` +
+            `${Math.round(CONFIG.INLINE_MAX_TOTAL_BYTES / 1024 / 1024)}MB inline total limit. ` +
             `Consider the Gemini Files API for large payloads: https://ai.google.dev/api/files`,
         );
       }

--- a/src/server/inference.ts
+++ b/src/server/inference.ts
@@ -7,7 +7,7 @@
  */
 
 import { invokeGemini } from "./api";
-import { fetchAndEncodeFile } from "./drive";
+import { prepareDriveAttachments } from "./drive";
 import { flattenArg, isValidDriveLink, extractId } from "./utils";
 import type { GeminiInlineData, GeminiResponse } from "./types";
 import type { ToolId } from "../shared/types";
@@ -37,9 +37,7 @@ export function runInference(
   try {
     const inlineData: GeminiInlineData[] =
       driveLinks !== undefined
-        ? flattenArg(driveLinks)
-            .filter(isValidDriveLink)
-            .map((link) => fetchAndEncodeFile(extractId(link)))
+        ? prepareDriveAttachments(flattenArg(driveLinks).filter(isValidDriveLink).map(extractId))
         : [];
 
     return invokeGemini({

--- a/src/server/inference.ts
+++ b/src/server/inference.ts
@@ -9,7 +9,7 @@
 import { invokeGemini } from "./api";
 import { prepareDriveAttachments } from "./drive";
 import { flattenArg, isValidDriveLink, extractId } from "./utils";
-import type { GeminiInlineData, GeminiResponse } from "./types";
+import type { GeminiResponse } from "./types";
 import type { ToolId } from "../shared/types";
 
 /**
@@ -35,7 +35,7 @@ export function runInference(
   if (userTexts.length === 0) return null;
 
   try {
-    const inlineData: GeminiInlineData[] =
+    const inlineData =
       driveLinks !== undefined
         ? prepareDriveAttachments(flattenArg(driveLinks).filter(isValidDriveLink).map(extractId))
         : [];

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -13,7 +13,24 @@ import type { ToolId } from "../shared/types";
 export interface AppConfig {
   API_KEY_PROPERTY: string;
   MODEL_NAME: string;
-  MAX_FILE_SIZE_BYTES: number;
+  /**
+   * Inline data size limits for the Gemini REST API.
+   * Source: https://ai.google.dev/gemini-api/docs/file-input-methods#method-comparison
+   *
+   * - Total request ceiling: 100MB (post-encoded, all inline_data parts combined)
+   * - Per-PDF ceiling: 50MB (post-encoded, per individual PDF file)
+   * - Base64 encoding expands raw file size by exactly 4/3
+   *
+   * We apply a 5% safety buffer to both ceilings to account for:
+   *   1. JSON envelope overhead (prompt text, mime_type fields, etc.)
+   *   2. Exported file size uncertainty (Docs/Sheets native size before export is unknown)
+   *
+   * For files exceeding these limits, consider the Gemini Files API (up to 2GB,
+   * no base64 overhead): https://ai.google.dev/api/files
+   */
+  INLINE_MAX_TOTAL_BYTES: number; // 95MB (100MB ceiling × 0.95)
+  INLINE_MAX_PDF_BYTES: number; // 47MB (50MB ceiling × 0.95)
+  INLINE_PREFLIGHT_FACTOR: number; // exact base64 expansion ratio (4/3)
   MAX_OUTPUT_TOKENS: number;
 }
 


### PR DESCRIPTION
## Summary

- Replaces `fetchAndEncodeFile` with `prepareDriveAttachments` — an aggregate pipeline that handles all Drive file types and enforces correct inline size limits
- Adds support for Google Docs (exported as PDF via `file.getAs()`), Google Sheets (one CSV part per sheet via SpreadsheetApp), video/* and audio/* MIME types
- Replaces the stale 25MB single threshold with three documented constants: `INLINE_MAX_TOTAL_BYTES` (95MB), `INLINE_MAX_PDF_BYTES` (47MB), `INLINE_PREFLIGHT_FACTOR` (4/3) — all with source URL and 5% safety buffer rationale in JSDoc
- Enforces limits on post-encoded (base64) aggregate size across all files in a row, with two tiers: per-PDF ceiling and total request ceiling
- Error messages for oversized files tell users to break up the file into smaller components

## Manual Testing

For each test, put the Drive URL in the `source_drive` column, a prompt in `user_prompt`, and run the AI tool.

**Google Doc → PDF**
- [x] Link a Google Doc — confirm the AI response reflects the document's content
- [ ] Link a Google Doc with tables/formatting — confirm Gemini reads it correctly (PDF export preserves layout)

**Google Sheets → multi-sheet CSV**
- [x] Link a Sheets file with a single sheet — confirm the AI response reflects the data
- [x] Link a Sheets file with 2+ sheets — confirm Gemini receives and can reason across all sheets (ask it to compare sheets or reference a specific one by name)

**Standard file types**
- [x] Link a PDF — confirm response reflects its content
- [x] Link an image — confirm Gemini describes it correctly

**Multiple attachments in one row**
- [x] Put two Drive URLs (comma-separated or in adjacent cells) in `source_drive` — confirm both files are attached and the response references content from both

**Size limit errors**
- [x] Link a file larger than the limit — confirm the error message says "consider breaking up the file into smaller components" and does NOT mention the Gemini Files API URL

**Unsupported file type**
- [x] Link a `.zip` or other unsupported file — confirm a clear error like "Unsupported file type: application/zip"

## Design Doc
`docs/plans/2026-03-17-drive-file-handling-redesign.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)