### PR TITLE
feat: Import Drive Links panel

### DIFF
--- a/__tests__/menu.test.ts
+++ b/__tests__/menu.test.ts
@@ -44,6 +44,7 @@ const mockSpreadsheetApp = {
     toast: jest.fn(),
   }),
   getActive: jest.fn().mockReturnValue({ toast: jest.fn() }),
+  WrapStrategy: { CLIP: "CLIP", WRAP: "WRAP", OVERFLOW: "OVERFLOW" },
 };
 
 const mockEvaluate = jest.fn().mockReturnValue({
@@ -67,7 +68,7 @@ const mockHtmlService = {
 
 // ── Import after mocks ─────────────────────────────────────────
 
-import { onOpen, showSidebar, runTool } from "../src/server/index";
+import { onOpen, showSidebar, runTool, importDriveLinks } from "../src/server/index";
 
 // ── Tests ──────────────────────────────────────────────────────
 
@@ -115,12 +116,52 @@ describe("runTool", () => {
     jest.clearAllMocks();
   });
 
-  it("dispatches 'importDriveLinks' without throwing", () => {
-    // importDriveLinks calls ui.prompt() which is mocked to return CANCEL (early exit)
-    expect(() => runTool("importDriveLinks")).not.toThrow();
-  });
-
   it("does nothing for an unknown function name", () => {
     expect(() => runTool("doesNotExist")).not.toThrow();
+  });
+});
+
+const mockSetValues = jest.fn();
+
+describe("importDriveLinks", () => {
+  function makeFileIterator(files: { getUrl: () => string; getMimeType: () => string }[]) {
+    let i = 0;
+    return { hasNext: () => i < files.length, next: () => files[i++] };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockActiveSheet.getRange.mockReturnValue({ setValues: mockSetValues });
+    mockActiveSheet.getLastColumn.mockReturnValue(1);
+    mockActiveSheet.getLastRow.mockReturnValue(0);
+    // Provide a header row for findOrCreateColumn
+    mockActiveSheet.getRange.mockImplementation(
+      (row: number, col: number, numRows?: number, _numCols?: number) => {
+        if (row === 1 && col === 1 && numRows === 1) {
+          return { getValues: () => [["source_drive"]] };
+        }
+        return { setValues: mockSetValues };
+      },
+    );
+  });
+
+  it("calls DriveApp and writes file URLs to the output column", () => {
+    const mockFile = {
+      getUrl: (): string => "https://drive.google.com/file/1",
+      getMimeType: (): string => "application/pdf",
+    };
+    const mockFiles = makeFileIterator([mockFile]);
+    const mockSubfolders = makeFileIterator([]);
+    const mockFolder = {
+      getFiles: () => mockFiles,
+      getFolders: () => mockSubfolders,
+    };
+    (globalThis as unknown as { DriveApp: unknown }).DriveApp = {
+      getFolderById: jest.fn().mockReturnValue(mockFolder),
+    };
+
+    importDriveLinks({ folderUrl: "https://drive.google.com/drive/folders/abc123", outputCol: "source_drive" });
+
+    expect(mockSetValues).toHaveBeenCalledWith([["https://drive.google.com/file/1"]]);
   });
 });

--- a/__tests__/panels/import-drive-links.test.ts
+++ b/__tests__/panels/import-drive-links.test.ts
@@ -112,4 +112,41 @@ describe("ImportDriveLinksPanel", () => {
       "https://drive.google.com/drive/folders/saved",
     );
   });
+
+  it("navigates back when getSheetHeaders fails", async () => {
+    globalThis.alert = jest.fn();
+    (services.getSheetHeaders as jest.Mock).mockRejectedValue(new Error("network error"));
+    mountPanel();
+    await Promise.resolve();
+    expect(mockNav.back).toHaveBeenCalled();
+  });
+
+  it("alerts when output column is not selected and Import is clicked", async () => {
+    globalThis.alert = jest.fn();
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive"]);
+    const c = mountPanel();
+    await Promise.resolve();
+    c.querySelector<HTMLInputElement>("#folder-url-input")!.value =
+      "https://drive.google.com/drive/folders/abc123";
+    // do NOT click any output column tag — leave it unselected
+    c.querySelector<HTMLButtonElement>("#import-btn")!.click();
+    expect(globalThis.alert).toHaveBeenCalledWith(expect.stringContaining("output column"));
+  });
+
+  it("alerts on jobStore dispatch failure", async () => {
+    globalThis.alert = jest.fn();
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive"]);
+    (services.importDriveLinks as jest.Mock).mockReturnValue(Promise.resolve());
+    (jobStoreModule.jobStore.dispatch as jest.Mock).mockReturnValue(
+      Promise.reject(new Error("job failed")),
+    );
+    const c = mountPanel();
+    await Promise.resolve();
+    c.querySelector<HTMLInputElement>("#folder-url-input")!.value =
+      "https://drive.google.com/drive/folders/abc123";
+    c.querySelector<HTMLElement>("#output-col .tag")?.click();
+    c.querySelector<HTMLButtonElement>("#import-btn")!.click();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(globalThis.alert).toHaveBeenCalledWith("Error: job failed");
+  });
 });

--- a/__tests__/panels/import-drive-links.test.ts
+++ b/__tests__/panels/import-drive-links.test.ts
@@ -133,6 +133,34 @@ describe("ImportDriveLinksPanel", () => {
     expect(globalThis.alert).toHaveBeenCalledWith(expect.stringContaining("output column"));
   });
 
