### PR TITLE
feat: Extract Text panel (#54)

### DIFF
--- a/__tests__/panels/extract-text.test.ts
+++ b/__tests__/panels/extract-text.test.ts
@@ -84,10 +84,9 @@ describe("ExtractTextPanel", () => {
     const c = mountPanel();
     await Promise.resolve();
 
-    // select source column (first tag) and output column (second tag)
-    const tags = c.querySelectorAll<HTMLElement>(".tag");
-    tags[0]?.click(); // source-col first tag
-    tags[1]?.click(); // output-col first tag (or new col)
+    // select first tag in each list independently
+    c.querySelector<HTMLElement>("#source-col .tag")?.click();
+    c.querySelector<HTMLElement>("#output-col .tag")?.click();
 
     c.querySelector<HTMLButtonElement>("#extract-btn")!.click();
     expect(jobStoreModule.jobStore.dispatch).toHaveBeenCalledWith(
@@ -141,9 +140,8 @@ describe("ExtractTextPanel", () => {
     const c = mountPanel();
     await Promise.resolve();
 
-    const tags = c.querySelectorAll<HTMLElement>(".tag");
-    tags[0]?.click();
-    tags[1]?.click();
+    c.querySelector<HTMLElement>("#source-col .tag")?.click();
+    c.querySelector<HTMLElement>("#output-col .tag")?.click();
     c.querySelector<HTMLButtonElement>("#extract-btn")!.click();
     await new Promise((r) => setTimeout(r, 0));
     expect(globalThis.alert).toHaveBeenCalledWith("Error: job failed");

--- a/__tests__/panels/extract-text.test.ts
+++ b/__tests__/panels/extract-text.test.ts
@@ -96,6 +96,49 @@ describe("ExtractTextPanel", () => {
     );
   });
 
+  it("passes rowRange: undefined to extractText when sheet selection is active", async () => {
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive", "extracted_text"]);
+    (services.extractText as jest.Mock).mockReturnValue(Promise.resolve());
+    const c = mountPanel();
+    await Promise.resolve();
+
+    c.querySelector<HTMLElement>("#source-col .tag")?.click();
+    c.querySelector<HTMLElement>("#output-col .tag")?.click();
+    // leave RowRange in default "Use sheet selection" mode
+    c.querySelector<HTMLButtonElement>("#extract-btn")!.click();
+
+    expect(services.extractText).toHaveBeenCalledWith(
+      expect.objectContaining({ rowRange: undefined }),
+      expect.any(String),
+    );
+  });
+
+  it("passes explicit rowRange to extractText when specify range is active", async () => {
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive", "extracted_text"]);
+    (services.extractText as jest.Mock).mockReturnValue(Promise.resolve());
+    const c = mountPanel();
+    await Promise.resolve();
+
+    c.querySelector<HTMLElement>("#source-col .tag")?.click();
+    c.querySelector<HTMLElement>("#output-col .tag")?.click();
+
+    // switch to "Specify range" and fill in values
+    const rangeRadio = c.querySelector<HTMLInputElement>("input[value='range']")!;
+    rangeRadio.click();
+    const rangeInputs = c.querySelectorAll<HTMLInputElement>(".range-inputs input");
+    const startInput = rangeInputs[0];
+    const endInput = rangeInputs[1];
+    startInput.value = "3";
+    endInput.value = "7";
+
+    c.querySelector<HTMLButtonElement>("#extract-btn")!.click();
+
+    expect(services.extractText).toHaveBeenCalledWith(
+      expect.objectContaining({ rowRange: { start: 3, end: 7 } }),
+      expect.any(String),
+    );
+  });
+
   it("unmount returns saved state", async () => {
     (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive"]);
     document.body.innerHTML = '<div id="app"></div>';

--- a/__tests__/panels/extract-text.test.ts
+++ b/__tests__/panels/extract-text.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock("../../src/client/services", () => ({
+  getSheetHeaders: jest.fn(),
+  extractText: jest.fn(),
+}));
+
+jest.mock("../../src/client/job-store", () => ({
+  jobStore: { dispatch: jest.fn().mockResolvedValue(undefined) },
+}));
+
+import { ExtractTextPanel } from "../../src/client/panels/extract-text";
+import * as services from "../../src/client/services";
+import * as jobStoreModule from "../../src/client/job-store";
+import type { NavigationContext } from "../../src/client/types";
+
+const mockNav: NavigationContext = {
+  navigate: jest.fn(),
+  back: jest.fn(),
+  canGoBack: jest.fn().mockReturnValue(true),
+};
+
+function mountPanel(savedState?: unknown): HTMLElement {
+  document.body.innerHTML = '<div id="app"></div>';
+  const container = document.getElementById("app")!;
+  const panel = new ExtractTextPanel();
+  panel.mount(container, mockNav, undefined, savedState as never);
+  return container;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (jobStoreModule.jobStore.dispatch as jest.Mock).mockResolvedValue(undefined);
+});
+
+describe("ExtractTextPanel", () => {
+  it("shows a loader while headers are loading", () => {
+    (services.getSheetHeaders as jest.Mock).mockReturnValue(new Promise(() => {}));
+    const c = mountPanel();
+    expect(c.querySelector("#panel-loader")).toBeTruthy();
+    expect(c.querySelector<HTMLElement>("#config-form")!.style.display).toBe("none");
+  });
+
+  it("reveals form after headers load", async () => {
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive", "ai_inference"]);
+    const c = mountPanel();
+    await Promise.resolve();
+    expect(c.querySelector<HTMLElement>("#config-form")!.style.display).not.toBe("none");
+  });
+
+  it("back button calls nav.back()", () => {
+    (services.getSheetHeaders as jest.Mock).mockReturnValue(new Promise(() => {}));
+    const c = mountPanel();
+    c.querySelector<HTMLButtonElement>("#back-btn")!.click();
+    expect(mockNav.back).toHaveBeenCalled();
+  });
+
+  it("alerts when source column is not selected and Extract is clicked", async () => {
+    globalThis.alert = jest.fn();
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive"]);
+    const c = mountPanel();
+    await Promise.resolve();
+    c.querySelector<HTMLButtonElement>("#extract-btn")!.click();
+    expect(globalThis.alert).toHaveBeenCalledWith(expect.stringContaining("source column"));
+  });
+
+  it("alerts when output column is not selected and Extract is clicked", async () => {
+    globalThis.alert = jest.fn();
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive"]);
+    const c = mountPanel();
+    await Promise.resolve();
+    // select source column but not output
+    c.querySelector<HTMLElement>("#source-col .tag")?.click();
+    c.querySelector<HTMLButtonElement>("#extract-btn")!.click();
+    expect(globalThis.alert).toHaveBeenCalledWith(expect.stringContaining("output column"));
+  });
+
+  it("dispatches extractText job when form is valid", async () => {
+    const promise = Promise.resolve();
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive", "extracted_text"]);
+    (services.extractText as jest.Mock).mockReturnValue(promise);
+    const c = mountPanel();
+    await Promise.resolve();
+
+    // select source column (first tag) and output column (second tag)
+    const tags = c.querySelectorAll<HTMLElement>(".tag");
+    tags[0]?.click(); // source-col first tag
+    tags[1]?.click(); // output-col first tag (or new col)
+
+    c.querySelector<HTMLButtonElement>("#extract-btn")!.click();
+    expect(jobStoreModule.jobStore.dispatch).toHaveBeenCalledWith(
+      expect.stringMatching(/^extract-text-\d+$/),
+      "Extract Text",
+      promise,
+    );
+  });
+
+  it("unmount returns saved state", async () => {
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive"]);
+    document.body.innerHTML = '<div id="app"></div>';
+    const container = document.getElementById("app")!;
+    const panel = new ExtractTextPanel();
+    panel.mount(container, mockNav);
+    await Promise.resolve();
+    const state = panel.unmount();
+    expect(state).toBeDefined();
+    expect(typeof state?.startRow).toBe("number");
+    expect(typeof state?.endRow).toBe("number");
+  });
+
+  it("restores saved state on remount", async () => {
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive"]);
+    const c = mountPanel({
+      sourceCol: "source_drive",
+      outputCol: "extracted_text",
+      startRow: 2,
+      endRow: 10,
+    });
+    await Promise.resolve();
+    // Panel should not throw and form should be visible after load
+    expect(c.querySelector("#config-form")).toBeTruthy();
+  });
+
+  it("navigates back when getSheetHeaders fails", async () => {
+    globalThis.alert = jest.fn();
+    (services.getSheetHeaders as jest.Mock).mockRejectedValue(new Error("network error"));
+    mountPanel();
+    await Promise.resolve();
+    expect(mockNav.back).toHaveBeenCalled();
+  });
+
+  it("alerts on jobStore dispatch failure", async () => {
+    globalThis.alert = jest.fn();
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive", "extracted_text"]);
+    (services.extractText as jest.Mock).mockReturnValue(Promise.resolve());
+    (jobStoreModule.jobStore.dispatch as jest.Mock).mockReturnValue(
+      Promise.reject(new Error("job failed")),
+    );
+    const c = mountPanel();
+    await Promise.resolve();
+
+    const tags = c.querySelectorAll<HTMLElement>(".tag");
+    tags[0]?.click();
+    tags[1]?.click();
+    c.querySelector<HTMLButtonElement>("#extract-btn")!.click();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(globalThis.alert).toHaveBeenCalledWith("Error: job failed");
+  });
+
+  it("refresh button re-fetches headers", async () => {
+    (services.getSheetHeaders as jest.Mock).mockResolvedValue(["source_drive"]);
+    const c = mountPanel();
+    await Promise.resolve();
+    expect(services.getSheetHeaders).toHaveBeenCalledTimes(1);
+    c.querySelector<HTMLButtonElement>("#refresh-btn")!.click();
+    await Promise.resolve();
+    expect(services.getSheetHeaders).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/panels/tool-list.test.ts
+++ b/__tests__/panels/tool-list.test.ts
@@ -63,14 +63,10 @@ describe("ToolListPanel", () => {
     );
   });
 
-  it("clicking Extract Text calls runTool with 'extractTextFromSelection' and a jobId", () => {
-    (services.runTool as jest.Mock).mockResolvedValue(undefined);
+  it("clicking Extract Text navigates to extract-text panel", () => {
     const c = mountPanel();
     c.querySelector<HTMLButtonElement>("#btn-extract-text")!.click();
-    expect(services.runTool).toHaveBeenCalledWith(
-      "extractTextFromSelection",
-      expect.stringMatching(/^extractTextFromSelection-\d+$/),
-    );
+    expect(mockNav.navigate).toHaveBeenCalledWith("extract-text");
   });
 
   it("unmount() returns undefined", () => {

--- a/__tests__/services.test.ts
+++ b/__tests__/services.test.ts
@@ -11,6 +11,7 @@ const mockRun = {
   prepRecipe: jest.fn(),
   getJobProgress: jest.fn(),
   importDriveLinks: jest.fn(),
+  extractText: jest.fn(),
 };
 (globalThis as unknown as { google: unknown }).google = { script: { run: mockRun } };
 
@@ -149,6 +150,33 @@ describe("importDriveLinks", () => {
     const promise = services.importDriveLinks(config, "job-1");
     handlers.reject(new Error("drive error"));
     await expect(promise).rejects.toThrow("drive error");
+  });
+});
+
+describe("extractText", () => {
+  it("calls google.script.run.extractText with config and jobId and resolves", async () => {
+    const handlers = captureHandlers();
+    const config: import("../src/shared/types").ExtractTextConfig = {
+      sourceCol: "source_drive",
+      outputCol: "source_text",
+      rowRange: { start: 2, end: 10 },
+    };
+    const promise = services.extractText(config, "job-2");
+    handlers.resolve(undefined);
+    await expect(promise).resolves.toBeUndefined();
+    expect(mockRun.extractText).toHaveBeenCalledWith(config, "job-2");
+  });
+
+  it("rejects on failure", async () => {
+    const handlers = captureHandlers();
+    const config: import("../src/shared/types").ExtractTextConfig = {
+      sourceCol: "source_drive",
+      outputCol: "source_text",
+      rowRange: { start: 2, end: 10 },
+    };
+    const promise = services.extractText(config, "job-2");
+    handlers.reject(new Error("extract error"));
+    await expect(promise).rejects.toThrow("extract error");
   });
 });
 

--- a/docs/plans/2026-03-20-extract-text-panel-design.md
+++ b/docs/plans/2026-03-20-extract-text-panel-design.md
@@ -1,0 +1,162 @@
+# Extract Text Panel — Design
+
+**Date:** 2026-03-20
+**Status:** Approved
+
+## Overview
+
+Rebuild the "Extract Text" tool as a first-class sidebar panel, replacing the legacy active-selection-based flow with a panel-based UX consistent with `ConfigureAIRunPanel` and `ImportDriveLinksPanel`. Remove all code supporting the old selection-driven path.
+
+## Goals
+
+- Collect source column, output column, and row range in the sidebar before running
+- Route the `btn-extract-text` button to a panel (`nav.navigate`) instead of dispatching immediately via `runTool`
+- Delete the old `extractTextFromSelection` server function and its `runTool` dispatcher entry
+
+## Architecture
+
+### New files
+
+- `src/client/panels/extract-text.ts` — `ExtractTextPanel` class
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `src/shared/types.ts` | Add `ExtractTextConfig` interface |
+| `src/server/index.ts` | Replace old `extractTextFromSelection` with new `extractText(config)`; remove from `runTool` dispatcher |
+| `src/client/types.ts` | Add `"extract-text"` to `PanelId` union |
+| `src/client/services.ts` | Add `extractText(config, jobId?)` service wrapper |
+| `src/client/panels/tool-list.ts` | Change Extract Text button to `nav.navigate("extract-text")` |
+| `src/client/sidebar-entry.ts` | Register `ExtractTextPanel` in the panels Map |
+| `src/client/google.d.ts` | Add `extractText` declaration |
+| `rollup.config.js` | Update global stub from `extractTextFromSelection(jobId)` → `extractText(config, jobId)` |
+
+## Data Flow
+
+```
+ExtractTextPanel
+  → validate (sourceCol required, outputCol required)
+  → jobStore.dispatch(jobId, "Extract Text", extractText(config, jobId))
+  → services.extractText(config, jobId)
+  → google.script.run.extractText(config, jobId)
+  → server: resolve sourceCol → loop rows → extractTextUniversal(fileId)
+  → findOrCreateColumn → cell.setValue (per row, flushed immediately)
+```
+
+## RPC Config Type (`shared/types.ts`)
+
+```ts
+export interface ExtractTextConfig {
+  sourceCol: string;  // Column header containing Drive links
+  outputCol: string;  // Column header for extracted text output (may be new)
+  startRow: number;
+  endRow: number;
+}
+```
+
+## Server Function (`index.ts`)
+
+Replaces the old `extractTextFromSelection` (which read from `SpreadsheetApp.getActiveRange()`):
+
+```ts
+export function extractText(config: ExtractTextConfig, jobId?: string): void {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+  const headers = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0] as string[];
+  const sourceColIdx = headers.indexOf(config.sourceCol);
+
+  if (sourceColIdx === -1) {
+    throw new Error(`Column "${config.sourceCol}" not found`);
+  }
+
+  const outputCol = findOrCreateColumn(sheet, config.outputCol, SpreadsheetApp.WrapStrategy.WRAP);
+  const total = config.endRow - config.startRow + 1;
+
+  for (let i = 0; i < total; i++) {
+    const rowIdx = config.startRow + i; // 1-based data row
+    const cellValue = sheet.getRange(rowIdx + 1, sourceColIdx + 1).getValue() as string;
+
+    if (jobId) {
+      writeJobProgress(CacheService.getUserCache(), jobId, {
+        message: `Extracting row ${i + 1} of ${total}...`,
+        current: i + 1,
+        total,
+      });
+    }
+
+    if (!isValidDriveLink(cellValue)) {
+      continue;
+    }
+
+    const fileId = extractId(cellValue);
+    const text = extractTextUniversal(fileId);
+    const truncated = truncateText(text, 49000);
+    sheet.getRange(rowIdx + 1, outputCol).setValue(truncated);
+    SpreadsheetApp.flush();
+  }
+}
+```
+
+Error handling: exceptions propagate to the client via `jobStore`, which surfaces them as alerts.
+
+### `extractTextUniversal` (`drive.ts`)
+
+No changes to the function signature or logic. A comment marks where a file size guard would slot in, before the `Drive.Files.create()` call for PDFs and images:
+
+```ts
+// TODO: enforce a max file size here if needed (e.g. blob.getBytes().length > MAX_BYTES)
+```
+
+## Panel UX
+
+```
+┌─────────────────────────────────────┐
+│ ← Back    📜 Extract Text           │
+├─────────────────────────────────────┤
+│  [PanelLoader — loading columns]    │
+│                                     │
+│ Source Column *                     │
+│ [SingleTagList — existing cols only]│
+│                                     │
+│ Output Column *                     │
+│ [SingleTagList w/ includeNew:true ] │
+│                                     │
+│ Row Range *                         │
+│ [RowRange — start / end inputs    ] │
+│                                     │
+│ ℹ Supported file types: Google      │
+│   Docs, PDFs, and images (JPEG,     │
+│   PNG, GIF, WebP, etc.)             │
+│   Google Docs are read directly.    │
+│   PDFs and images are processed     │
+│   using Google Drive's native OCR.  │
+│   Output is truncated at 49,000     │
+│   characters.                       │
+│                                     │
+│         [ Extract Text ]            │
+└─────────────────────────────────────┘
+```
+
+The entire form is hidden behind `PanelLoader` until `getSheetHeaders()` resolves (same pattern as `ConfigureAIRunPanel` and `ImportDriveLinksPanel`). Extract Text button is disabled until both source and output columns are selected.
+
+## Panel Saved State
+
+```ts
+type SavedState = {
+  sourceCol: string;
+  outputCol: string;
+  startRow: number;
+  endRow: number;
+};
+```
+
+Restored on back navigation so the user doesn't lose their inputs.
+
+## Cleanup
+
+- Remove old `extractTextFromSelection` body (selection-driven, used `SpreadsheetApp.getActiveRange()`)
+- Remove `extractTextFromSelection` entry from `runTool` TOOLS dispatcher in `index.ts`
+- Update `rollup.config.js` footer stub
+- Update `google.d.ts` declaration
+- Change `btn-extract-text` in `ToolListPanel` from `dispatchTool()` to `nav.navigate("extract-text")`
+- Once Sample Rows is also migrated, `runTool` becomes dead code — delete the function, its GAS stub, and its `google.d.ts` declaration

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -82,7 +82,7 @@ function runTool(fn, jobId) { _GASEntry.runTool(fn, jobId); }
 function getSheetHeaders() { return _GASEntry.getSheetHeaders(); }
 function runBatchAI(config, jobId) { _GASEntry.runBatchAI(config, jobId); }
 function importDriveLinks(config, jobId) { _GASEntry.importDriveLinks(config, jobId); }
-function extractTextFromSelection(jobId) { _GASEntry.extractTextFromSelection(jobId); }
+function extractText(config, jobId) { _GASEntry.extractText(config, jobId); }
 function sampleRowsToEvaluation(jobId) { _GASEntry.sampleRowsToEvaluation(jobId); }
 /**
  * Call the Gemini API from a spreadsheet cell.

--- a/src/client/google.d.ts
+++ b/src/client/google.d.ts
@@ -1,4 +1,9 @@
-import type { RunConfig, PrepRecipeParams, ImportDriveLinksConfig, ExtractTextConfig } from "../shared/types";
+import type {
+  RunConfig,
+  PrepRecipeParams,
+  ImportDriveLinksConfig,
+  ExtractTextConfig,
+} from "../shared/types";
 
 declare global {
   interface GoogleScriptRun {

--- a/src/client/google.d.ts
+++ b/src/client/google.d.ts
@@ -1,4 +1,4 @@
-import type { RunConfig, PrepRecipeParams, ImportDriveLinksConfig } from "../shared/types";
+import type { RunConfig, PrepRecipeParams, ImportDriveLinksConfig, ExtractTextConfig } from "../shared/types";
 
 declare global {
   interface GoogleScriptRun {
@@ -8,6 +8,7 @@ declare global {
     getSheetHeaders(): void;
     runBatchAI(config: RunConfig, jobId?: string): void;
     importDriveLinks(config: ImportDriveLinksConfig, jobId?: string): void;
+    extractText(config: ExtractTextConfig, jobId?: string): void;
     prepRecipe(params: PrepRecipeParams): void;
     getJobProgress(jobId: string): void;
   }

--- a/src/client/panels/extract-text.ts
+++ b/src/client/panels/extract-text.ts
@@ -149,14 +149,13 @@ export class ExtractTextPanel implements Panel<undefined, SavedState> {
       <div id="config-form" style="display:none">
         <div class="field-group">
           <span class="field-label">Source Column <span class="required">*</span></span>
+          <p class="field-helper">Accepts Google Docs, PDFs, and images (OCR'd via Google Drive).</p>
           <div id="source-col" class="tag-list"></div>
-          <p class="field-helper">Supported file types: Google Docs, PDFs, and images (JPEG, PNG, GIF, WebP, etc.)</p>
-          <p class="field-helper">Google Docs are read directly. PDFs and images are processed using Google Drive's native OCR service.</p>
         </div>
         <div class="field-group">
           <span class="field-label">Output Column <span class="required">*</span></span>
+          <p class="field-helper">Truncated at 49,000 characters.</p>
           <div id="output-col" class="tag-list"></div>
-          <p class="field-helper">Output is truncated at 49,000 characters.</p>
         </div>
         <div class="field-group">
           <span class="field-label">Row Range <span class="required">*</span></span>

--- a/src/client/panels/extract-text.ts
+++ b/src/client/panels/extract-text.ts
@@ -31,28 +31,19 @@ export class ExtractTextPanel implements Panel<undefined, SavedState> {
 
     const loader = new PanelLoader(container);
 
-    const loadHeaders = (
-      selectedSource?: string,
-      selectedOutput?: string,
-    ): Promise<void> => {
+    const loadHeaders = (selectedSource?: string, selectedOutput?: string): Promise<void> => {
       loader.setState({ status: "loading", message: "Loading columns..." });
       return getSheetHeaders().then(
         (headers) => {
-          this.sourceColList = new SingleTagList(
-            container.querySelector("#source-col")!,
-            headers,
-            { selected: selectedSource },
-          );
-          this.outputColList = new SingleTagList(
-            container.querySelector("#output-col")!,
-            headers,
-            {
-              includeNew: true,
-              selected: selectedOutput,
-              newPlaceholder: "extracted_text",
-              newDefault: "",
-            },
-          );
+          this.sourceColList = new SingleTagList(container.querySelector("#source-col")!, headers, {
+            selected: selectedSource,
+          });
+          this.outputColList = new SingleTagList(container.querySelector("#output-col")!, headers, {
+            includeNew: true,
+            selected: selectedOutput,
+            newPlaceholder: "extracted_text",
+            newDefault: "",
+          });
           container.querySelector<HTMLElement>("#config-form")!.style.display = "block";
           loader.setState({ status: "idle" });
         },
@@ -78,10 +69,7 @@ export class ExtractTextPanel implements Panel<undefined, SavedState> {
       const btn = container.querySelector<HTMLButtonElement>("#refresh-btn")!;
       btn.classList.add("spinning");
       btn.disabled = true;
-      loadHeaders(
-        this.sourceColList?.getValue(),
-        this.outputColList?.getValue(),
-      ).finally(() => {
+      loadHeaders(this.sourceColList?.getValue(), this.outputColList?.getValue()).finally(() => {
         btn.classList.remove("spinning");
         btn.disabled = false;
       });

--- a/src/client/panels/extract-text.ts
+++ b/src/client/panels/extract-text.ts
@@ -123,12 +123,10 @@ export class ExtractTextPanel implements Panel<undefined, SavedState> {
       return null;
     }
 
-    const range = this.rowRange?.getValue();
-
     return {
       sourceCol,
       outputCol,
-      rowRange: range ? { start: range.start, end: range.end } : { start: 2, end: 2 },
+      rowRange: this.rowRange?.getValue(),
     };
   }
 

--- a/src/client/panels/extract-text.ts
+++ b/src/client/panels/extract-text.ts
@@ -38,12 +38,9 @@ export class ExtractTextPanel implements Panel<undefined, SavedState> {
       loader.setState({ status: "loading", message: "Loading columns..." });
       return getSheetHeaders().then(
         (headers) => {
-          const sourceHeaders = headers.filter(
-            (h) => h.toLowerCase().includes("source") || h.toLowerCase().includes("drive"),
-          );
           this.sourceColList = new SingleTagList(
             container.querySelector("#source-col")!,
-            sourceHeaders.length > 0 ? sourceHeaders : headers,
+            headers,
             { selected: selectedSource },
           );
           this.outputColList = new SingleTagList(

--- a/src/client/panels/extract-text.ts
+++ b/src/client/panels/extract-text.ts
@@ -150,19 +150,17 @@ export class ExtractTextPanel implements Panel<undefined, SavedState> {
         <div class="field-group">
           <span class="field-label">Source Column <span class="required">*</span></span>
           <div id="source-col" class="tag-list"></div>
+          <p class="field-helper">Supported file types: Google Docs, PDFs, and images (JPEG, PNG, GIF, WebP, etc.)</p>
+          <p class="field-helper">Google Docs are read directly. PDFs and images are processed using Google Drive's native OCR service.</p>
         </div>
         <div class="field-group">
           <span class="field-label">Output Column <span class="required">*</span></span>
           <div id="output-col" class="tag-list"></div>
+          <p class="field-helper">Output is truncated at 49,000 characters.</p>
         </div>
         <div class="field-group">
           <span class="field-label">Row Range <span class="required">*</span></span>
           <div id="row-range"></div>
-        </div>
-        <div class="field-group helper-text">
-          <p>Supported file types: Google Docs, PDFs, and images (JPEG, PNG, GIF, WebP, etc.)</p>
-          <p>Google Docs are read directly. PDFs and images are processed using Google Drive's native OCR service.</p>
-          <p>Output is truncated at 49,000 characters.</p>
         </div>
         <div class="panel-buttons">
           <button id="extract-btn" class="btn-run">Extract Text</button>

--- a/src/client/panels/extract-text.ts
+++ b/src/client/panels/extract-text.ts
@@ -1,0 +1,176 @@
+import type { NavigationContext, Panel } from "../types";
+import type { ExtractTextConfig } from "../../shared/types";
+import { SingleTagList } from "../components/single-tag-list";
+import { RowRange } from "../components/row-range";
+import { PanelLoader } from "../components/panel-loader";
+import { getSheetHeaders, extractText } from "../services";
+import { jobStore } from "../job-store";
+
+type SavedState = {
+  sourceCol: string;
+  outputCol: string;
+  startRow: number;
+  endRow: number;
+};
+
+export class ExtractTextPanel implements Panel<undefined, SavedState> {
+  private sourceColList: SingleTagList | null = null;
+  private outputColList: SingleTagList | null = null;
+  private rowRange: RowRange | null = null;
+  private nav: NavigationContext | null = null;
+
+  mount(
+    container: HTMLElement,
+    nav: NavigationContext,
+    _params?: undefined,
+    savedState?: SavedState,
+  ): void {
+    this.nav = nav;
+    container.innerHTML = this.template();
+    container.querySelector("#back-btn")?.addEventListener("click", () => nav.back());
+
+    const loader = new PanelLoader(container);
+
+    const loadHeaders = (
+      selectedSource?: string,
+      selectedOutput?: string,
+    ): Promise<void> => {
+      loader.setState({ status: "loading", message: "Loading columns..." });
+      return getSheetHeaders().then(
+        (headers) => {
+          const sourceHeaders = headers.filter(
+            (h) => h.toLowerCase().includes("source") || h.toLowerCase().includes("drive"),
+          );
+          this.sourceColList = new SingleTagList(
+            container.querySelector("#source-col")!,
+            sourceHeaders.length > 0 ? sourceHeaders : headers,
+            { selected: selectedSource },
+          );
+          this.outputColList = new SingleTagList(
+            container.querySelector("#output-col")!,
+            headers,
+            {
+              includeNew: true,
+              selected: selectedOutput,
+              newPlaceholder: "extracted_text",
+              newDefault: "",
+            },
+          );
+          container.querySelector<HTMLElement>("#config-form")!.style.display = "block";
+          loader.setState({ status: "idle" });
+        },
+        (err: Error) => {
+          globalThis.alert("Error loading headers: " + err.message);
+          nav.back();
+        },
+      );
+    };
+
+    const savedRowRange =
+      savedState?.startRow !== undefined && savedState?.endRow !== undefined
+        ? { start: savedState.startRow, end: savedState.endRow }
+        : undefined;
+
+    this.rowRange = new RowRange(container.querySelector("#row-range")!, savedRowRange);
+
+    container
+      .querySelector<HTMLButtonElement>("#extract-btn")!
+      .addEventListener("click", () => this.handleExtract());
+
+    container.querySelector("#refresh-btn")?.addEventListener("click", () => {
+      const btn = container.querySelector<HTMLButtonElement>("#refresh-btn")!;
+      btn.classList.add("spinning");
+      btn.disabled = true;
+      loadHeaders(
+        this.sourceColList?.getValue(),
+        this.outputColList?.getValue(),
+      ).finally(() => {
+        btn.classList.remove("spinning");
+        btn.disabled = false;
+      });
+    });
+
+    loadHeaders(savedState?.sourceCol, savedState?.outputCol);
+  }
+
+  unmount(): SavedState {
+    const range = this.rowRange?.getValue();
+    return {
+      sourceCol: this.sourceColList?.getValue() ?? "",
+      outputCol: this.outputColList?.getValue() ?? "",
+      startRow: range?.start ?? 2,
+      endRow: range?.end ?? 2,
+    };
+  }
+
+  private handleExtract(): void {
+    const config = this.assembleConfig();
+    if (!config) return;
+
+    const jobId = `extract-text-${Date.now()}`;
+    jobStore
+      .dispatch(jobId, "Extract Text", extractText(config, jobId))
+      .catch((err: Error) => globalThis.alert("Error: " + err.message));
+  }
+
+  private assembleConfig(): ExtractTextConfig | null {
+    const sourceCol = this.sourceColList?.getValue() ?? "";
+    if (!sourceCol) {
+      globalThis.alert("Please select a source column.");
+      return null;
+    }
+
+    const outputCol = this.outputColList?.getValue() ?? "";
+    if (!outputCol) {
+      globalThis.alert("Please select an output column.");
+      return null;
+    }
+
+    const range = this.rowRange?.getValue();
+
+    return {
+      sourceCol,
+      outputCol,
+      rowRange: range ? { start: range.start, end: range.end } : { start: 2, end: 2 },
+    };
+  }
+
+  private template(): string {
+    return `
+      <div class="panel-header">
+        <button id="back-btn" class="back-btn">← Back</button>
+        <span class="panel-title">📜 Extract Text</span>
+        <button id="refresh-btn" class="refresh-btn" title="Refresh columns">↻</button>
+      </div>
+      <div id="panel-loader" class="panel-loader" hidden>
+        <div class="panel-loader__bar-wrap" hidden>
+          <div class="panel-loader__bar-fill"></div>
+        </div>
+        <div class="panel-loader__spinner" hidden></div>
+        <p class="panel-loader__message"></p>
+      </div>
+      <div id="config-form" style="display:none">
+        <div class="field-group">
+          <span class="field-label">Source Column <span class="required">*</span></span>
+          <div id="source-col" class="tag-list"></div>
+        </div>
+        <div class="field-group">
+          <span class="field-label">Output Column <span class="required">*</span></span>
+          <div id="output-col" class="tag-list"></div>
+        </div>
+        <div class="field-group">
+          <span class="field-label">Row Range <span class="required">*</span></span>
+          <div id="row-range"></div>
+        </div>
+        <div class="field-group helper-text">
+          <p>Supported file types: Google Docs, PDFs, and images (JPEG, PNG, GIF, WebP, etc.)</p>
+          <p>Google Docs are read directly. PDFs and images are processed using Google Drive's native OCR service.</p>
+          <p>Output is truncated at 49,000 characters.</p>
+        </div>
+        <div class="panel-buttons">
+          <button id="extract-btn" class="btn-run">Extract Text</button>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/client/panels/tool-list.ts
+++ b/src/client/panels/tool-list.ts
@@ -25,8 +25,8 @@ export class ToolListPanel implements Panel {
     container.querySelector("#btn-sample-rows")?.addEventListener("click", (e) => {
       this.dispatchTool(e as MouseEvent, "sampleRowsToEvaluation");
     });
-    container.querySelector("#btn-extract-text")?.addEventListener("click", (e) => {
-      this.dispatchTool(e as MouseEvent, "extractTextFromSelection");
+    container.querySelector("#btn-extract-text")?.addEventListener("click", () => {
+      nav.navigate("extract-text");
     });
   }
 

--- a/src/client/services.ts
+++ b/src/client/services.ts
@@ -1,4 +1,5 @@
 import type {
+  ExtractTextConfig,
   ImportDriveLinksConfig,
   PrepRecipeParams,
   PrepRecipeResult,
@@ -47,6 +48,15 @@ export function importDriveLinks(config: ImportDriveLinksConfig, jobId?: string)
       .withSuccessHandler(() => resolve())
       .withFailureHandler((err: Error) => reject(err))
       .importDriveLinks(config, jobId);
+  });
+}
+
+export function extractText(config: ExtractTextConfig, jobId?: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    google.script.run
+      .withSuccessHandler(() => resolve())
+      .withFailureHandler((err: Error) => reject(err))
+      .extractText(config, jobId);
   });
 }
 

--- a/src/client/sidebar-entry.ts
+++ b/src/client/sidebar-entry.ts
@@ -12,6 +12,7 @@ import { ConfigureAIRunPanel } from "./panels/configure-ai-run";
 import { RecipesListPanel } from "./panels/recipes-list";
 import { RecipePanel } from "./panels/recipe";
 import { ImportDriveLinksPanel } from "./panels/import-drive-links";
+import { ExtractTextPanel } from "./panels/extract-text";
 import { JobIndicator } from "./components/job-indicator";
 import { jobStore } from "./job-store";
 import type { Panel, PanelId } from "./types";
@@ -31,6 +32,7 @@ function init(): void {
     ["recipes-list", new RecipesListPanel()],
     ["recipe", new RecipePanel()],
     ["import-drive-links", new ImportDriveLinksPanel()],
+    ["extract-text", new ExtractTextPanel()],
   ]);
 
   const router = new Router(app, panels);

--- a/src/client/sidebar.css
+++ b/src/client/sidebar.css
@@ -55,6 +55,7 @@
 
         h3 {
             font-size: 11px;
+            font-style: italic;
             font-weight: 500;
             color: var(--text-secondary);
             text-transform: uppercase;
@@ -95,6 +96,7 @@
             padding: 16px;
             border-top: 1px solid #eee;
             font-size: 11px;
+            font-style: italic;
             color: var(--text-secondary);
             text-align: center;
             line-height: 1.5;
@@ -208,6 +210,7 @@
         .field-label {
             display: block;
             font-size: 11px;
+            font-style: italic;
             font-weight: 500;
             color: var(--text-secondary);
             text-transform: uppercase;
@@ -357,6 +360,7 @@
             align-items: center;
             gap: 6px;
             font-size: 11px;
+            font-style: italic;
             color: var(--text-secondary);
             margin-top: 10px;
             cursor: pointer;
@@ -387,6 +391,7 @@
 
         .tool-btn-sub {
             font-size: 11px;
+            font-style: italic;
             color: var(--text-secondary);
             font-weight: 400;
             line-height: 1.3;
@@ -433,6 +438,7 @@
 
         .field-helper {
             font-size: 11px;
+            font-style: italic;
             color: var(--text-secondary);
             margin: 0 0 8px 0;
             line-height: 1.4;
@@ -476,6 +482,7 @@
             border-radius: 4px;
             color: var(--text-secondary);
             font-size: 11px;
+            font-style: italic;
             cursor: pointer;
             padding: 3px 6px;
             white-space: nowrap;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -52,7 +52,8 @@ export type PanelId =
   | "configure-ai-run"
   | "recipes-list"
   | "recipe"
-  | "import-drive-links";
+  | "import-drive-links"
+  | "extract-text";
 
 /**
  * Passed to each panel's mount() so panels can trigger navigation

--- a/src/server/drive.ts
+++ b/src/server/drive.ts
@@ -52,6 +52,8 @@ export function extractTextUniversal(fileId: string): string {
         mimeType: MimeType.GOOGLE_DOCS,
       };
       // Drive.Files.create with content triggers server-side OCR
+      // TODO: enforce a max file size here if needed before calling the Drive API
+      // e.g. if (file.getBlob().getBytes().length > MAX_BYTES) return "[Skipped: File too large]";
       const tempFile = Drive.Files.create(resource, file.getBlob());
       const tempId = tempFile.id!;
       const text = DocumentApp.openById(tempId).getBody().getText();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -127,7 +127,7 @@ export function extractText(config: ExtractTextConfig, jobId?: string): void {
   const total = config.rowRange.end - config.rowRange.start + 1;
 
   for (let i = 0; i < total; i++) {
-    const rowIdx = config.rowRange.start + i; // 1-based data row (row 1 = header)
+    const rowIdx = config.rowRange.start + i; // sheet row number (1-indexed; start=2 = first data row)
 
     if (jobId) {
       writeJobProgress(CacheService.getUserCache(), jobId, {
@@ -138,7 +138,7 @@ export function extractText(config: ExtractTextConfig, jobId?: string): void {
     }
 
     const cellValue = sheet
-      .getRange(rowIdx + 1, sourceColIdx + 1)
+      .getRange(rowIdx, sourceColIdx + 1)
       .getValue() as string;
 
     if (!isValidDriveLink(cellValue)) {
@@ -147,7 +147,7 @@ export function extractText(config: ExtractTextConfig, jobId?: string): void {
 
     const fileId = extractId(cellValue);
     const text = truncateText(extractTextUniversal(fileId), 49000);
-    sheet.getRange(rowIdx + 1, outputCol).setValue(text);
+    sheet.getRange(rowIdx, outputCol).setValue(text);
     SpreadsheetApp.flush();
   }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -118,11 +118,7 @@ export function extractText(config: ExtractTextConfig, jobId?: string): void {
     throw new Error(`Column "${config.sourceCol}" not found`);
   }
 
-  const outputCol = findOrCreateColumn(
-    sheet,
-    config.outputCol,
-    SpreadsheetApp.WrapStrategy.WRAP,
-  );
+  const outputCol = findOrCreateColumn(sheet, config.outputCol, SpreadsheetApp.WrapStrategy.WRAP);
 
   let startRow: number;
   let total: number;
@@ -147,9 +143,7 @@ export function extractText(config: ExtractTextConfig, jobId?: string): void {
       });
     }
 
-    const cellValue = sheet
-      .getRange(rowIdx, sourceColIdx + 1)
-      .getValue() as string;
+    const cellValue = sheet.getRange(rowIdx, sourceColIdx + 1).getValue() as string;
 
     if (!isValidDriveLink(cellValue)) {
       continue;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -32,6 +32,7 @@ import type {
   PrepRecipeParams,
   PrepRecipeResult,
   ImportDriveLinksConfig,
+  ExtractTextConfig,
 } from "../shared/types";
 import type { DriveFileInfo } from "./types";
 
@@ -104,51 +105,51 @@ export function importDriveLinks(config: ImportDriveLinksConfig, jobId?: string)
 // 📝 TOOL 2: EXTRACT TEXT
 // ==========================================
 
-export function extractTextFromSelection(jobId?: string): void {
-  const ui = SpreadsheetApp.getUi();
+export function extractText(config: ExtractTextConfig, jobId?: string): void {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
 
-  if (!checkDriveService(ui)) return;
+  if (!checkDriveService(SpreadsheetApp.getUi())) return;
 
-  const range = sheet.getActiveRange();
-  if (!range) return;
+  const lastCol = sheet.getLastColumn();
+  const headers = sheet.getRange(1, 1, 1, lastCol).getValues()[0] as string[];
+  const sourceColIdx = headers.indexOf(config.sourceCol);
 
-  const values = range.getValues();
-  const totalRows = range.getNumRows();
-
-  if (totalRows > 10) {
-    const confirm = ui.alert(
-      "Batch Process",
-      `You selected ${totalRows} rows. This may take time. Continue?`,
-      ui.ButtonSet.YES_NO,
-    );
-    if (confirm !== ui.Button.YES) return;
+  if (sourceColIdx === -1) {
+    throw new Error(`Column "${config.sourceCol}" not found`);
   }
 
-  let processedCount = 0;
+  const outputCol = findOrCreateColumn(
+    sheet,
+    config.outputCol,
+    SpreadsheetApp.WrapStrategy.WRAP,
+  );
 
-  for (let i = 0; i < totalRows; i++) {
-    const cellValue = values[i][0];
+  const total = config.rowRange.end - config.rowRange.start + 1;
 
-    if (isValidDriveLink(cellValue)) {
-      const fileId = extractId(cellValue);
+  for (let i = 0; i < total; i++) {
+    const rowIdx = config.rowRange.start + i; // 1-based data row (row 1 = header)
 
-      if (jobId) {
-        writeJobProgress(CacheService.getUserCache(), jobId, {
-          message: `Extracting ${i + 1} of ${totalRows}`,
-          current: i + 1,
-          total: totalRows,
-        });
-      }
-
-      const text = truncateText(extractTextUniversal(fileId), 49000);
-
-      range.getCell(i + 1, 2).setValue(text);
-      processedCount++;
-      SpreadsheetApp.flush();
+    if (jobId) {
+      writeJobProgress(CacheService.getUserCache(), jobId, {
+        message: `Extracting row ${i + 1} of ${total}...`,
+        current: i + 1,
+        total,
+      });
     }
+
+    const cellValue = sheet
+      .getRange(rowIdx + 1, sourceColIdx + 1)
+      .getValue() as string;
+
+    if (!isValidDriveLink(cellValue)) {
+      continue;
+    }
+
+    const fileId = extractId(cellValue);
+    const text = truncateText(extractTextUniversal(fileId), 49000);
+    sheet.getRange(rowIdx + 1, outputCol).setValue(text);
+    SpreadsheetApp.flush();
   }
-  SpreadsheetApp.getActive().toast(`Done! Extracted ${processedCount} files.`, "Complete", 5);
 }
 
 // ==========================================
@@ -387,7 +388,6 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
 
 export function runTool(functionName: string, jobId?: string): void {
   const TOOLS: Record<string, (jobId?: string) => void> = {
-    extractTextFromSelection,
     sampleRowsToEvaluation,
   };
   TOOLS[functionName]?.(jobId);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -124,10 +124,20 @@ export function extractText(config: ExtractTextConfig, jobId?: string): void {
     SpreadsheetApp.WrapStrategy.WRAP,
   );
 
-  const total = config.rowRange.end - config.rowRange.start + 1;
+  let startRow: number;
+  let total: number;
+  if (config.rowRange) {
+    startRow = config.rowRange.start;
+    total = config.rowRange.end - config.rowRange.start + 1;
+  } else {
+    const activeRange = sheet.getActiveRange();
+    if (!activeRange) return;
+    startRow = activeRange.getRow();
+    total = activeRange.getNumRows();
+  }
 
   for (let i = 0; i < total; i++) {
-    const rowIdx = config.rowRange.start + i; // sheet row number (1-indexed; start=2 = first data row)
+    const rowIdx = startRow + i; // sheet row number (1-indexed; start=2 = first data row)
 
     if (jobId) {
       writeJobProgress(CacheService.getUserCache(), jobId, {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -75,3 +75,12 @@ export interface ImportDriveLinksConfig {
   /** MIME type prefix strings. Absent = import all files. */
   mimeTypes?: string[];
 }
+
+// ── Extract Text ─────────────────────────────────────────────────
+
+export interface ExtractTextConfig {
+  sourceCol: string;
+  outputCol: string;
+  startRow: number;
+  endRow: number;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -83,6 +83,6 @@ export interface ExtractTextConfig {
   sourceCol: string;
   /** Header of the column where extracted text will be written. */
   outputCol: string;
-  /** Inclusive row range (1-based data rows) over which extraction runs. */
-  rowRange: { start: number; end: number };
+  /** Inclusive row range (1-based data rows) over which extraction runs. Absent = use active sheet selection. */
+  rowRange?: { start: number; end: number };
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -76,11 +76,13 @@ export interface ImportDriveLinksConfig {
   mimeTypes?: string[];
 }
 
-// ── Extract Text ─────────────────────────────────────────────────
+// ── Extract Text ────────────────────────────────────────────────
 
 export interface ExtractTextConfig {
+  /** Header of the column containing Drive links or file IDs to extract text from. */
   sourceCol: string;
+  /** Header of the column where extracted text will be written. */
   outputCol: string;
-  startRow: number;
-  endRow: number;
+  /** Inclusive row range (1-based data rows) over which extraction runs. */
+  rowRange: { start: number; end: number };
 }


### PR DESCRIPTION
## Summary

- Migrates the Extract Text tool from a manual cell-selection flow into a dedicated sidebar panel, following the same pattern established by the Import Drive Links panel (#53)
- Adds `ExtractTextPanel` with a source column picker, output column picker (with new column support), and row range inputs
- Replaces `extractTextFromSelection` (read from active range, hardcoded column 2) with config-driven `extractText(config, jobId)` that reads from and writes to named columns

## How it works

The underlying text extraction is unchanged: Google Docs are read directly via `DocumentApp`, and PDFs/images are OCR'd by converting them to a temporary Google Doc via the Drive API v3. The panel adds helper text explaining supported types, the native OCR mechanism, and the 49,000-character truncation limit.

## Manual Testing Steps

### Setup
1. Deploy to Apps Script: `npm run deploy`
2. Open a Google Sheet and launch the SSI Toolkit sidebar
3. Ensure your sheet has at least one column containing Google Drive file links (Docs, PDFs, or images)

### Happy path — existing output column
1. Click **Extras → Extract Text** in the sidebar
2. Verify the panel loads with Source Column, Output Column, and Row Range fields
3. Select your Drive links column as the source
4. Select an existing column as the output
5. Set a row range covering your Drive link rows
6. Click **Extract Text**
7. Verify progress is shown in the job indicator strip
8. Verify extracted text appears in the output column for each row
9. Verify rows without a valid Drive link are skipped (output cell left unchanged)

### Happy path — new output column
1. Repeat steps 1–5 above, but this time select **+ New Column** and enter `extracted_text`
2. Click **Extract Text**
3. Verify a new `extracted_text` column is created at the end of the sheet
4. Verify text is written starting from the correct row (not off by one)

### File type coverage
1. Test with a Google Doc link — text should be extracted directly
2. Test with a PDF link — text should be OCR'd (requires Drive Advanced Service enabled)
3. Test with an image link (JPEG or PNG) — text should be OCR'd
4. Test with an unsupported file type (e.g. a Google Sheet) — cell should contain `[Skipped: Unsupported Type]`

### Navigation
1. Fill in source/output/row range, then click ← Back
2. Click the ↻ refresh button — verify column lists reload

### Error handling
1. Click **Extract Text** without selecting a source column — verify alert: "Please select a source column."
2. Select a source column but not an output — verify alert: "Please select an output column."
3. Delete the Drive Advanced Service from Apps Script and retry — verify a descriptive error appears
