### PR TITLE
feat: add TokenInput searchable chip field for column selection

### DIFF
--- a/__tests__/components/token-input.test.ts
+++ b/__tests__/components/token-input.test.ts
@@ -1,0 +1,340 @@
+/**
+ * @jest-environment jsdom
+ */
+import { TokenInput } from "../../src/client/components/token-input";
+
+function makeContainer(): HTMLElement {
+  document.body.innerHTML = '<div id="c"></div>';
+  return document.getElementById("c")!;
+}
+
+const ITEMS = ["col_a", "col_b", "col_c"];
+
+function openDropdown(c: HTMLElement): void {
+  c.querySelector<HTMLElement>(".token-add-btn")!.click();
+}
+
+function selectOption(c: HTMLElement, value: string): void {
+  c.querySelector<HTMLElement>(`.token-option[data-value="${value}"]`)!.click();
+}
+
+// ─── Initial render ──────────────────────────────────────────────────────────
+
+describe("TokenInput — initial render", () => {
+  it("renders a .token-field container", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    expect(c.querySelector(".token-field")).not.toBeNull();
+  });
+
+  it("shows no chips when nothing is pre-selected", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    expect(c.querySelectorAll(".token-chip")).toHaveLength(0);
+  });
+
+  it("shows one chip per pre-selected item", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { selected: ["col_a", "col_c"] });
+    expect(c.querySelectorAll(".token-chip")).toHaveLength(2);
+  });
+
+  it("dropdown is hidden initially", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    expect(c.querySelector<HTMLElement>(".token-dropdown")!.style.display).toBe("none");
+  });
+});
+
+// ─── Dropdown open / close ────────────────────────────────────────────────────
+
+describe("TokenInput — dropdown open/close", () => {
+  it("clicking the field opens the dropdown", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    expect(c.querySelector<HTMLElement>(".token-dropdown")!.style.display).not.toBe("none");
+  });
+
+  it("dropdown shows only unselected items", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { selected: ["col_a"] });
+    openDropdown(c);
+    const options = c.querySelectorAll(".token-option");
+    expect(options).toHaveLength(2);
+    const values = Array.from(options).map((o) => o.getAttribute("data-value"));
+    expect(values).not.toContain("col_a");
+  });
+
+  it("pressing Escape closes the dropdown", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    c.querySelector<HTMLInputElement>(".token-search")!.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    expect(c.querySelector<HTMLElement>(".token-dropdown")!.style.display).toBe("none");
+  });
+
+  it("clicking outside the field closes the dropdown", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    document.body.click();
+    expect(c.querySelector<HTMLElement>(".token-dropdown")!.style.display).toBe("none");
+  });
+});
+
+// ─── Filtering ────────────────────────────────────────────────────────────────
+
+describe("TokenInput — filtering", () => {
+  it("typing filters visible dropdown options", () => {
+    const c = makeContainer();
+    new TokenInput(c, ["alpha", "beta", "algebra"], {});
+    openDropdown(c);
+    const input = c.querySelector<HTMLInputElement>(".token-search")!;
+    input.value = "alp";
+    input.dispatchEvent(new Event("input"));
+    const visible = Array.from(c.querySelectorAll<HTMLElement>(".token-option")).filter(
+      (o) => o.style.display !== "none",
+    );
+    expect(visible).toHaveLength(1);
+    expect(visible[0].getAttribute("data-value")).toBe("alpha");
+  });
+
+  it("shows a no-match message when filter has no results", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    const input = c.querySelector<HTMLInputElement>(".token-search")!;
+    input.value = "zzz";
+    input.dispatchEvent(new Event("input"));
+    expect(c.querySelector(".token-no-match")).not.toBeNull();
+  });
+
+  it("clearing the filter restores all unselected options", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    const input = c.querySelector<HTMLInputElement>(".token-search")!;
+    input.value = "col_a";
+    input.dispatchEvent(new Event("input"));
+    input.value = "";
+    input.dispatchEvent(new Event("input"));
+    const visible = Array.from(c.querySelectorAll<HTMLElement>(".token-option")).filter(
+      (o) => o.style.display !== "none",
+    );
+    expect(visible).toHaveLength(3);
+  });
+});
+
+// ─── Selection — multi (default) ──────────────────────────────────────────────
+
+describe("TokenInput — selection (multi)", () => {
+  it("clicking a dropdown option adds a chip", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    selectOption(c, "col_b");
+    expect(c.querySelectorAll(".token-chip")).toHaveLength(1);
+  });
+
+  it("selecting an option removes it from the dropdown", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    selectOption(c, "col_b");
+    const values = Array.from(c.querySelectorAll(".token-option")).map((o) =>
+      o.getAttribute("data-value"),
+    );
+    expect(values).not.toContain("col_b");
+  });
+
+  it("dropdown closes after selecting in multi mode", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    selectOption(c, "col_b");
+    expect(c.querySelector<HTMLElement>(".token-dropdown")!.style.display).toBe("none");
+  });
+
+  it("getValue() returns all selected values", () => {
+    const c = makeContainer();
+    const ti = new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    selectOption(c, "col_a");
+    selectOption(c, "col_c");
+    expect(ti.getValue()).toEqual(["col_a", "col_c"]);
+  });
+
+  it("getValue() returns empty array when nothing is selected", () => {
+    const c = makeContainer();
+    const ti = new TokenInput(c, ITEMS, {});
+    expect(ti.getValue()).toEqual([]);
+  });
+
+  it("getValue() includes pre-selected items", () => {
+    const c = makeContainer();
+    const ti = new TokenInput(c, ITEMS, { selected: ["col_b"] });
+    expect(ti.getValue()).toEqual(["col_b"]);
+  });
+});
+
+// ─── Chip removal ─────────────────────────────────────────────────────────────
+
+describe("TokenInput — chip removal", () => {
+  it("clicking × on a chip removes it", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { selected: ["col_a"] });
+    c.querySelector<HTMLButtonElement>(".token-chip-remove")!.click();
+    expect(c.querySelectorAll(".token-chip")).toHaveLength(0);
+  });
+
+  it("removing a chip makes the item available in the dropdown again", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { selected: ["col_a"] });
+    c.querySelector<HTMLButtonElement>(".token-chip-remove")!.click();
+    openDropdown(c);
+    const values = Array.from(c.querySelectorAll(".token-option")).map((o) =>
+      o.getAttribute("data-value"),
+    );
+    expect(values).toContain("col_a");
+  });
+
+  it("getValue() excludes removed chips", () => {
+    const c = makeContainer();
+    const ti = new TokenInput(c, ITEMS, { selected: ["col_a", "col_b"] });
+    c.querySelector<HTMLButtonElement>('[data-value="col_a"] .token-chip-remove')!.click();
+    expect(ti.getValue()).toEqual(["col_b"]);
+  });
+});
+
+// ─── Single-select mode ───────────────────────────────────────────────────────
+
+describe("TokenInput — single-select mode", () => {
+  it("selecting an option closes the dropdown", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { multi: false });
+    openDropdown(c);
+    selectOption(c, "col_a");
+    expect(c.querySelector<HTMLElement>(".token-dropdown")!.style.display).toBe("none");
+  });
+
+  it("selecting a second option replaces the first chip", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { multi: false });
+    openDropdown(c);
+    selectOption(c, "col_a");
+    openDropdown(c);
+    selectOption(c, "col_b");
+    expect(c.querySelectorAll(".token-chip")).toHaveLength(1);
+    expect(c.querySelector<HTMLElement>(".token-chip")!.getAttribute("data-value")).toBe("col_b");
+  });
+
+  it("getValue() returns array with single selected value", () => {
+    const c = makeContainer();
+    const ti = new TokenInput(c, ITEMS, { multi: false });
+    openDropdown(c);
+    selectOption(c, "col_b");
+    expect(ti.getValue()).toEqual(["col_b"]);
+  });
+});
+
+// ─── includeNew (output column) ───────────────────────────────────────────────
+
+describe("TokenInput — includeNew", () => {
+  it("dropdown shows a '+ New column' option when includeNew is true", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { multi: false, includeNew: true });
+    openDropdown(c);
+    expect(c.querySelector('[data-value="__new__"]')).not.toBeNull();
+  });
+
+  it("selecting '+ New column' adds an editable text chip", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { multi: false, includeNew: true });
+    openDropdown(c);
+    selectOption(c, "__new__");
+    expect(c.querySelector<HTMLInputElement>(".token-chip-input")).not.toBeNull();
+  });
+
+  it("getValue() returns the editable chip text when '+ New column' is selected", () => {
+    const c = makeContainer();
+    const ti = new TokenInput(c, ITEMS, { multi: false, includeNew: true });
+    openDropdown(c);
+    selectOption(c, "__new__");
+    c.querySelector<HTMLInputElement>(".token-chip-input")!.value = "my_col";
+    expect(ti.getValue()).toEqual(["my_col"]);
+  });
+
+  it("pre-selects '+ New column' and fills chip input when selected value is not a known item", () => {
+    const c = makeContainer();
+    const ti = new TokenInput(c, ITEMS, {
+      multi: false,
+      includeNew: true,
+      selected: ["custom_val"],
+    });
+    expect(c.querySelector<HTMLInputElement>(".token-chip-input")).not.toBeNull();
+    expect(ti.getValue()).toEqual(["custom_val"]);
+  });
+
+  it("removing the '+ New column' chip makes '+ Add' reappear", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { multi: false, includeNew: true });
+    openDropdown(c);
+    selectOption(c, "__new__");
+    c.querySelector<HTMLButtonElement>('[data-value="__new__"].token-chip-remove')!.click();
+    expect(c.querySelector<HTMLElement>(".token-add-btn")!.style.display).not.toBe("none");
+  });
+
+  it("getValue() returns the regular selection after replacing a new-column chip", () => {
+    const c = makeContainer();
+    const ti = new TokenInput(c, ITEMS, { multi: false, includeNew: true });
+    openDropdown(c);
+    selectOption(c, "__new__"); // select + New column
+    openDropdown(c);
+    selectOption(c, "col_b"); // replace with a regular column
+    expect(ti.getValue()).toEqual(["col_b"]);
+  });
+});
+
+// ─── Add/change button ────────────────────────────────────────────────────────
+
+describe("TokenInput — add button visibility", () => {
+  it("shows '+ Add' button initially", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    expect(c.querySelector<HTMLElement>(".token-add-btn")!.style.display).not.toBe("none");
+  });
+
+  it("multi-select always shows '+ Add' after selection", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    selectOption(c, "col_a");
+    expect(c.querySelector<HTMLElement>(".token-add-btn")!.style.display).not.toBe("none");
+  });
+
+  it("single-select hides '+ Add' button after selection", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { multi: false });
+    openDropdown(c);
+    selectOption(c, "col_a");
+    expect(c.querySelector<HTMLElement>(".token-add-btn")!.style.display).toBe("none");
+  });
+
+  it("single-select shows '+ Add' again after chip is removed", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { multi: false });
+    openDropdown(c);
+    selectOption(c, "col_a");
+    c.querySelector<HTMLButtonElement>(".token-chip-remove")!.click();
+    expect(c.querySelector<HTMLElement>(".token-add-btn")!.style.display).not.toBe("none");
+  });
+
+  it("single-select hides '+ Add' when pre-selected", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { multi: false, selected: ["col_a"] });
+    expect(c.querySelector<HTMLElement>(".token-add-btn")!.style.display).toBe("none");
+  });
+});

