### PR TITLE
Remove deprecated documentation button from sidebar

### DIFF
--- a/src/client/panels/tool-list.ts
+++ b/src/client/panels/tool-list.ts
@@ -41,12 +41,6 @@ export class ToolListPanel implements Panel {
 
   private template(): string {
     return `
-      <div class="guide-card">
-        <a href="https://docs.google.com/document/d/1BQJzBHiE6L0hvU6NMD0jaQE71VWRpWH-vNQu3UtGjBA/edit?tab=t.66jobsqlduah#heading=h.h5k0s81xpiiq"
-            target="_blank" class="guide-link">
-          <span>📖</span> View User Guide ↗
-        </a>
-      </div>
       <div class="section">
         <h3>Main Tools</h3>
         <button id="btn-recipes" class="tool-btn">

--- a/src/client/sidebar.css
+++ b/src/client/sidebar.css
@@ -28,28 +28,6 @@
 
         .container { padding: 16px; }
 
-        .guide-card {
-            background-color: #f8f9fa;
-            border: 1px solid var(--border-color);
-            border-radius: 8px;
-            padding: 16px;
-            margin-bottom: 24px;
-            text-align: center;
-            transition: background-color 0.2s;
-        }
-
-        .guide-card:hover { background-color: #f1f3f4; }
-
-        .guide-link {
-            color: var(--primary-blue);
-            font-weight: 500;
-            text-decoration: none;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            gap: 8px;
-            font-size: 14px;
-        }
 
         .section { margin-bottom: 28px; }
 


### PR DESCRIPTION
## Summary

- Removes the deprecated "View User Guide" guide card from the top of the sidebar tool list
- Removes the associated `.guide-card` and `.guide-link` CSS rules from `sidebar.css`