+  it("refresh button re-fetches headers", async () => {
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive"]);
+    const c = mountPanel();
+    await Promise.resolve();
+    expect(services.getSheetHeaders).toHaveBeenCalledTimes(1);
+    c.querySelector<HTMLButtonElement>("#refresh-btn")!.click();
+    await Promise.resolve();
+    expect(services.getSheetHeaders).toHaveBeenCalledTimes(2);
+  });
+
+  it("refresh button disables during load and re-enables after", async () => {
+    let resolveHeaders!: (v: string[]) => void;
+    (services.getSheetHeaders as jest.Mock)
+      .mockResolvedValueOnce(["source_drive"])
+      .mockReturnValueOnce(new Promise((r) => (resolveHeaders = r)));
+    const c = mountPanel();
+    await Promise.resolve();
+    const btn = c.querySelector<HTMLButtonElement>("#refresh-btn")!;
+    btn.click();
+    expect(btn.disabled).toBe(true);
+    expect(btn.classList.contains("spinning")).toBe(true);
+    resolveHeaders(["source_drive", "new_col"]);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(btn.disabled).toBe(false);
+    expect(btn.classList.contains("spinning")).toBe(false);
+  });
+
   it("alerts on jobStore dispatch failure", async () => {
     globalThis.alert = jest.fn();
     (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive"]);

--- a/__tests__/panels/import-drive-links.test.ts
+++ b/__tests__/panels/import-drive-links.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock("../../src/client/services", () => ({
+  getSheetHeaders: jest.fn(),
+  importDriveLinks: jest.fn(),
+}));
+
+jest.mock("../../src/client/job-store", () => ({
+  jobStore: { dispatch: jest.fn().mockResolvedValue(undefined) },
+}));
+
+import { ImportDriveLinksPanel } from "../../src/client/panels/import-drive-links";
+import * as services from "../../src/client/services";
+import * as jobStoreModule from "../../src/client/job-store";
+import type { NavigationContext } from "../../src/client/types";
+
+const mockNav: NavigationContext = {
+  navigate: jest.fn(),
+  back: jest.fn(),
+  canGoBack: jest.fn().mockReturnValue(true),
+};
+
+function mountPanel(savedState?: unknown): HTMLElement {
+  document.body.innerHTML = '<div id="app"></div>';
+  const container = document.getElementById("app")!;
+  const panel = new ImportDriveLinksPanel();
+  panel.mount(container, mockNav, undefined, savedState as never);
+  return container;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (jobStoreModule.jobStore.dispatch as jest.Mock).mockResolvedValue(undefined);
+});
+
+describe("ImportDriveLinksPanel", () => {
+  it("shows a loader while headers are loading", () => {
+    (services.getSheetHeaders as jest.Mock).mockReturnValue(new Promise(() => {}));
+    const c = mountPanel();
+    expect(c.querySelector("#panel-loader")).toBeTruthy();
+    expect(c.querySelector<HTMLElement>("#config-form")!.style.display).toBe("none");
+  });
+
+  it("reveals form after headers load", async () => {
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive", "ai_inference"]);
+    const c = mountPanel();
+    await Promise.resolve();
+    expect(c.querySelector<HTMLElement>("#config-form")!.style.display).not.toBe("none");
+  });
+
+  it("back button calls nav.back()", () => {
+    (services.getSheetHeaders as jest.Mock).mockReturnValue(new Promise(() => {}));
+    const c = mountPanel();
+    c.querySelector<HTMLButtonElement>("#back-btn")!.click();
+    expect(mockNav.back).toHaveBeenCalled();
+  });
+
+  it("alerts when folder URL is empty and Import is clicked", async () => {
+    globalThis.alert = jest.fn();
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive"]);
+    const c = mountPanel();
+    await Promise.resolve();
+    c.querySelector<HTMLButtonElement>("#import-btn")!.click();
+    expect(globalThis.alert).toHaveBeenCalledWith(expect.stringContaining("folder"));
+  });
+
+  it("dispatches importDriveLinks job when form is valid", async () => {
+    const promise = Promise.resolve();
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive"]);
+    (services.importDriveLinks as jest.Mock).mockReturnValue(promise);
+    const c = mountPanel();
+    await Promise.resolve();
+
+    c.querySelector<HTMLInputElement>("#folder-url-input")!.value =
+      "https://drive.google.com/drive/folders/abc123";
+    // select the output column tag
+    c.querySelector<HTMLElement>("#output-col .tag")?.click();
+
+    c.querySelector<HTMLButtonElement>("#import-btn")!.click();
+    expect(jobStoreModule.jobStore.dispatch).toHaveBeenCalledWith(
+      expect.stringMatching(/^import-drive-links-\d+$/),
+      "Import Drive Links",
+      promise,
+    );
+  });
+
+  it("unmount returns saved state with folderUrl and mimeTypes array", async () => {
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive"]);
+    document.body.innerHTML = '<div id="app"></div>';
+    const container = document.getElementById("app")!;
+    const panel = new ImportDriveLinksPanel();
+    panel.mount(container, mockNav);
+    await Promise.resolve();
+    container.querySelector<HTMLInputElement>("#folder-url-input")!.value =
+      "https://drive.google.com/drive/folders/xyz";
+    const state = panel.unmount();
+    expect(state?.folderUrl).toBe("https://drive.google.com/drive/folders/xyz");
+    expect(Array.isArray(state?.mimeTypes)).toBe(true);
+  });
+
+  it("restores saved folder URL on mount", async () => {
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive"]);
+    const c = mountPanel({
+      folderUrl: "https://drive.google.com/drive/folders/saved",
+      outputCol: "",
+      mimeTypes: [],
+    });
+    await Promise.resolve();
+    expect(c.querySelector<HTMLInputElement>("#folder-url-input")!.value).toBe(
+      "https://drive.google.com/drive/folders/saved",
+    );
+  });
+});

--- a/__tests__/panels/tool-list.test.ts
+++ b/__tests__/panels/tool-list.test.ts
@@ -47,14 +47,10 @@ describe("ToolListPanel", () => {
     expect(mockNav.navigate).toHaveBeenCalledWith("recipes-list");
   });
 
-  it("clicking a tool button calls runTool with the function name and a jobId", () => {
-    (services.runTool as jest.Mock).mockResolvedValue(undefined);
+  it("clicking Import Drive Links navigates to import-drive-links panel", () => {
     const c = mountPanel();
     c.querySelector<HTMLButtonElement>("#btn-import-drive-links")!.click();
-    expect(services.runTool).toHaveBeenCalledWith(
-      "importDriveLinks",
-      expect.stringMatching(/^importDriveLinks-\d+$/),
-    );
+    expect(mockNav.navigate).toHaveBeenCalledWith("import-drive-links");
   });
 
   it("clicking Sample Rows calls runTool with 'sampleRowsToEvaluation' and a jobId", () => {
@@ -75,33 +71,6 @@ describe("ToolListPanel", () => {
       "extractTextFromSelection",
       expect.stringMatching(/^extractTextFromSelection-\d+$/),
     );
-  });
-
-  it("clicking a tool button dispatches to jobStore with matching jobId, label, and promise", () => {
-    const promise = Promise.resolve();
-    (services.runTool as jest.Mock).mockReturnValue(promise);
-    const c = mountPanel();
-    const btn = c.querySelector<HTMLButtonElement>("#btn-import-drive-links")!;
-    btn.click();
-    expect(jobStoreModule.jobStore.dispatch).toHaveBeenCalledWith(
-      expect.stringMatching(/^importDriveLinks-\d+$/),
-      expect.any(String),
-      promise,
-    );
-  });
-
-  it("on runTool failure: alerts with error message", async () => {
-    globalThis.alert = jest.fn();
-    const err = new Error("Drive error");
-    (services.runTool as jest.Mock).mockResolvedValue(undefined);
-    // Use mockImplementation so the rejection is created at call time (handlers attach before rejection fires)
-    (jobStoreModule.jobStore.dispatch as jest.Mock).mockImplementation(() =>
-      Promise.reject(err),
-    );
-    const c = mountPanel();
-    c.querySelector<HTMLButtonElement>("#btn-import-drive-links")!.click();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(globalThis.alert).toHaveBeenCalledWith("Error: Drive error");
   });
 
   it("unmount() returns undefined", () => {

--- a/__tests__/services.test.ts
+++ b/__tests__/services.test.ts
@@ -10,6 +10,7 @@ const mockRun = {
   runTool: jest.fn(),
   prepRecipe: jest.fn(),
   getJobProgress: jest.fn(),
+  importDriveLinks: jest.fn(),
 };
 (globalThis as unknown as { google: unknown }).google = { script: { run: mockRun } };
 
@@ -123,6 +124,25 @@ describe("prepRecipe", () => {
     const promise = services.prepRecipe({});
     handlers.reject(new Error("prep error"));
     await expect(promise).rejects.toThrow("prep error");
+  });
+});
+
+describe("importDriveLinks", () => {
+  it("calls google.script.run.importDriveLinks with config and jobId and resolves", async () => {
+    const handlers = captureHandlers();
+    const config = { folderUrl: "https://drive.google.com/drive/folders/abc", outputCol: "source_drive" };
+    const promise = services.importDriveLinks(config, "job-1");
+    handlers.resolve(undefined);
+    await expect(promise).resolves.toBeUndefined();
+    expect(mockRun.importDriveLinks).toHaveBeenCalledWith(config, "job-1");
+  });
+
+  it("rejects on failure", async () => {
+    const handlers = captureHandlers();
+    const config = { folderUrl: "https://drive.google.com/drive/folders/abc", outputCol: "source_drive" };
+    const promise = services.importDriveLinks(config, "job-1");
+    handlers.reject(new Error("drive error"));
+    await expect(promise).rejects.toThrow("drive error");
   });
 });
 

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -194,6 +194,36 @@ describe("getAllFilesRecursive", () => {
     getAllFilesRecursive(folder as any, result);
     expect(result).toHaveLength(0);
   });
+
+  it("filters by mimeType prefix when mimeTypePrefixes is provided", () => {
+    const mockDoc = { getUrl: () => "doc-url", getMimeType: () => "application/vnd.google-apps.document" };
+    const mockPdf = { getUrl: () => "pdf-url", getMimeType: () => "application/pdf" };
+    const mockImg = { getUrl: () => "img-url", getMimeType: () => "image/png" };
+    const files = makeFileIterator([]) as any;
+    let i = 0;
+    const mockFiles = [mockDoc, mockPdf, mockImg];
+    const fileIter = { hasNext: () => i < mockFiles.length, next: () => mockFiles[i++] };
+    const subfolders = makeFolderIterator([]);
+    const folder = { getFiles: () => fileIter, getFolders: () => subfolders } as unknown as GoogleAppsScript.Drive.Folder;
+
+    const result: DriveFileInfo[] = [];
+    getAllFilesRecursive(folder, result, ["application/"]);
+    expect(result.map((f) => f.url)).toEqual(["doc-url", "pdf-url"]);
+  });
+
+  it("imports all files when mimeTypePrefixes is absent", () => {
+    const mockDoc = { getUrl: () => "doc-url", getMimeType: () => "application/vnd.google-apps.document" };
+    const mockImg = { getUrl: () => "img-url", getMimeType: () => "image/png" };
+    let i = 0;
+    const mockFiles = [mockDoc, mockImg];
+    const fileIter = { hasNext: () => i < mockFiles.length, next: () => mockFiles[i++] };
+    const subfolders = makeFolderIterator([]);
+    const folder = { getFiles: () => fileIter, getFolders: () => subfolders } as unknown as GoogleAppsScript.Drive.Folder;
+
+    const result: DriveFileInfo[] = [];
+    getAllFilesRecursive(folder, result);
+    expect(result.map((f) => f.url)).toEqual(["doc-url", "img-url"]);
+  });
 });
 
 describe("flattenArg", () => {

--- a/docs/plans/2026-03-18-import-drive-links-panel-design.md
+++ b/docs/plans/2026-03-18-import-drive-links-panel-design.md
@@ -1,0 +1,162 @@
+# Import Drive Links Panel — Design
+
+**Date:** 2026-03-18
+**Status:** Approved
+
+## Overview
+
+Rebuild the "Import Drive Links" tool as a first-class sidebar panel, replacing the legacy `ui.prompt()` dialog flow with a panel-based UX consistent with `ConfigureAIRunPanel` and `RecipePanel`. Remove all code supporting the old dialog-driven path.
+
+## Goals
+
+- Collect folder URL, output column, and optional file type filters in the sidebar before running
+- Route the `btn-import-drive-links` button to a panel (`nav.navigate`) instead of dispatching immediately
+- Delete the old `importDriveLinks` server function and its `runTool` dispatcher entry
+- Lay down patterns that support future Extra tool panels (Sample Rows, Extract Text)
+
+## Architecture
+
+### New files
+
+- `src/client/panels/import-drive-links.ts` — `ImportDriveLinksPanel` class
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `src/shared/types.ts` | Add `ImportDriveLinksConfig` interface |
+| `src/server/index.ts` | Replace old `importDriveLinks` with new panel-driven version; remove from `runTool` dispatcher |
+| `src/server/utils.ts` | Add optional `mimeTypePrefixes?: string[]` param to `getAllFilesRecursive` |
+| `src/client/types.ts` | Add `"import-drive-links"` to `PanelId` union |
+| `src/client/services.ts` | Add `importDriveLinks(config, jobId?)` service wrapper |
+| `src/client/panels/tool-list.ts` | Change Import Drive Links button to `nav.navigate("import-drive-links")` |
+| `src/client/sidebar-entry.ts` | Register `ImportDriveLinksPanel` in the panels Map |
+| `src/client/google.d.ts` | Add `importDriveLinks` declaration |
+| `rollup.config.js` | Add global stub for `importDriveLinks` |
+
+## Data Flow
+
+```
+ImportDriveLinksPanel
+  → validate (folderUrl required, outputCol required)
+  → jobStore.dispatch(jobId, "Import Drive Links", importDriveLinks(config, jobId))
+  → services.importDriveLinks(config, jobId)
+  → google.script.run.importDriveLinks(config, jobId)
+  → server: extractId → DriveApp.getFolderById → getAllFilesRecursive (with mimeType filter)
+  → findOrCreateColumn → writeColumn
+```
+
+## RPC Config Type (`shared/types.ts`)
+
+```ts
+export interface ImportDriveLinksConfig {
+  folderUrl: string;
+  outputCol: string;
+  mimeTypes?: string[]; // MIME type prefix strings; absent = all files
+}
+```
+
+## Server Function (`index.ts`)
+
+Replaces the old `importDriveLinks` (which used `ui.prompt()` dialogs):
+
+```ts
+export function importDriveLinks(config: ImportDriveLinksConfig, jobId?: string): void {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+  const folderId = extractId(config.folderUrl);
+
+  if (jobId) {
+    writeJobProgress(CacheService.getUserCache(), jobId, { message: "Scanning folder..." });
+  }
+
+  const parentFolder = DriveApp.getFolderById(folderId);
+  const allFiles: DriveFileInfo[] = [];
+  getAllFilesRecursive(parentFolder, allFiles, config.mimeTypes);
+
+  const col = findOrCreateColumn(sheet, config.outputCol, SpreadsheetApp.WrapStrategy.CLIP);
+  writeColumn(sheet, col, allFiles.map((f) => f.url));
+}
+```
+
+Error handling: exceptions propagate to the client via `jobStore`, which surfaces them as alerts.
+
+## `getAllFilesRecursive` Change (`utils.ts`)
+
+Add optional `mimeTypePrefixes?: string[]` third param. When present, only files whose `getMimeType()` starts with one of the prefix strings are included:
+
+```ts
+export function getAllFilesRecursive(
+  folder: GoogleAppsScript.Drive.Folder,
+  fileList: DriveFileInfo[],
+  mimeTypePrefixes?: string[],
+): void {
+  const files = folder.getFiles();
+  while (files.hasNext()) {
+    const file = files.next();
+    const mime = file.getMimeType();
+    if (!mimeTypePrefixes || mimeTypePrefixes.some((p) => mime.startsWith(p))) {
+      fileList.push({ url: file.getUrl() });
+    }
+  }
+  const subfolders = folder.getFolders();
+  while (subfolders.hasNext()) {
+    getAllFilesRecursive(subfolders.next(), fileList, mimeTypePrefixes);
+  }
+}
+```
+
+## Panel UX
+
+```
+┌─────────────────────────────────────┐
+│ ← Back    📂 Import Drive Links     │
+├─────────────────────────────────────┤
+│  [PanelLoader — loading columns]    │
+│                                     │
+│ Drive Folder *                      │
+│ [text input: paste URL or ID      ] │
+│                                     │
+│ Output Column *                     │
+│ [SingleTagList w/ includeNew:true ] │
+│                                     │
+│ File Types  (optional)              │
+│ [Docs] [Sheets] [PDFs]              │
+│ [Images] [Audio] [Video]            │
+│                                     │
+│         [ Import Links ]            │
+└─────────────────────────────────────┘
+```
+
+The entire form is hidden behind `PanelLoader` until `getSheetHeaders()` resolves (same pattern as `ConfigureAIRunPanel`). The file type TagList uses fixed options; the output column uses `SingleTagList` with `includeNew: true`.
+
+### File Type → MIME Prefix Map
+
+| Label | Prefix sent to server |
+|---|---|
+| Google Docs | `application/vnd.google-apps.document` |
+| Google Sheets | `application/vnd.google-apps.spreadsheet` |
+| PDFs | `application/pdf` |
+| Images | `image/` |
+| Audio | `audio/` |
+| Video | `video/` |
+
+When no file types are selected, `mimeTypes` is omitted from the config and all files are imported.
+
+## Panel Saved State
+
+```ts
+type SavedState = {
+  folderUrl: string;
+  outputCol: string;
+  mimeTypes: string[];
+};
+```
+
+Restored on back navigation so the user doesn't lose their inputs.
+
+## Cleanup
+
+- Remove old `importDriveLinks` body (dialog-driven, used `ui.prompt()`)
+- Remove `importDriveLinks` entry from `runTool` TOOLS dispatcher in `index.ts`
+- Change `btn-import-drive-links` in `ToolListPanel` from `dispatchTool()` to `nav.navigate("import-drive-links")`
+- No menu changes needed — the menu already only has "Open SSI Toolkit"

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -115,6 +115,12 @@ module.exports = {
       branches: 70,
       functions: 100,
     },
+    "./src/client/panels/import-drive-links.ts": {
+      statements: 95,
+      branches: 75,
+      functions: 95,
+      lines: 95,
+    },
     "./src/server/rich-text.ts": {
       statements: 94,
       branches: 82,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -81,7 +81,7 @@ function showSidebar() { _GASEntry.showSidebar(); }
 function runTool(fn, jobId) { _GASEntry.runTool(fn, jobId); }
 function getSheetHeaders() { return _GASEntry.getSheetHeaders(); }
 function runBatchAI(config, jobId) { _GASEntry.runBatchAI(config, jobId); }
-function importDriveLinks(jobId) { _GASEntry.importDriveLinks(jobId); }
+function importDriveLinks(config, jobId) { _GASEntry.importDriveLinks(config, jobId); }
 function extractTextFromSelection(jobId) { _GASEntry.extractTextFromSelection(jobId); }
 function sampleRowsToEvaluation(jobId) { _GASEntry.sampleRowsToEvaluation(jobId); }
 /**

--- a/src/client/components/single-tag-list.ts
+++ b/src/client/components/single-tag-list.ts
@@ -1,6 +1,8 @@
 export interface SingleTagListOpts {
   includeNew?: boolean;
   selected?: string;
+  newPlaceholder?: string;
+  newDefault?: string;
 }
 
 export class SingleTagList {
@@ -51,8 +53,8 @@ export class SingleTagList {
       this.newInput = document.createElement("input");
       this.newInput.type = "text";
       this.newInput.className = "text-input";
-      this.newInput.placeholder = "ai_column_name";
-      this.newInput.value = "ai_";
+      this.newInput.placeholder = opts.newPlaceholder ?? "ai_column_name";
+      this.newInput.value = opts.newDefault ?? "ai_";
       this.newInput.style.display = "none";
 
       if (selectedIsCustom) {

--- a/src/client/components/single-tag-list.ts
+++ b/src/client/components/single-tag-list.ts
@@ -53,8 +53,8 @@ export class SingleTagList {
       this.newInput = document.createElement("input");
       this.newInput.type = "text";
       this.newInput.className = "text-input";
-      this.newInput.placeholder = opts.newPlaceholder ?? "ai_column_name";
-      this.newInput.value = opts.newDefault ?? "ai_";
+      this.newInput.placeholder = opts.newPlaceholder ?? "column_name";
+      this.newInput.value = opts.newDefault ?? "";
       this.newInput.style.display = "none";
 
       if (selectedIsCustom) {

--- a/src/client/google.d.ts
+++ b/src/client/google.d.ts
@@ -1,4 +1,4 @@
-import type { RunConfig, PrepRecipeParams } from "../shared/types";
+import type { RunConfig, PrepRecipeParams, ImportDriveLinksConfig } from "../shared/types";
 
 declare global {
   interface GoogleScriptRun {
@@ -7,6 +7,7 @@ declare global {
     runTool(functionName: string, jobId?: string): void;
     getSheetHeaders(): void;
     runBatchAI(config: RunConfig, jobId?: string): void;
+    importDriveLinks(config: ImportDriveLinksConfig, jobId?: string): void;
     prepRecipe(params: PrepRecipeParams): void;
     getJobProgress(jobId: string): void;
   }

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -106,6 +106,8 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
         this.outputColList = new SingleTagList(container.querySelector("#output-col")!, headers, {
           includeNew: true,
           selected: preset.outputCol,
+          newPlaceholder: "ai_column_name",
+          newDefault: "ai_",
         });
         this.rowRangeComp = new RowRange(
           container.querySelector("#row-range-container")!,

--- a/src/client/panels/import-drive-links.ts
+++ b/src/client/panels/import-drive-links.ts
@@ -1,0 +1,147 @@
+import type { NavigationContext, Panel } from "../types";
+import type { ImportDriveLinksConfig } from "../../shared/types";
+import { SingleTagList } from "../components/single-tag-list";
+import { TagList } from "../components/tag-list";
+import { PanelLoader } from "../components/panel-loader";
+import { getSheetHeaders, importDriveLinks } from "../services";
+import { jobStore } from "../job-store";
+
+type SavedState = {
+  folderUrl: string;
+  outputCol: string;
+  mimeTypes: string[];
+};
+
+const MIME_TYPE_OPTIONS = [
+  { label: "Google Docs", value: "application/vnd.google-apps.document" },
+  { label: "Google Sheets", value: "application/vnd.google-apps.spreadsheet" },
+  { label: "PDFs", value: "application/pdf" },
+  { label: "Images", value: "image/" },
+  { label: "Audio", value: "audio/" },
+  { label: "Video", value: "video/" },
+];
+
+export class ImportDriveLinksPanel implements Panel<undefined, SavedState> {
+  private folderUrlInput: HTMLInputElement | null = null;
+  private outputColList: SingleTagList | null = null;
+  private mimeTypeList: TagList | null = null;
+  private nav: NavigationContext | null = null;
+
+  mount(
+    container: HTMLElement,
+    nav: NavigationContext,
+    _params?: undefined,
+    savedState?: SavedState,
+  ): void {
+    this.nav = nav;
+    container.innerHTML = this.template();
+    container.querySelector("#back-btn")?.addEventListener("click", () => nav.back());
+
+    this.folderUrlInput = container.querySelector<HTMLInputElement>("#folder-url-input");
+    if (savedState?.folderUrl && this.folderUrlInput) {
+      this.folderUrlInput.value = savedState.folderUrl;
+    }
+
+    this.mimeTypeList = new TagList(
+      container.querySelector("#mime-type-list")!,
+      MIME_TYPE_OPTIONS,
+      savedState?.mimeTypes ?? [],
+    );
+
+    const loader = new PanelLoader(container);
+    loader.setState({ status: "loading", message: "Loading columns..." });
+
+    getSheetHeaders().then(
+      (headers) => {
+        this.outputColList = new SingleTagList(
+          container.querySelector("#output-col")!,
+          headers,
+          { includeNew: true, selected: savedState?.outputCol },
+        );
+        container.querySelector<HTMLElement>("#config-form")!.style.display = "block";
+        container
+          .querySelector<HTMLButtonElement>("#import-btn")!
+          .addEventListener("click", () => this.handleImport());
+        loader.setState({ status: "idle" });
+      },
+      (err: Error) => {
+        globalThis.alert("Error loading headers: " + err.message);
+        nav.back();
+      },
+    );
+  }
+
+  unmount(): SavedState {
+    return {
+      folderUrl: this.folderUrlInput?.value ?? "",
+      outputCol: this.outputColList?.getValue() ?? "",
+      mimeTypes: this.mimeTypeList?.getValue() ?? [],
+    };
+  }
+
+  private handleImport(): void {
+    const config = this.assembleConfig();
+    if (!config) return;
+
+    const jobId = `import-drive-links-${Date.now()}`;
+    jobStore
+      .dispatch(jobId, "Import Drive Links", importDriveLinks(config, jobId))
+      .catch((err: Error) => globalThis.alert("Error: " + err.message));
+  }
+
+  private assembleConfig(): ImportDriveLinksConfig | null {
+    const folderUrl = this.folderUrlInput?.value.trim() ?? "";
+    if (!folderUrl) {
+      globalThis.alert("Please enter a Google Drive folder link.");
+      return null;
+    }
+
+    const outputCol = this.outputColList?.getValue() ?? "";
+    if (!outputCol) {
+      globalThis.alert("Please select an output column.");
+      return null;
+    }
+
+    const mimeTypes = this.mimeTypeList?.getValue() ?? [];
+
+    return {
+      folderUrl,
+      outputCol,
+      mimeTypes: mimeTypes.length > 0 ? mimeTypes : undefined,
+    };
+  }
+
+  private template(): string {
+    return `
+      <div class="panel-header">
+        <button id="back-btn" class="back-btn">← Back</button>
+        <span class="panel-title">Import Drive Links</span>
+      </div>
+      <div id="panel-loader" class="panel-loader" hidden>
+        <div class="panel-loader__bar-wrap" hidden>
+          <div class="panel-loader__bar-fill"></div>
+        </div>
+        <div class="panel-loader__spinner" hidden></div>
+        <p class="panel-loader__message"></p>
+      </div>
+      <div id="config-form" style="display:none">
+        <div class="field-group">
+          <span class="field-label">Drive Folder <span class="required">*</span></span>
+          <input id="folder-url-input" type="text" class="text-input"
+            placeholder="Paste Google Drive folder URL or ID" />
+        </div>
+        <div class="field-group">
+          <span class="field-label">Output Column <span class="required">*</span></span>
+          <div id="output-col" class="tag-list"></div>
+        </div>
+        <div class="field-group">
+          <span class="field-label">File Types <span class="optional">(optional)</span></span>
+          <div id="mime-type-list" class="tag-list"></div>
+        </div>
+        <div class="panel-buttons">
+          <button id="import-btn" class="btn-run">Import Links</button>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/client/panels/import-drive-links.ts
+++ b/src/client/panels/import-drive-links.ts
@@ -53,11 +53,10 @@ export class ImportDriveLinksPanel implements Panel<undefined, SavedState> {
 
     getSheetHeaders().then(
       (headers) => {
-        this.outputColList = new SingleTagList(
-          container.querySelector("#output-col")!,
-          headers,
-          { includeNew: true, selected: savedState?.outputCol },
-        );
+        this.outputColList = new SingleTagList(container.querySelector("#output-col")!, headers, {
+          includeNew: true,
+          selected: savedState?.outputCol,
+        });
         container.querySelector<HTMLElement>("#config-form")!.style.display = "block";
         container
           .querySelector<HTMLButtonElement>("#import-btn")!

--- a/src/client/panels/import-drive-links.ts
+++ b/src/client/panels/import-drive-links.ts
@@ -49,25 +49,42 @@ export class ImportDriveLinksPanel implements Panel<undefined, SavedState> {
     );
 
     const loader = new PanelLoader(container);
-    loader.setState({ status: "loading", message: "Loading columns..." });
 
-    getSheetHeaders().then(
-      (headers) => {
-        this.outputColList = new SingleTagList(container.querySelector("#output-col")!, headers, {
-          includeNew: true,
-          selected: savedState?.outputCol,
-        });
-        container.querySelector<HTMLElement>("#config-form")!.style.display = "block";
-        container
-          .querySelector<HTMLButtonElement>("#import-btn")!
-          .addEventListener("click", () => this.handleImport());
-        loader.setState({ status: "idle" });
-      },
-      (err: Error) => {
-        globalThis.alert("Error loading headers: " + err.message);
-        nav.back();
-      },
-    );
+    const loadHeaders = (selected?: string): Promise<void> => {
+      loader.setState({ status: "loading", message: "Loading columns..." });
+      return getSheetHeaders().then(
+        (headers) => {
+          this.outputColList = new SingleTagList(container.querySelector("#output-col")!, headers, {
+            includeNew: true,
+            selected,
+            newPlaceholder: "drive_links",
+            newDefault: "",
+          });
+          container.querySelector<HTMLElement>("#config-form")!.style.display = "block";
+          loader.setState({ status: "idle" });
+        },
+        (err: Error) => {
+          globalThis.alert("Error loading headers: " + err.message);
+          nav.back();
+        },
+      );
+    };
+
+    container
+      .querySelector<HTMLButtonElement>("#import-btn")!
+      .addEventListener("click", () => this.handleImport());
+
+    container.querySelector("#refresh-btn")?.addEventListener("click", () => {
+      const btn = container.querySelector<HTMLButtonElement>("#refresh-btn")!;
+      btn.classList.add("spinning");
+      btn.disabled = true;
+      loadHeaders(this.outputColList?.getValue()).finally(() => {
+        btn.classList.remove("spinning");
+        btn.disabled = false;
+      });
+    });
+
+    loadHeaders(savedState?.outputCol);
   }
 
   unmount(): SavedState {
@@ -114,7 +131,8 @@ export class ImportDriveLinksPanel implements Panel<undefined, SavedState> {
     return `
       <div class="panel-header">
         <button id="back-btn" class="back-btn">← Back</button>
-        <span class="panel-title">Import Drive Links</span>
+        <span class="panel-title">📂 Import Drive Links</span>
+        <button id="refresh-btn" class="refresh-btn" title="Refresh columns">↻</button>
       </div>
       <div id="panel-loader" class="panel-loader" hidden>
         <div class="panel-loader__bar-wrap" hidden>

--- a/src/client/panels/tool-list.ts
+++ b/src/client/panels/tool-list.ts
@@ -19,8 +19,8 @@ export class ToolListPanel implements Panel {
     container.querySelector("#btn-recipes")?.addEventListener("click", () => {
       nav.navigate("recipes-list");
     });
-    container.querySelector("#btn-import-drive-links")?.addEventListener("click", (e) => {
-      this.dispatchTool(e as MouseEvent, "importDriveLinks");
+    container.querySelector("#btn-import-drive-links")?.addEventListener("click", () => {
+      nav.navigate("import-drive-links");
     });
     container.querySelector("#btn-sample-rows")?.addEventListener("click", (e) => {
       this.dispatchTool(e as MouseEvent, "sampleRowsToEvaluation");

--- a/src/client/services.ts
+++ b/src/client/services.ts
@@ -1,4 +1,9 @@
-import type { ImportDriveLinksConfig, PrepRecipeParams, PrepRecipeResult, RunConfig } from "../shared/types";
+import type {
+  ImportDriveLinksConfig,
+  PrepRecipeParams,
+  PrepRecipeResult,
+  RunConfig,
+} from "../shared/types";
 
 export function getSheetHeaders(): Promise<string[]> {
   return new Promise((resolve, reject) => {

--- a/src/client/services.ts
+++ b/src/client/services.ts
@@ -1,4 +1,4 @@
-import type { PrepRecipeParams, PrepRecipeResult, RunConfig } from "../shared/types";
+import type { ImportDriveLinksConfig, PrepRecipeParams, PrepRecipeResult, RunConfig } from "../shared/types";
 
 export function getSheetHeaders(): Promise<string[]> {
   return new Promise((resolve, reject) => {
@@ -33,6 +33,15 @@ export function prepRecipe(params: PrepRecipeParams): Promise<PrepRecipeResult> 
       .withSuccessHandler((result: unknown) => resolve(result as PrepRecipeResult))
       .withFailureHandler((err: Error) => reject(err))
       .prepRecipe(params);
+  });
+}
+
+export function importDriveLinks(config: ImportDriveLinksConfig, jobId?: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    google.script.run
+      .withSuccessHandler(() => resolve())
+      .withFailureHandler((err: Error) => reject(err))
+      .importDriveLinks(config, jobId);
   });
 }
 

--- a/src/client/sidebar-entry.ts
+++ b/src/client/sidebar-entry.ts
@@ -11,6 +11,7 @@ import { ToolListPanel } from "./panels/tool-list";
 import { ConfigureAIRunPanel } from "./panels/configure-ai-run";
 import { RecipesListPanel } from "./panels/recipes-list";
 import { RecipePanel } from "./panels/recipe";
+import { ImportDriveLinksPanel } from "./panels/import-drive-links";
 import { JobIndicator } from "./components/job-indicator";
 import { jobStore } from "./job-store";
 import type { Panel, PanelId } from "./types";
@@ -29,6 +30,7 @@ function init(): void {
     ["configure-ai-run", new ConfigureAIRunPanel()],
     ["recipes-list", new RecipesListPanel()],
     ["recipe", new RecipePanel()],
+    ["import-drive-links", new ImportDriveLinksPanel()],
   ]);
 
   const router = new Router(app, panels);

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -47,7 +47,12 @@ export interface RecipeParams {
 /**
  * All registered panel identifiers. Add new panels here first.
  */
-export type PanelId = "tool-list" | "configure-ai-run" | "recipes-list" | "recipe" | "import-drive-links";
+export type PanelId =
+  | "tool-list"
+  | "configure-ai-run"
+  | "recipes-list"
+  | "recipe"
+  | "import-drive-links";
 
 /**
  * Passed to each panel's mount() so panels can trigger navigation

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -47,7 +47,7 @@ export interface RecipeParams {
 /**
  * All registered panel identifiers. Add new panels here first.
  */
-export type PanelId = "tool-list" | "configure-ai-run" | "recipes-list" | "recipe";
+export type PanelId = "tool-list" | "configure-ai-run" | "recipes-list" | "recipe" | "import-drive-links";
 
 /**
  * Passed to each panel's mount() so panels can trigger navigation

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -27,7 +27,8 @@ import {
   writeColumn,
   writeJobProgress,
 } from "./utils";
-import type { RunConfig, PrepRecipeParams, PrepRecipeResult } from "../shared/types";
+import type { RunConfig, PrepRecipeParams, PrepRecipeResult, ImportDriveLinksConfig } from "../shared/types";
+import type { DriveFileInfo } from "./types";
 
 // ==========================================
 // 🚀 MENU & INITIALIZATION
@@ -69,60 +70,20 @@ export function showSidebar(): void {
 // 📂 TOOL 1: IMPORT DRIVE LINKS
 // ==========================================
 
-export function importDriveLinks(jobId?: string): void {
-  const ui = SpreadsheetApp.getUi();
+export function importDriveLinks(config: ImportDriveLinksConfig, jobId?: string): void {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+  const folderId = extractId(config.folderUrl);
 
-  // 1. Get Folder
-  const folderResponse = ui.prompt(
-    "Step 1/2: Select Folder",
-    "Paste the Google Drive Folder Link or ID:",
-    ui.ButtonSet.OK_CANCEL,
-  );
-  if (folderResponse.getSelectedButton() !== ui.Button.OK) return;
-  const folderId = extractId(folderResponse.getResponseText().trim());
-
-  // 2. Get Location
-  const activeA1 = sheet.getActiveCell().getA1Notation();
-  const cellResponse = ui.prompt(
-    "Step 2/2: Confirm Location",
-    `Importing links starting at cell ${activeA1}.\nClick OK to proceed or type a new cell below:`,
-    ui.ButtonSet.OK_CANCEL,
-  );
-  if (cellResponse.getSelectedButton() !== ui.Button.OK) return;
-  const startCell = cellResponse.getResponseText().trim() || activeA1;
-
-  try {
-    const parentFolder = DriveApp.getFolderById(folderId);
-    const targetRange = sheet.getRange(startCell);
-
-    if (jobId) {
-      writeJobProgress(CacheService.getUserCache(), jobId, { message: "Scanning folder..." });
-    }
-
-    const allFiles: { url: string }[] = [];
-    getAllFilesRecursive(parentFolder, allFiles);
-
-    if (allFiles.length > 0) {
-      const output = allFiles.map((f) => [f.url]);
-      sheet
-        .getRange(targetRange.getRow(), targetRange.getColumn(), output.length, 1)
-        .setValues(output);
-      SpreadsheetApp.getActive().toast(
-        `Imported ${output.length} links starting at ${startCell}`,
-        "Complete",
-        5,
-      );
-    } else {
-      ui.alert("No files found in that folder.");
-    }
-  } catch (e) {
-    ui.alert(
-      "Error accessing folder",
-      "Please ensure you have access to this folder ID.\n\nDetails: " + (e as Error).message,
-      ui.ButtonSet.OK,
-    );
+  if (jobId) {
+    writeJobProgress(CacheService.getUserCache(), jobId, { message: "Scanning folder..." });
   }
+
+  const parentFolder = DriveApp.getFolderById(folderId);
+  const allFiles: DriveFileInfo[] = [];
+  getAllFilesRecursive(parentFolder, allFiles, config.mimeTypes);
+
+  const col = findOrCreateColumn(sheet, config.outputCol, SpreadsheetApp.WrapStrategy.CLIP);
+  writeColumn(sheet, col, allFiles.map((f) => f.url));
 }
 
 // ==========================================
@@ -412,7 +373,6 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
 
 export function runTool(functionName: string, jobId?: string): void {
   const TOOLS: Record<string, (jobId?: string) => void> = {
-    importDriveLinks,
     extractTextFromSelection,
     sampleRowsToEvaluation,
   };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -27,7 +27,12 @@ import {
   writeColumn,
   writeJobProgress,
 } from "./utils";
-import type { RunConfig, PrepRecipeParams, PrepRecipeResult, ImportDriveLinksConfig } from "../shared/types";
+import type {
+  RunConfig,
+  PrepRecipeParams,
+  PrepRecipeResult,
+  ImportDriveLinksConfig,
+} from "../shared/types";
 import type { DriveFileInfo } from "./types";
 
 // ==========================================
@@ -83,7 +88,11 @@ export function importDriveLinks(config: ImportDriveLinksConfig, jobId?: string)
   getAllFilesRecursive(parentFolder, allFiles, config.mimeTypes);
 
   const col = findOrCreateColumn(sheet, config.outputCol, SpreadsheetApp.WrapStrategy.CLIP);
-  writeColumn(sheet, col, allFiles.map((f) => f.url));
+  writeColumn(
+    sheet,
+    col,
+    allFiles.map((f) => f.url),
+  );
 }
 
 // ==========================================

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -93,6 +93,11 @@ export function importDriveLinks(config: ImportDriveLinksConfig, jobId?: string)
     col,
     allFiles.map((f) => f.url),
   );
+  SpreadsheetApp.getActive().toast(
+    `Imported ${allFiles.length} link${allFiles.length === 1 ? "" : "s"} into "${config.outputCol}".`,
+    "Complete",
+    5,
+  );
 }
 
 // ==========================================

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -47,14 +47,20 @@ export function createSeededRandom(seed?: number): () => number {
 export function getAllFilesRecursive(
   folder: GoogleAppsScript.Drive.Folder,
   fileList: DriveFileInfo[],
+  mimeTypePrefixes?: string[],
 ): void {
   const files = folder.getFiles();
   while (files.hasNext()) {
-    fileList.push({ url: files.next().getUrl() });
+    const file = files.next();
+    if (mimeTypePrefixes) {
+      const mime = file.getMimeType();
+      if (!mimeTypePrefixes.some((p) => mime.startsWith(p))) continue;
+    }
+    fileList.push({ url: file.getUrl() });
   }
   const subfolders = folder.getFolders();
   while (subfolders.hasNext()) {
-    getAllFilesRecursive(subfolders.next(), fileList);
+    getAllFilesRecursive(subfolders.next(), fileList, mimeTypePrefixes);
   }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -66,3 +66,12 @@ export interface PrepRecipeResult {
   /** Echoed from PrepRecipeParams — no server-side processing. */
   tools?: ToolId[];
 }
+
+// ── Import Drive Links ───────────────────────────────────────────
+
+export interface ImportDriveLinksConfig {
+  folderUrl: string;
+  outputCol: string;
+  /** MIME type prefix strings. Absent = import all files. */
+  mimeTypes?: string[];
+}


### PR DESCRIPTION
## Summary

- Replaces the legacy `ui.prompt()` dialog flow for Import Drive Links with a dedicated sidebar panel
- New `ImportDriveLinksPanel` collects folder URL, output column (via `SingleTagList` with create-new support), and optional file type filters (Google Docs, Sheets, PDFs, Images, Audio, Video) before dispatching the job
- Server-side `importDriveLinks` rewritten to accept `ImportDriveLinksConfig` and use `findOrCreateColumn`/`writeColumn` instead of A1 cell notation; `getAllFilesRecursive` gains optional MIME prefix filtering
- `importDriveLinks` removed from the `runTool` dispatcher (first of three Extra tool → panel migrations; `runTool` will be deleted once Sample Rows and Extract Text follow)

## Test Plan
- [ ] 309 tests pass, all coverage thresholds met
- [ ] Lint, typecheck, format check all clean
- [ ] Build succeeds (server IIFE + Sidebar.html)
- [ ] Manually: open sidebar → click Import Drive Links → verify panel loads with folder URL input, output column selector, and file type chips
- [ ] Manually: paste a Drive folder URL, select an output column, click Import Links → verify job runs and links appear in the sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)