--- a/__tests__/panels/configure-ai-run.test.ts
+++ b/__tests__/panels/configure-ai-run.test.ts
@@ -46,6 +46,19 @@ async function mountAndLoad(
   return { container, panel };
 }
 
+/** Selects a column in a TokenInput field by opening its dropdown and clicking the option. */
+function selectColumn(container: HTMLElement, fieldId: string, value: string): void {
+  container.querySelector<HTMLElement>(`#${fieldId} .token-add-btn`)!.click();
+  container.querySelector<HTMLElement>(`#${fieldId} .token-option[data-value="${value}"]`)!.click();
+}
+
+/** Returns data-value attributes of current chips in a TokenInput field. */
+function getChipValues(container: HTMLElement, fieldId: string): string[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(`#${fieldId} .token-chip[data-value]`),
+  ).map((el) => el.getAttribute("data-value") ?? "");
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   globalThis.alert = jest.fn();
@@ -84,9 +97,7 @@ describe("ConfigureAIRunPanel — mount", () => {
 
   it("pre-selects params on mount", async () => {
     const { container } = await mountAndLoad({ promptCols: [{ col: "col_a", kind: "text" }] });
-    const selected = container.querySelectorAll("#user-prompt-cols .tag.selected");
-    expect(selected).toHaveLength(1);
-    expect(selected[0].getAttribute("data-value")).toBe("col_a");
+    expect(getChipValues(container, "user-prompt-cols")).toContain("col_a");
   });
 
   it("restores savedState over params", async () => {
@@ -99,8 +110,7 @@ describe("ConfigureAIRunPanel — mount", () => {
       { promptCols: [{ col: "col_a", kind: "text" }] },
       savedState,
     );
-    const selected = container.querySelectorAll("#user-prompt-cols .tag.selected");
-    expect(selected[0].getAttribute("data-value")).toBe("col_b");
+    expect(getChipValues(container, "user-prompt-cols")).toContain("col_b");
   });
 });
 
@@ -114,7 +124,7 @@ describe("ConfigureAIRunPanel — Run AI", () => {
 
   it("alerts when no output column selected", async () => {
     const { container } = await mountAndLoad();
-    container.querySelector<HTMLButtonElement>('[data-value="col_a"]')!.click();
+    selectColumn(container, "user-prompt-cols", "col_a");
     container.querySelector<HTMLButtonElement>("#run-btn")!.click();
     expect(globalThis.alert).toHaveBeenCalledWith("Please select an output column.");
   });
@@ -155,7 +165,7 @@ describe("ConfigureAIRunPanel — Run AI", () => {
     );
   });
 
-  it("stays on panel after run is dispatched and refetches headers", async () => {
+  it("stays on panel after run is dispatched without reloading headers", async () => {
     (services.runBatchAI as jest.Mock).mockResolvedValue(undefined);
     const { container } = await mountAndLoad({
       promptCols: [{ col: "col_a", kind: "text" }],
@@ -164,7 +174,7 @@ describe("ConfigureAIRunPanel — Run AI", () => {
     container.querySelector<HTMLButtonElement>("#run-btn")!.click();
     await Promise.resolve();
     expect(mockNav.back).not.toHaveBeenCalled();
-    expect(services.getSheetHeaders).toHaveBeenCalledTimes(2); // initial load + refresh
+    expect(services.getSheetHeaders).toHaveBeenCalledTimes(1); // initial load only, no reload
   });
 
   it("alerts on failure via jobStore catch handler", async () => {
@@ -222,8 +232,7 @@ describe("ConfigureAIRunPanel — refresh", () => {
     await Promise.resolve();
     expect(services.getSheetHeaders).toHaveBeenCalledTimes(2);
     // selections preserved after refresh
-    const tags = container.querySelectorAll("#user-prompt-cols .tag.selected");
-    expect(tags.length).toBeGreaterThan(0);
+    expect(getChipValues(container, "user-prompt-cols")).toContain("col_a");
   });
 });
 
@@ -300,19 +309,17 @@ describe("includeGrounding checkbox", () => {
   it("unmount saves includeGrounding state", async () => {
     const { container, panel } = await mountAndLoad();
     container.querySelector<HTMLInputElement>("#include-grounding-cb")!.checked = true;
-    // Select at least one user-prompt column so unmount() returns a value (not undefined)
-    container.querySelectorAll<HTMLElement>("#user-prompt-cols .tag")[0]?.click();
+    selectColumn(container, "user-prompt-cols", "col_a");
     const saved = panel.unmount();
     expect(saved?.includeGrounding).toBe(true);
   });
 
   it("updates grounding column label when output column selection changes", async () => {
-    const { container } = await mountAndLoad(); // no pre-selected output column
-    const tag = container.querySelector<HTMLButtonElement>("#output-col .tag");
-    if (!tag) return; // guard against no tags in jsdom
-    tag.click();
+    const { container } = await mountAndLoad();
+    selectColumn(container, "output-col", "col_a");
+    await Promise.resolve(); // flush MutationObserver microtask
     const label = container.querySelector<HTMLElement>("#grounding-col-name");
-    expect(label?.textContent).toBe(`${tag.textContent}_grounding`);
+    expect(label?.textContent).toBe("col_a_grounding");
   });
 
   it("restores includeGrounding from savedState", async () => {
@@ -365,10 +372,8 @@ describe("includeGrounding checkbox", () => {
 describe("ConfigureAIRunPanel — unmount", () => {
   it("unmount() returns current form state as SavedState", async () => {
     const { container, panel } = await mountAndLoad();
-    container.querySelector<HTMLButtonElement>('[data-value="col_a"]')!.click(); // user-prompt
-    container
-      .querySelectorAll<HTMLButtonElement>("#output-col .tag")[1]! // ai_inference
-      .click();
+    selectColumn(container, "user-prompt-cols", "col_a");
+    selectColumn(container, "output-col", "ai_inference");
     const state = panel.unmount();
     expect(state).not.toBeUndefined();
     const typedState = state as { promptCols: Array<{ col: string; kind: string }> };

--- a/__tests__/panels/extract-text.test.ts
+++ b/__tests__/panels/extract-text.test.ts
@@ -30,6 +30,11 @@ function mountPanel(savedState?: unknown): HTMLElement {
   return container;
 }
 
+function selectColumn(container: HTMLElement, fieldId: string, value: string): void {
+  container.querySelector<HTMLElement>(`#${fieldId} .token-add-btn`)!.click();
+  container.querySelector<HTMLElement>(`#${fieldId} .token-option[data-value="${value}"]`)!.click();
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   (jobStoreModule.jobStore.dispatch as jest.Mock).mockResolvedValue(undefined);
@@ -72,7 +77,7 @@ describe("ExtractTextPanel", () => {
     const c = mountPanel();
     await Promise.resolve();
     // select source column but not output
-    c.querySelector<HTMLElement>("#source-col .tag")?.click();
+    selectColumn(c, "source-col", "source_drive");
     c.querySelector<HTMLButtonElement>("#extract-btn")!.click();
     expect(globalThis.alert).toHaveBeenCalledWith(expect.stringContaining("output column"));
   });
@@ -84,9 +89,8 @@ describe("ExtractTextPanel", () => {
     const c = mountPanel();
     await Promise.resolve();
 
-    // select first tag in each list independently
-    c.querySelector<HTMLElement>("#source-col .tag")?.click();
-    c.querySelector<HTMLElement>("#output-col .tag")?.click();
+    selectColumn(c, "source-col", "source_drive");
+    selectColumn(c, "output-col", "extracted_text");
 
     c.querySelector<HTMLButtonElement>("#extract-btn")!.click();
     expect(jobStoreModule.jobStore.dispatch).toHaveBeenCalledWith(
@@ -102,8 +106,8 @@ describe("ExtractTextPanel", () => {
     const c = mountPanel();
     await Promise.resolve();
 
-    c.querySelector<HTMLElement>("#source-col .tag")?.click();
-    c.querySelector<HTMLElement>("#output-col .tag")?.click();
+    selectColumn(c, "source-col", "source_drive");
+    selectColumn(c, "output-col", "extracted_text");
     // leave RowRange in default "Use sheet selection" mode
     c.querySelector<HTMLButtonElement>("#extract-btn")!.click();
 
@@ -119,8 +123,8 @@ describe("ExtractTextPanel", () => {
     const c = mountPanel();
     await Promise.resolve();
 
-    c.querySelector<HTMLElement>("#source-col .tag")?.click();
-    c.querySelector<HTMLElement>("#output-col .tag")?.click();
+    selectColumn(c, "source-col", "source_drive");
+    selectColumn(c, "output-col", "extracted_text");
 
     // switch to "Specify range" and fill in values
     const rangeRadio = c.querySelector<HTMLInputElement>("input[value='range']")!;
@@ -183,8 +187,8 @@ describe("ExtractTextPanel", () => {
     const c = mountPanel();
     await Promise.resolve();
 
-    c.querySelector<HTMLElement>("#source-col .tag")?.click();
-    c.querySelector<HTMLElement>("#output-col .tag")?.click();
+    selectColumn(c, "source-col", "source_drive");
+    selectColumn(c, "output-col", "extracted_text");
     c.querySelector<HTMLButtonElement>("#extract-btn")!.click();
     await new Promise((r) => setTimeout(r, 0));
     expect(globalThis.alert).toHaveBeenCalledWith("Error: job failed");

--- a/__tests__/panels/import-drive-links.test.ts
+++ b/__tests__/panels/import-drive-links.test.ts
@@ -30,6 +30,11 @@ function mountPanel(savedState?: unknown): HTMLElement {
   return container;
 }
 
+function selectColumn(container: HTMLElement, fieldId: string, value: string): void {
+  container.querySelector<HTMLElement>(`#${fieldId} .token-add-btn`)!.click();
+  container.querySelector<HTMLElement>(`#${fieldId} .token-option[data-value="${value}"]`)!.click();
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   (jobStoreModule.jobStore.dispatch as jest.Mock).mockResolvedValue(undefined);
@@ -75,8 +80,7 @@ describe("ImportDriveLinksPanel", () => {
 
     c.querySelector<HTMLInputElement>("#folder-url-input")!.value =
       "https://drive.google.com/drive/folders/abc123";
-    // select the output column tag
-    c.querySelector<HTMLElement>("#output-col .tag")?.click();
+    selectColumn(c, "output-col", "source_drive");
 
     c.querySelector<HTMLButtonElement>("#import-btn")!.click();
     expect(jobStoreModule.jobStore.dispatch).toHaveBeenCalledWith(
@@ -128,7 +132,7 @@ describe("ImportDriveLinksPanel", () => {
     await Promise.resolve();
     c.querySelector<HTMLInputElement>("#folder-url-input")!.value =
       "https://drive.google.com/drive/folders/abc123";
-    // do NOT click any output column tag — leave it unselected
+    // do NOT select any output column — leave it unselected
     c.querySelector<HTMLButtonElement>("#import-btn")!.click();
     expect(globalThis.alert).toHaveBeenCalledWith(expect.stringContaining("output column"));
   });
@@ -172,7 +176,7 @@ describe("ImportDriveLinksPanel", () => {
     await Promise.resolve();
     c.querySelector<HTMLInputElement>("#folder-url-input")!.value =
       "https://drive.google.com/drive/folders/abc123";
-    c.querySelector<HTMLElement>("#output-col .tag")?.click();
+    selectColumn(c, "output-col", "source_drive");
     c.querySelector<HTMLButtonElement>("#import-btn")!.click();
     await new Promise((r) => setTimeout(r, 0));
     expect(globalThis.alert).toHaveBeenCalledWith("Error: job failed");

--- a/src/client/components/token-input.ts
+++ b/src/client/components/token-input.ts
@@ -25,6 +25,8 @@ export interface TokenInputOpts {
   multi?: boolean;
   /** Append a "+ New column" option for creating a new named column. */
   includeNew?: boolean;
+  /** Initial value pre-filled in the new-column chip input. Defaults to "". */
+  newDefault?: string;
 }
 
 export class TokenInput {
@@ -37,6 +39,7 @@ export class TokenInput {
   private readonly allItems: string[];
   private readonly multi: boolean;
   private readonly includeNew: boolean;
+  private readonly newDefault: string;
 
   /** Ordered list of currently selected values (preserves insertion order). */
   private selected: string[];
@@ -49,6 +52,7 @@ export class TokenInput {
     this.allItems = items;
     this.multi = opts.multi !== false;
     this.includeNew = opts.includeNew === true;
+    this.newDefault = opts.newDefault ?? "";
     this.selected = [];
 
     // Build DOM
@@ -241,7 +245,7 @@ export class TokenInput {
     }
 
     this.closeDropdown();
-    this.addNewChip("ai_");
+    this.addNewChip(this.newDefault);
     this.updateAddBtn();
   }
 

--- a/src/client/components/token-input.ts
+++ b/src/client/components/token-input.ts
@@ -1,0 +1,310 @@
+/**
+ * TokenInput — searchable token/chip field for column selection.
+ *
+ * USE THIS when the list of items is potentially large (8+ items) and users
+ * know what they're looking for. Selected items appear as removable chips
+ * inside the field; unselected items appear in a filtered dropdown.
+ *
+ * Supports multi-select (default) and single-select (`multi: false`).
+ * Use `includeNew: true` on single-select output fields to allow the user to
+ * type a brand-new column name.
+ *
+ * Prefer TagList when the item count is small and users benefit from seeing
+ * all options at a glance (e.g. the Tools section with ~5 fixed entries).
+ *
+ * Naming note: selected items are called "chips" here (inline removable tokens).
+ * They reuse the `.tag.selected` CSS class from TagList for visual consistency —
+ * same appearance, different interaction model (chips are removed individually;
+ * tags are toggled).
+ */
+
+export interface TokenInputOpts {
+  /** Values to pre-select on construction. */
+  selected?: string[];
+  /** Allow multiple selections. Defaults to true. */
+  multi?: boolean;
+  /** Append a "+ New column" option for creating a new named column. */
+  includeNew?: boolean;
+}
+
+export class TokenInput {
+  private readonly field: HTMLElement;
+  private readonly chipsArea: HTMLElement;
+  private readonly addBtn: HTMLButtonElement;
+  private readonly searchInput: HTMLInputElement;
+  private readonly dropdown: HTMLElement;
+
+  private readonly allItems: string[];
+  private readonly multi: boolean;
+  private readonly includeNew: boolean;
+
+  /** Ordered list of currently selected values (preserves insertion order). */
+  private selected: string[];
+  /** True when the editable "+ New column" chip is present. */
+  private hasNewChip = false;
+
+  private readonly onDocumentClick: (e: MouseEvent) => void;
+
+  constructor(container: HTMLElement, items: string[], opts: TokenInputOpts) {
+    this.allItems = items;
+    this.multi = opts.multi !== false;
+    this.includeNew = opts.includeNew === true;
+    this.selected = [];
+
+    // Build DOM
+    this.field = document.createElement("div");
+    this.field.className = "token-field";
+
+    this.chipsArea = document.createElement("div");
+    this.chipsArea.className = "token-chips";
+
+    this.addBtn = document.createElement("button");
+    this.addBtn.type = "button";
+    this.addBtn.className = "token-add-btn tag";
+    this.addBtn.textContent = "+ Add";
+    this.chipsArea.appendChild(this.addBtn);
+
+    this.field.appendChild(this.chipsArea);
+
+    this.dropdown = document.createElement("div");
+    this.dropdown.className = "token-dropdown";
+    this.dropdown.style.display = "none";
+    this.field.appendChild(this.dropdown);
+
+    this.searchInput = document.createElement("input");
+    this.searchInput.type = "text";
+    this.searchInput.className = "token-search";
+    this.searchInput.placeholder = "Search...";
+    this.searchInput.autocomplete = "off";
+    this.dropdown.appendChild(this.searchInput);
+
+    container.appendChild(this.field);
+
+    this.onDocumentClick = (e: MouseEvent): void => {
+      if (!this.field.contains(e.target as Node)) this.closeDropdown();
+    };
+    this.wireEvents();
+    this.renderDropdown();
+
+    // Apply pre-selections
+    const initial = opts.selected ?? [];
+    if (this.includeNew && initial.length > 0 && !items.includes(initial[0])) {
+      // Custom value not in known items — treat as a "new column" selection
+      this.addNewChip(initial[0]);
+    } else {
+      for (const val of initial) {
+        if (items.includes(val)) {
+          this.selected.push(val);
+          this.addChip(val);
+        }
+      }
+    }
+
+    this.updateAddBtn();
+  }
+
+  // ─── Public API ─────────────────────────────────────────────────────────────
+
+  destroy(): void {
+    document.removeEventListener("click", this.onDocumentClick);
+    this.field.remove();
+  }
+
+  /**
+   * Returns the current selected values.
+   * Note: returns [] if the "+ New column" chip is present but its input is empty.
+   */
+  getValue(): string[] {
+    if (this.hasNewChip) {
+      const val = this.chipsArea.querySelector<HTMLInputElement>(".token-chip-input")?.value.trim();
+      return val ? [val] : [];
+    }
+    return [...this.selected];
+  }
+
+  // ─── Events ─────────────────────────────────────────────────────────────────
+
+  private wireEvents(): void {
+    this.addBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.openDropdown();
+      this.searchInput.focus();
+    });
+
+    this.searchInput.addEventListener("input", () => this.applyFilter());
+
+    this.searchInput.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") this.closeDropdown();
+    });
+
+    document.addEventListener("click", this.onDocumentClick);
+  }
+
+  // ─── Dropdown ───────────────────────────────────────────────────────────────
+
+  private openDropdown(): void {
+    this.renderDropdown();
+    this.searchInput.value = "";
+    this.applyFilter();
+    this.dropdown.style.display = "block";
+  }
+
+  private closeDropdown(): void {
+    this.dropdown.style.display = "none";
+    this.searchInput.value = "";
+  }
+
+  private updateAddBtn(): void {
+    const hasSelection = this.selected.length > 0 || this.hasNewChip;
+    this.addBtn.style.display = !this.multi && hasSelection ? "none" : "";
+  }
+
+  private renderDropdown(): void {
+    // Clear only option elements, preserving the searchInput as first child
+    const options = this.dropdown.querySelectorAll(".token-option, .token-no-match");
+    options.forEach((el) => el.remove());
+
+    const unselected = this.allItems.filter((item) => !this.selected.includes(item));
+
+    for (const item of unselected) {
+      const opt = document.createElement("div");
+      opt.className = "token-option";
+      opt.setAttribute("data-value", item);
+      opt.textContent = item;
+      opt.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this.selectItem(item);
+      });
+      this.dropdown.appendChild(opt);
+    }
+
+    if (this.includeNew) {
+      const newOpt = document.createElement("div");
+      newOpt.className = "token-option";
+      newOpt.setAttribute("data-value", "__new__");
+      newOpt.textContent = "+ New column";
+      newOpt.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this.selectNewColumn();
+      });
+      this.dropdown.appendChild(newOpt);
+    }
+  }
+
+  private applyFilter(): void {
+    const query = this.searchInput.value.toLowerCase();
+    const options = this.dropdown.querySelectorAll<HTMLElement>(".token-option");
+    let anyVisible = false;
+
+    options.forEach((opt) => {
+      const matches =
+        opt.getAttribute("data-value") === "__new__" ||
+        (opt.textContent ?? "").toLowerCase().includes(query);
+      opt.style.display = matches ? "block" : "none";
+      if (matches) anyVisible = true;
+    });
+
+    // Remove stale no-match message before re-evaluating
+    this.dropdown.querySelector(".token-no-match")?.remove();
+
+    if (!anyVisible) {
+      const msg = document.createElement("div");
+      msg.className = "token-no-match";
+      msg.textContent = "No matches";
+      this.dropdown.appendChild(msg);
+    }
+  }
+
+  // ─── Selection ──────────────────────────────────────────────────────────────
+
+  private selectItem(value: string): void {
+    if (!this.multi) {
+      // Single-select: clear existing selection first
+      this.selected = [];
+      this.hasNewChip = false;
+      this.chipsArea.querySelectorAll<HTMLElement>(".token-chip").forEach((chip) => chip.remove());
+    }
+
+    this.selected.push(value);
+    this.addChip(value);
+    this.renderDropdown();
+
+    this.closeDropdown();
+    this.updateAddBtn();
+  }
+
+  private selectNewColumn(): void {
+    if (!this.multi) {
+      this.selected = [];
+      this.hasNewChip = false;
+      this.chipsArea.querySelectorAll<HTMLElement>(".token-chip").forEach((chip) => chip.remove());
+    }
+
+    this.closeDropdown();
+    this.addNewChip("ai_");
+    this.updateAddBtn();
+  }
+
+  // ─── Chips ──────────────────────────────────────────────────────────────────
+
+  private addChip(value: string): void {
+    const chip = document.createElement("span");
+    chip.className = "token-chip tag selected";
+    chip.setAttribute("data-value", value);
+    chip.textContent = value;
+
+    const removeBtn = document.createElement("button");
+    removeBtn.className = "token-chip-remove";
+    removeBtn.setAttribute("data-value", value);
+    removeBtn.type = "button";
+    removeBtn.textContent = "×";
+    removeBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.removeChip(value, chip);
+    });
+
+    chip.appendChild(removeBtn);
+    this.chipsArea.insertBefore(chip, this.addBtn);
+  }
+
+  private addNewChip(initialValue: string): void {
+    this.hasNewChip = true;
+
+    const chip = document.createElement("span");
+    chip.className = "token-chip token-chip-new tag selected";
+
+    const chipInput = document.createElement("input");
+    chipInput.type = "text";
+    chipInput.className = "token-chip-input";
+    chipInput.value = initialValue;
+    chipInput.addEventListener("click", (e) => e.stopPropagation());
+
+    const removeBtn = document.createElement("button");
+    removeBtn.className = "token-chip-remove";
+    removeBtn.setAttribute("data-value", "__new__");
+    removeBtn.type = "button";
+    removeBtn.textContent = "×";
+    removeBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      chip.remove();
+      this.hasNewChip = false;
+      this.updateAddBtn();
+    });
+
+    chip.appendChild(chipInput);
+    chip.appendChild(removeBtn);
+    this.chipsArea.insertBefore(chip, this.addBtn);
+    chipInput.focus();
+  }
+
+  private removeChip(value: string, chipEl: HTMLElement): void {
+    this.selected = this.selected.filter((v) => v !== value);
+    chipEl.remove();
+    // Refresh dropdown so the removed item reappears
+    if (this.dropdown.style.display !== "none") {
+      this.renderDropdown();
+      this.applyFilter();
+    }
+    this.updateAddBtn();
+  }
+}

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -130,6 +130,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
         this.outputColList = new TokenInput(container.querySelector("#output-col")!, headers, {
           multi: false,
           includeNew: true,
+          newDefault: "ai_",
           selected: preset.outputCol ? [preset.outputCol] : [],
         });
         this.rowRangeComp = new RowRange(

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -1,7 +1,7 @@
 import type { NavigationContext, Panel } from "../types";
 import type { RunConfig, ToolId, PromptColumnSpec } from "../../shared/types";
 import { TagList } from "../components/tag-list";
-import { SingleTagList } from "../components/single-tag-list";
+import { TokenInput } from "../components/token-input";
 import { RowRange } from "../components/row-range";
 import { PanelLoader } from "../components/panel-loader";
 import { getSheetHeaders, runBatchAI } from "../services";
@@ -30,14 +30,15 @@ export type SavedState = Required<
   Pick<RunConfig, "rowRange" | "tools" | "includeGrounding" | "applyMarkdown">;
 
 export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState> {
-  private userPromptList: TagList | null = null;
-  private driveFileList: TagList | null = null;
-  private systemPromptList: SingleTagList | null = null;
-  private outputColList: SingleTagList | null = null;
+  private userPromptList: TokenInput | null = null;
+  private driveFileList: TokenInput | null = null;
+  private systemPromptList: TokenInput | null = null;
+  private outputColList: TokenInput | null = null;
   private rowRangeComp: RowRange | null = null;
   private toolsList: TagList | null = null;
   private includeGroundingCb: HTMLInputElement | null = null;
   private applyMarkdownCb: HTMLInputElement | null = null;
+  private outputColObserver: MutationObserver | null = null;
   private nav: NavigationContext | null = null;
   private headersLoaded = false;
 
@@ -96,6 +97,12 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
   }
 
   private loadHeaders(container: HTMLElement, preset: Partial<RunConfig>): Promise<void> {
+    this.outputColObserver?.disconnect();
+    this.outputColObserver = null;
+    this.userPromptList?.destroy();
+    this.driveFileList?.destroy();
+    this.systemPromptList?.destroy();
+    this.outputColList?.destroy();
     return getSheetHeaders().then(
       (headers) => {
         if (headers.length === 0) {
@@ -107,26 +114,23 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
           preset.promptCols?.filter((p) => p.kind === "text").map((p) => p.col) ?? [];
         const presetFileCols =
           preset.promptCols?.filter((p) => p.kind === "file").map((p) => p.col) ?? [];
-        this.userPromptList = new TagList(
+        this.userPromptList = new TokenInput(
           container.querySelector("#user-prompt-cols")!,
           headers,
-          presetTextCols,
+          { selected: presetTextCols },
         );
-        this.driveFileList = new TagList(
-          container.querySelector("#drive-file-cols")!,
-          headers,
-          presetFileCols,
-        );
-        this.systemPromptList = new SingleTagList(
+        this.driveFileList = new TokenInput(container.querySelector("#drive-file-cols")!, headers, {
+          selected: presetFileCols,
+        });
+        this.systemPromptList = new TokenInput(
           container.querySelector("#system-prompt-col")!,
           headers,
-          { selected: preset.systemPromptCol },
+          { multi: false, selected: preset.systemPromptCol ? [preset.systemPromptCol] : [] },
         );
-        this.outputColList = new SingleTagList(container.querySelector("#output-col")!, headers, {
+        this.outputColList = new TokenInput(container.querySelector("#output-col")!, headers, {
+          multi: false,
           includeNew: true,
-          selected: preset.outputCol,
-          newPlaceholder: "ai_column_name",
-          newDefault: "ai_",
+          selected: preset.outputCol ? [preset.outputCol] : [],
         });
         this.rowRangeComp = new RowRange(
           container.querySelector("#row-range-container")!,
@@ -134,15 +138,17 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
         );
 
         const updateGroundingLabel = (): void => {
-          const val = this.outputColList?.getValue() ?? "";
+          const val = this.outputColList?.getValue()[0] ?? "";
           const label = container.querySelector<HTMLElement>("#grounding-col-name");
           if (label) label.textContent = val ? `${val}_grounding` : "_grounding";
         };
         updateGroundingLabel();
-        container.querySelector("#output-col")?.addEventListener("click", updateGroundingLabel);
-        container
-          .querySelector("#output-col input")
-          ?.addEventListener("input", updateGroundingLabel);
+        const outputColEl = container.querySelector("#output-col");
+        if (outputColEl) {
+          const observer = new MutationObserver(updateGroundingLabel);
+          observer.observe(outputColEl, { childList: true, subtree: true });
+          this.outputColObserver = observer;
+        }
 
         if (!this.headersLoaded) {
           container.querySelector<HTMLElement>("#config-form")!.style.display = "block";
@@ -161,13 +167,18 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
 
   unmount(): SavedState | undefined {
     if (!this.userPromptList) return undefined;
+    this.outputColObserver?.disconnect();
+    this.userPromptList.destroy();
+    this.driveFileList?.destroy();
+    this.systemPromptList?.destroy();
+    this.outputColList?.destroy();
     return {
       promptCols: [
         ...this.userPromptList.getValue().map((col) => ({ col, kind: "text" as const })),
         ...(this.driveFileList?.getValue() ?? []).map((col) => ({ col, kind: "file" as const })),
       ],
-      systemPromptCol: this.systemPromptList?.getValue() ?? "",
-      outputCol: this.outputColList?.getValue() ?? "",
+      systemPromptCol: this.systemPromptList?.getValue()[0] ?? "",
+      outputCol: this.outputColList?.getValue()[0] ?? "",
       rowRange: this.rowRangeComp?.getValue(),
       tools: (this.toolsList?.getValue() ?? []) as ToolId[],
       includeGrounding: this.includeGroundingCb?.checked ?? false,
@@ -196,8 +207,8 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
         ...textCols.map((col) => ({ col, kind: "text" as const })),
         ...fileCols.map((col) => ({ col, kind: "file" as const })),
       ],
-      systemPromptCol: this.systemPromptList?.getValue() || undefined,
-      outputCol: this.outputColList?.getValue() || undefined,
+      systemPromptCol: this.systemPromptList?.getValue()[0] || undefined,
+      outputCol: this.outputColList?.getValue()[0] || undefined,
       rowRange: this.rowRangeComp?.getValue(),
       tools: (this.toolsList?.getValue() ?? []) as ToolId[],
       includeGrounding: this.includeGroundingCb?.checked,
@@ -205,7 +216,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
     };
   }
 
-  private handleRun(container: HTMLElement): void {
+  private handleRun(_container: HTMLElement): void {
     const config = this.assembleRunConfig();
     if (!config) return;
 
@@ -241,8 +252,8 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
         globalThis.alert("Error: " + err.message);
       });
     }
-
-    this.loadHeaders(container, this.currentPreset());
+    // NOTE: loadHeaders() is intentionally NOT called here.
+    // Reloading after dispatch caused flicker and re-initialization mid-run.
   }
 
   private async runChunks(
@@ -269,8 +280,8 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
       ...textCols.map((col) => ({ col, kind: "text" as const })),
       ...fileCols.map((col) => ({ col, kind: "file" as const })),
     ];
-    const systemPromptCol = this.systemPromptList?.getValue() || undefined;
-    const outputCol = this.outputColList?.getValue() ?? "";
+    const systemPromptCol = this.systemPromptList?.getValue()[0] || undefined;
+    const outputCol = this.outputColList?.getValue()[0] ?? "";
     if (!outputCol) {
       globalThis.alert("Please select an output column.");
       return null;

--- a/src/client/panels/extract-text.ts
+++ b/src/client/panels/extract-text.ts
@@ -44,6 +44,7 @@ export class ExtractTextPanel implements Panel<undefined, SavedState> {
           this.outputColList = new TokenInput(container.querySelector("#output-col")!, headers, {
             multi: false,
             includeNew: true,
+            newDefault: "extracted_text",
             selected: selectedOutput ? [selectedOutput] : [],
           });
           container.querySelector<HTMLElement>("#config-form")!.style.display = "block";

--- a/src/client/panels/extract-text.ts
+++ b/src/client/panels/extract-text.ts
@@ -1,6 +1,6 @@
 import type { NavigationContext, Panel } from "../types";
 import type { ExtractTextConfig } from "../../shared/types";
-import { SingleTagList } from "../components/single-tag-list";
+import { TokenInput } from "../components/token-input";
 import { RowRange } from "../components/row-range";
 import { PanelLoader } from "../components/panel-loader";
 import { getSheetHeaders, extractText } from "../services";
@@ -14,8 +14,8 @@ type SavedState = {
 };
 
 export class ExtractTextPanel implements Panel<undefined, SavedState> {
-  private sourceColList: SingleTagList | null = null;
-  private outputColList: SingleTagList | null = null;
+  private sourceColList: TokenInput | null = null;
+  private outputColList: TokenInput | null = null;
   private rowRange: RowRange | null = null;
   private nav: NavigationContext | null = null;
 
@@ -32,17 +32,19 @@ export class ExtractTextPanel implements Panel<undefined, SavedState> {
     const loader = new PanelLoader(container);
 
     const loadHeaders = (selectedSource?: string, selectedOutput?: string): Promise<void> => {
+      this.sourceColList?.destroy();
+      this.outputColList?.destroy();
       loader.setState({ status: "loading", message: "Loading columns..." });
       return getSheetHeaders().then(
         (headers) => {
-          this.sourceColList = new SingleTagList(container.querySelector("#source-col")!, headers, {
-            selected: selectedSource,
+          this.sourceColList = new TokenInput(container.querySelector("#source-col")!, headers, {
+            multi: false,
+            selected: selectedSource ? [selectedSource] : [],
           });
-          this.outputColList = new SingleTagList(container.querySelector("#output-col")!, headers, {
+          this.outputColList = new TokenInput(container.querySelector("#output-col")!, headers, {
+            multi: false,
             includeNew: true,
-            selected: selectedOutput,
-            newPlaceholder: "extracted_text",
-            newDefault: "",
+            selected: selectedOutput ? [selectedOutput] : [],
           });
           container.querySelector<HTMLElement>("#config-form")!.style.display = "block";
           loader.setState({ status: "idle" });
@@ -69,10 +71,12 @@ export class ExtractTextPanel implements Panel<undefined, SavedState> {
       const btn = container.querySelector<HTMLButtonElement>("#refresh-btn")!;
       btn.classList.add("spinning");
       btn.disabled = true;
-      loadHeaders(this.sourceColList?.getValue(), this.outputColList?.getValue()).finally(() => {
-        btn.classList.remove("spinning");
-        btn.disabled = false;
-      });
+      loadHeaders(this.sourceColList?.getValue()[0], this.outputColList?.getValue()[0]).finally(
+        () => {
+          btn.classList.remove("spinning");
+          btn.disabled = false;
+        },
+      );
     });
 
     loadHeaders(savedState?.sourceCol, savedState?.outputCol);
@@ -80,9 +84,13 @@ export class ExtractTextPanel implements Panel<undefined, SavedState> {
 
   unmount(): SavedState {
     const range = this.rowRange?.getValue();
+    const sourceCol = this.sourceColList?.getValue()[0] ?? "";
+    const outputCol = this.outputColList?.getValue()[0] ?? "";
+    this.sourceColList?.destroy();
+    this.outputColList?.destroy();
     return {
-      sourceCol: this.sourceColList?.getValue() ?? "",
-      outputCol: this.outputColList?.getValue() ?? "",
+      sourceCol,
+      outputCol,
       startRow: range?.start ?? 2,
       endRow: range?.end ?? 2,
     };
@@ -99,13 +107,13 @@ export class ExtractTextPanel implements Panel<undefined, SavedState> {
   }
 
   private assembleConfig(): ExtractTextConfig | null {
-    const sourceCol = this.sourceColList?.getValue() ?? "";
+    const sourceCol = this.sourceColList?.getValue()[0] ?? "";
     if (!sourceCol) {
       globalThis.alert("Please select a source column.");
       return null;
     }
 
-    const outputCol = this.outputColList?.getValue() ?? "";
+    const outputCol = this.outputColList?.getValue()[0] ?? "";
     if (!outputCol) {
       globalThis.alert("Please select an output column.");
       return null;

--- a/src/client/panels/import-drive-links.ts
+++ b/src/client/panels/import-drive-links.ts
@@ -58,6 +58,7 @@ export class ImportDriveLinksPanel implements Panel<undefined, SavedState> {
           this.outputColList = new TokenInput(container.querySelector("#output-col")!, headers, {
             multi: false,
             includeNew: true,
+            newDefault: "drive_links",
             selected: selected ? [selected] : [],
           });
           container.querySelector<HTMLElement>("#config-form")!.style.display = "block";

--- a/src/client/panels/import-drive-links.ts
+++ b/src/client/panels/import-drive-links.ts
@@ -1,6 +1,6 @@
 import type { NavigationContext, Panel } from "../types";
 import type { ImportDriveLinksConfig } from "../../shared/types";
-import { SingleTagList } from "../components/single-tag-list";
+import { TokenInput } from "../components/token-input";
 import { TagList } from "../components/tag-list";
 import { PanelLoader } from "../components/panel-loader";
 import { getSheetHeaders, importDriveLinks } from "../services";
@@ -23,7 +23,7 @@ const MIME_TYPE_OPTIONS = [
 
 export class ImportDriveLinksPanel implements Panel<undefined, SavedState> {
   private folderUrlInput: HTMLInputElement | null = null;
-  private outputColList: SingleTagList | null = null;
+  private outputColList: TokenInput | null = null;
   private mimeTypeList: TagList | null = null;
   private nav: NavigationContext | null = null;
 
@@ -51,14 +51,14 @@ export class ImportDriveLinksPanel implements Panel<undefined, SavedState> {
     const loader = new PanelLoader(container);
 
     const loadHeaders = (selected?: string): Promise<void> => {
+      this.outputColList?.destroy();
       loader.setState({ status: "loading", message: "Loading columns..." });
       return getSheetHeaders().then(
         (headers) => {
-          this.outputColList = new SingleTagList(container.querySelector("#output-col")!, headers, {
+          this.outputColList = new TokenInput(container.querySelector("#output-col")!, headers, {
+            multi: false,
             includeNew: true,
-            selected,
-            newPlaceholder: "drive_links",
-            newDefault: "",
+            selected: selected ? [selected] : [],
           });
           container.querySelector<HTMLElement>("#config-form")!.style.display = "block";
           loader.setState({ status: "idle" });
@@ -78,7 +78,7 @@ export class ImportDriveLinksPanel implements Panel<undefined, SavedState> {
       const btn = container.querySelector<HTMLButtonElement>("#refresh-btn")!;
       btn.classList.add("spinning");
       btn.disabled = true;
-      loadHeaders(this.outputColList?.getValue()).finally(() => {
+      loadHeaders(this.outputColList?.getValue()[0]).finally(() => {
         btn.classList.remove("spinning");
         btn.disabled = false;
       });
@@ -88,9 +88,11 @@ export class ImportDriveLinksPanel implements Panel<undefined, SavedState> {
   }
 
   unmount(): SavedState {
+    const outputCol = this.outputColList?.getValue()[0] ?? "";
+    this.outputColList?.destroy();
     return {
       folderUrl: this.folderUrlInput?.value ?? "",
-      outputCol: this.outputColList?.getValue() ?? "",
+      outputCol,
       mimeTypes: this.mimeTypeList?.getValue() ?? [],
     };
   }
@@ -112,7 +114,7 @@ export class ImportDriveLinksPanel implements Panel<undefined, SavedState> {
       return null;
     }
 
-    const outputCol = this.outputColList?.getValue() ?? "";
+    const outputCol = this.outputColList?.getValue()[0] ?? "";
     if (!outputCol) {
       globalThis.alert("Please select an output column.");
       return null;

--- a/src/client/sidebar.css
+++ b/src/client/sidebar.css
@@ -544,3 +544,100 @@
   font-style: italic;
   opacity: 0.6;
 }
+
+        /* ── Token Input ─────────────────────────────────────────────────────────── */
+
+        .token-field {
+            position: relative;
+            width: 100%;
+        }
+
+        .token-chips {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            align-items: center;
+        }
+
+        .token-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 2px;
+        }
+
+        .token-chip-remove {
+            background: none;
+            border: none;
+            cursor: pointer;
+            color: #1a73e8;
+            font-size: 13px;
+            line-height: 1;
+            padding: 0 0 0 2px;
+            opacity: 0.7;
+        }
+
+        .token-chip-remove:hover {
+            opacity: 1;
+        }
+
+        .token-chip-input {
+            border: none;
+            outline: none;
+            font-size: 12px;
+            color: #1a73e8;
+            width: 120px;
+            background: transparent;
+        }
+
+        .token-add-btn {
+            color: var(--text-secondary) !important;
+        }
+
+        .token-search {
+            display: block;
+            width: 100%;
+            border: none;
+            outline: none;
+            border-bottom: 1px solid #dadce0;
+            padding: 6px 10px;
+            font-size: 13px;
+            color: #202124;
+            background: transparent;
+            box-sizing: border-box;
+        }
+
+        .token-search::placeholder {
+            color: #9aa0a6;
+        }
+
+        .token-dropdown {
+            position: absolute;
+            top: calc(100% + 4px);
+            left: 0;
+            right: 0;
+            background: #fff;
+            border: 1px solid #dadce0;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+            max-height: 220px;
+            overflow-y: auto;
+            z-index: 100;
+        }
+
+        .token-option {
+            padding: 7px 12px;
+            font-size: 13px;
+            cursor: pointer;
+            color: #202124;
+        }
+
+        .token-option:hover {
+            background: #f1f3f4;
+        }
+
+        .token-no-match {
+            padding: 7px 12px;
+            font-size: 13px;
+            color: #9aa0a6;
+            font-style: italic;
+        }


### PR DESCRIPTION
## Summary

Replaces the `TagList`/`SingleTagList` components in the Configure AI Run panel with a new `TokenInput` component designed for column selection when sheets have many columns (8+). The old tag-list pattern required users to visually scan all columns at once — this becomes unwieldy at scale. `TokenInput` shows selected columns as removable chips with a searchable dropdown for adding more.

### What changed

**New component: `TokenInput`** (`src/client/components/token-input.ts`)
- Searchable dropdown that filters as you type
- Selected values appear as removable `.tag.selected` chips (same visual language as the existing Tools section)
- Supports multi-select (User prompt, Drive file columns) and single-select (System prompt, Output column)
- `includeNew: true` option on the Output column field lets users type a brand-new column name
- Dropdown closes after every selection
- Click outside or Escape to dismiss
- `destroy()` cleans up the document-level click listener and removes the DOM node

**Updated panel: `ConfigureAIRunPanel`**
- All four column fields now use `TokenInput` instead of `TagList`/`SingleTagList`
- Removed `loadHeaders()` call after run dispatch — it was running at job start (not completion) so could never pick up newly created columns, and caused a visible flash where all fields emptied and reloaded. Use the ↻ refresh button to pick up new headers manually.

**Visual design**
- Borderless field container — no heavy input border
- `+ Add` pill button opens the dropdown; hides in single-select mode once a chip is present
- Chips reuse `.tag.selected` from the existing sidebar design (same appearance as the Tools section chips)
- Dropdown has a search input at the top with a subtle bottom border separator

**State model**
- `this.selected: string[]` tracks known-item chips
- `this.hasNewChip: boolean` tracks the editable new-column chip (its value lives in a DOM input and cannot be in `this.selected`)
- `updateAddBtn()` and `getValue()` read from these flags only — no DOM queries for state

## Test plan

- [ ] Open the Configure AI Run panel on a sheet with many columns (10+). Verify the column fields show `+ Add` buttons instead of a tag list
- [ ] Click `+ Add` on **User prompt columns** — verify a dropdown appears with a search input. Type part of a column name and confirm the list filters. Select a column and confirm it appears as a chip and the dropdown closes
- [ ] Select a second column on the same field — confirm a second chip appears
- [ ] Click `×` on a chip — confirm it disappears and the column reappears in the dropdown
- [ ] On **Output column** (single-select), select a column — confirm the `+ Add` button disappears. Click `×` — confirm `+ Add` reappears
- [ ] On **Output column**, open the dropdown and select `+ New column` — confirm an editable chip appears with `ai_` prefilled. Type a name. Confirm the grounding label updates to `<your_name>_grounding`
- [ ] Click `×` on the new-column chip — confirm it is removed and `+ Add` reappears
- [ ] After selecting a new-column chip, open the dropdown and select a regular column — confirm the new-column chip is replaced and `getValue()` returns the regular column (not empty)
- [ ] Fill in all required fields and click **Run AI** — confirm the fields remain populated after the run starts (no flash)
- [ ] Use the ↻ refresh button — confirm all current selections are preserved after the header reload
- [ ] Navigate away from the panel and back — confirm selections are restored from saved state
- [ ] All 331 tests pass: `npx jest --no-coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)