### PR TITLE
feat: Find a Thing in a Thing recipe + ColumnSpec type system

### DIFF
--- a/__tests__/inference.test.ts
+++ b/__tests__/inference.test.ts
@@ -4,8 +4,18 @@
 
 // ── Mock globals BEFORE imports ────────────────────────────────
 
+const mockFetch = jest.fn();
+const mockDriveApp = {
+  getFileById: jest.fn().mockReturnValue({
+    getMimeType: () => "application/pdf",
+    getSize: () => 1000,
+    getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+  }),
+};
+const mockBlob = { getBytes: () => [1, 2, 3] };
+
 (globalThis as any).UrlFetchApp = {
-  fetch: jest.fn(),
+  fetch: mockFetch,
 };
 
 (globalThis as any).PropertiesService = {
@@ -14,13 +24,7 @@
   }),
 };
 
-(globalThis as any).DriveApp = {
-  getFileById: jest.fn().mockReturnValue({
-    getMimeType: () => "application/pdf",
-    getSize: () => 1000,
-    getBlob: () => ({ getBytes: () => [1, 2, 3] }),
-  }),
-};
+(globalThis as any).DriveApp = mockDriveApp;
 
 (globalThis as any).Utilities = {
   base64Encode: jest.fn().mockReturnValue("encoded=="),
@@ -47,7 +51,7 @@ import { runInference } from "../src/server/inference";
 // ── Helpers ────────────────────────────────────────────────────
 
 function mockFetchResponse(body: unknown): void {
-  (UrlFetchApp.fetch as jest.Mock).mockReturnValue({
+  mockFetch.mockReturnValue({
     getContentText: () => JSON.stringify(body),
   });
 }
@@ -56,6 +60,8 @@ function mockOkResponse(text: string): void {
   mockFetchResponse({ candidates: [{ content: { parts: [{ text }] } }] });
 }
 
+const validResponse = { candidates: [{ content: { parts: [{ text: "ok" }] } }] };
+
 // ── Tests ──────────────────────────────────────────────────────
 
 describe("runInference", () => {
@@ -63,18 +69,18 @@ describe("runInference", () => {
 
   it("returns the model response string for a scalar user prompt", () => {
     mockOkResponse("AI response");
-    expect(runInference("Hello AI")?.text).toBe("AI response");
+    expect(runInference([{ kind: "text", value: "Hello AI" }])?.text).toBe("AI response");
   });
 
   it("returns null when userPrompts flattens to empty", () => {
-    expect(runInference(null)).toBeNull();
-    expect(runInference("")).toBeNull();
+    expect(runInference([{ kind: "text", value: null }])).toBeNull();
+    expect(runInference([{ kind: "text", value: "" }])).toBeNull();
   });
 
   it("flattens a vertical range of user prompts", () => {
     mockOkResponse("ok");
-    runInference([["p1"], ["p2"]]);
-    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    runInference([{ kind: "text", value: [["p1"], ["p2"]] }]);
+    const payload = JSON.parse(mockFetch.mock.calls[0][1].payload);
     expect(payload.contents[0].parts).toHaveLength(2);
     expect(payload.contents[0].parts[0].text).toBe("p1");
     expect(payload.contents[0].parts[1].text).toBe("p2");
@@ -82,8 +88,11 @@ describe("runInference", () => {
 
   it("encodes a valid drive link as inlineData", () => {
     mockOkResponse("ok");
-    runInference("prompt", "https://drive.google.com/file/d/abc123/view");
-    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    runInference([
+      { kind: "text", value: "prompt" },
+      { kind: "file", value: "https://drive.google.com/file/d/abc123/view" },
+    ]);
+    const payload = JSON.parse(mockFetch.mock.calls[0][1].payload);
     expect(payload.contents[0].parts[1].inline_data).toEqual({
       mime_type: "application/pdf",
       data: "encoded==",
@@ -92,58 +101,100 @@ describe("runInference", () => {
 
   it("filters out invalid drive links silently", () => {
     mockOkResponse("ok");
-    runInference("prompt", "not-a-drive-link");
-    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    runInference([
+      { kind: "text", value: "prompt" },
+      { kind: "file", value: "not-a-drive-link" },
+    ]);
+    const payload = JSON.parse(mockFetch.mock.calls[0][1].payload);
     expect(payload.contents[0].parts).toHaveLength(1); // text only, no inline_data
   });
 
-  it("omits inlineData from payload when driveLinks is omitted", () => {
+  it("omits inlineData from payload when no file parts provided", () => {
     mockOkResponse("ok");
-    runInference("prompt");
-    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    runInference([{ kind: "text", value: "prompt" }]);
+    const payload = JSON.parse(mockFetch.mock.calls[0][1].payload);
     expect(payload.contents[0].parts).toHaveLength(1);
   });
 
   it("passes systemPrompt to the payload", () => {
     mockOkResponse("ok");
-    runInference("prompt", undefined, "Be concise");
-    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    runInference([{ kind: "text", value: "prompt" }], "Be concise");
+    const payload = JSON.parse(mockFetch.mock.calls[0][1].payload);
     expect(payload.system_instruction.parts[0].text).toBe("Be concise");
   });
 
   it("uses default system prompt when systemPrompt is omitted", () => {
     mockOkResponse("ok");
-    runInference("prompt");
-    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    runInference([{ kind: "text", value: "prompt" }]);
+    const payload = JSON.parse(mockFetch.mock.calls[0][1].payload);
     expect(payload.system_instruction.parts[0].text).toBe("You are a helpful assistant.");
   });
 
   it("returns an error string when invokeGemini throws", () => {
     mockFetchResponse({ error: { message: "quota exceeded" } });
-    expect(runInference("prompt")?.text).toBe("Error: quota exceeded");
+    expect(runInference([{ kind: "text", value: "prompt" }])?.text).toBe("Error: quota exceeded");
   });
 
   it("returns an error string when Drive fetch throws", () => {
-    (DriveApp.getFileById as jest.Mock).mockImplementationOnce(() => {
+    mockDriveApp.getFileById.mockImplementationOnce(() => {
       throw new Error("File not found");
     });
-    expect(runInference("prompt", "https://drive.google.com/file/d/abc123/view")?.text).toBe(
-      "Error: File not found",
-    );
+    expect(
+      runInference([
+        { kind: "text", value: "prompt" },
+        { kind: "file", value: "https://drive.google.com/file/d/abc123/view" },
+      ])?.text,
+    ).toBe("Error: File not found");
   });
 
   it("passes tools to the payload when provided", () => {
     mockOkResponse("ok");
-    runInference("prompt", undefined, undefined, ["google_search"]);
-    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    runInference([{ kind: "text", value: "prompt" }], undefined, ["google_search"]);
+    const payload = JSON.parse(mockFetch.mock.calls[0][1].payload);
     expect(payload.tools).toBeDefined();
     expect(payload.tools[0]).toHaveProperty("google_search");
   });
 
   it("omits tools from the payload when not provided", () => {
     mockOkResponse("ok");
-    runInference("prompt");
-    const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
+    runInference([{ kind: "text", value: "prompt" }]);
+    const payload = JSON.parse(mockFetch.mock.calls[0][1].payload);
     expect(payload.tools).toBeUndefined();
+  });
+
+  it("separates text and file parts into userTexts and inlineData", () => {
+    mockFetch.mockReturnValue({
+      getContentText: () => JSON.stringify(validResponse),
+    });
+
+    runInference(
+      [
+        { kind: "text", value: "describe this" },
+        { kind: "file", value: "https://drive.google.com/file/d/abc123/view" },
+        { kind: "text", value: "is it relevant?" },
+      ],
+      "you are an analyst",
+    );
+
+    const payload = JSON.parse(mockFetch.mock.calls[0][1].payload);
+    // buildGeminiPayload puts all text parts first, then all inline_data parts
+    expect(payload.contents[0].parts[0].text).toBe("describe this");
+    expect(payload.contents[0].parts[1].text).toBe("is it relevant?");
+    expect(payload.contents[0].parts[2].inline_data).toBeDefined();
+    expect(payload.system_instruction.parts[0].text).toBe("you are an analyst");
+  });
+
+  it("returns null when no non-empty text parts", () => {
+    const result = runInference([{ kind: "text", value: "" }]);
+    expect(result).toBeNull();
+  });
+
+  it("silently filters invalid Drive links from file parts", () => {
+    mockOkResponse("ok");
+    runInference([
+      { kind: "text", value: "prompt" },
+      { kind: "file", value: "not-a-drive-link" },
+    ]);
+    expect(mockDriveApp.getFileById).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/inference.test.ts
+++ b/__tests__/inference.test.ts
@@ -12,8 +12,6 @@ const mockDriveApp = {
     getBlob: () => ({ getBytes: () => [1, 2, 3] }),
   }),
 };
-const mockBlob = { getBytes: () => [1, 2, 3] };
-
 (globalThis as any).UrlFetchApp = {
   fetch: mockFetch,
 };

--- a/__tests__/menu.test.ts
+++ b/__tests__/menu.test.ts
@@ -335,14 +335,11 @@ describe("prepRecipe", () => {
   // which call sheet.getRange / setValues under the hood.
   // We capture calls via mockActiveSheet.getRange mock.
 
-  let findOrCreateColumnColCounter: number;
-
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetAllFilesRecursive.mockReset();
     mockWriteColumnCalls.length = 0;
     mockFindOrCreateColumnResults.clear();
-    findOrCreateColumnColCounter = 2; // start at col 2 (after existing header col)
 
     // SpreadsheetApp.flush is called at the end of prepRecipe
     (globalThis as unknown as { SpreadsheetApp: typeof mockSpreadsheetApp & { flush: jest.Mock } })

--- a/__tests__/menu.test.ts
+++ b/__tests__/menu.test.ts
@@ -2,6 +2,11 @@
  * Tests for src/server/index.ts (Menu and sidebar functions)
  */
 
+// ── Mock runInference (hoisted by Jest) ────────────────────────
+jest.mock("../src/server/inference", () => ({
+  runInference: jest.fn(),
+}));
+
 // ── Mock globals BEFORE imports ────────────────────────────────
 
 const mockAddItem = jest.fn().mockReturnThis();
@@ -68,7 +73,10 @@ const mockHtmlService = {
 
 // ── Import after mocks ─────────────────────────────────────────
 
-import { onOpen, showSidebar, runTool, importDriveLinks } from "../src/server/index";
+import { onOpen, showSidebar, runTool, importDriveLinks, runBatchAI } from "../src/server/index";
+import { runInference } from "../src/server/inference";
+
+const mockRunInference = runInference as jest.MockedFunction<typeof runInference>;
 
 // ── Tests ──────────────────────────────────────────────────────
 
@@ -166,5 +174,133 @@ describe("importDriveLinks", () => {
     });
 
     expect(mockSetValues).toHaveBeenCalledWith([["https://drive.google.com/file/1"]]);
+  });
+});
+
+const mockSetValue = jest.fn();
+const mockFlush = jest.fn();
+
+describe("runBatchAI", () => {
+  // Headers: [Prompt(0), DriveLink(1), Output(2)]
+  const HEADERS = ["Prompt", "Drive Link", "Output"];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRunInference.mockReturnValue({ text: "AI result" });
+    (globalThis as unknown as { SpreadsheetApp: unknown }).SpreadsheetApp = {
+      ...mockSpreadsheetApp,
+      flush: mockFlush,
+      getActive: jest.fn().mockReturnValue({ toast: jest.fn() }),
+    };
+
+    // Sheet: 3 columns (Prompt, Drive Link, Output), last row = 2
+    mockActiveSheet.getLastColumn.mockReturnValue(3);
+    mockActiveSheet.getLastRow.mockReturnValue(2);
+
+    mockActiveSheet.getRange.mockImplementation(
+      (row: number, col: number, numRows?: number, numCols?: number) => {
+        // Header row read for getSheetHeaders
+        if (row === 1 && col === 1 && numRows === 1) {
+          return { getValues: () => [HEADERS] };
+        }
+        // Data range read for the row loop
+        if (numRows !== undefined && numCols !== undefined) {
+          return {
+            getValues: () => [["hello prompt", "https://drive.google.com/file/abc", ""]],
+          };
+        }
+        // Individual cell write
+        return { setValue: mockSetValue, setRichTextValue: jest.fn() };
+      },
+    );
+
+    // SpreadsheetApp.flush is called after each row
+    (globalThis as unknown as { SpreadsheetApp: { flush: jest.Mock } }).SpreadsheetApp.flush =
+      mockFlush;
+  });
+
+  it("writes runInference result to output column", () => {
+    const config = {
+      userPromptParts: [{ kind: "text" as const, col: "Prompt" }],
+      outputCol: "Output",
+      rowRange: { start: 2, end: 2 },
+    };
+
+    runBatchAI(config);
+
+    expect(mockRunInference).toHaveBeenCalledTimes(1);
+    expect(mockSetValue).toHaveBeenCalledWith("AI result");
+  });
+
+  it("alerts and returns early when a userPromptParts column is missing", () => {
+    const config = {
+      userPromptParts: [{ kind: "text" as const, col: "NonExistent" }],
+      outputCol: "Output",
+      rowRange: { start: 2, end: 2 },
+    };
+
+    runBatchAI(config);
+
+    expect(mockUi.alert).toHaveBeenCalledWith(
+      "Error: Missing Columns",
+      expect.stringContaining("NonExistent"),
+      expect.anything(),
+    );
+    expect(mockRunInference).not.toHaveBeenCalled();
+  });
+
+  it("skips rows where runInference returns null", () => {
+    mockRunInference.mockReturnValue(null);
+    const config = {
+      userPromptParts: [{ kind: "text" as const, col: "Prompt" }],
+      outputCol: "Output",
+      rowRange: { start: 2, end: 2 },
+    };
+
+    runBatchAI(config);
+
+    expect(mockRunInference).toHaveBeenCalledTimes(1);
+    expect(mockSetValue).not.toHaveBeenCalled();
+  });
+
+  it("passes userPromptParts to runInference in declared order", () => {
+    // Headers: Context(0), Doc(1), Question(2), Output(3)
+    const orderedHeaders = ["Context", "Doc", "Question", "Output"];
+    mockActiveSheet.getLastColumn.mockReturnValue(4);
+    mockActiveSheet.getRange.mockImplementation(
+      (row: number, col: number, numRows?: number, numCols?: number) => {
+        if (row === 1 && col === 1 && numRows === 1) {
+          return { getValues: () => [orderedHeaders] };
+        }
+        if (numRows !== undefined && numCols !== undefined) {
+          return {
+            getValues: () => [["ctx val", "doc val", "q val", ""]],
+          };
+        }
+        return { setValue: mockSetValue, setRichTextValue: jest.fn() };
+      },
+    );
+
+    const config = {
+      userPromptParts: [
+        { kind: "text" as const, col: "Context" },
+        { kind: "file" as const, col: "Doc" },
+        { kind: "text" as const, col: "Question" },
+      ],
+      outputCol: "Output",
+      rowRange: { start: 2, end: 2 },
+    };
+
+    runBatchAI(config);
+
+    expect(mockRunInference).toHaveBeenCalledWith(
+      [
+        { kind: "text", value: "ctx val" },
+        { kind: "file", value: "doc val" },
+        { kind: "text", value: "q val" },
+      ],
+      undefined,
+      undefined,
+    );
   });
 });

--- a/__tests__/menu.test.ts
+++ b/__tests__/menu.test.ts
@@ -7,6 +7,12 @@ jest.mock("../src/server/inference", () => ({
   runInference: jest.fn(),
 }));
 
+// ── Mock getAllFilesRecursive (keep rest of utils real) ─────────
+jest.mock("../src/server/utils", () => ({
+  ...jest.requireActual("../src/server/utils"),
+  getAllFilesRecursive: jest.fn(),
+}));
+
 // ── Mock globals BEFORE imports ────────────────────────────────
 
 const mockAddItem = jest.fn().mockReturnThis();
@@ -36,6 +42,7 @@ const mockActiveSheet = {
   getActiveRange: jest.fn(),
   getLastRow: jest.fn().mockReturnValue(0),
   getLastColumn: jest.fn().mockReturnValue(0),
+  getMaxRows: jest.fn().mockReturnValue(100),
   getRange: jest.fn(),
   getName: jest.fn().mockReturnValue("Sheet1"),
 };
@@ -73,10 +80,14 @@ const mockHtmlService = {
 
 // ── Import after mocks ─────────────────────────────────────────
 
-import { onOpen, showSidebar, runTool, importDriveLinks, runBatchAI } from "../src/server/index";
+import { onOpen, showSidebar, runTool, importDriveLinks, runBatchAI, prepRecipe } from "../src/server/index";
 import { runInference } from "../src/server/inference";
+import { getAllFilesRecursive } from "../src/server/utils";
 
 const mockRunInference = runInference as jest.MockedFunction<typeof runInference>;
+const mockGetAllFilesRecursive = getAllFilesRecursive as jest.MockedFunction<
+  typeof getAllFilesRecursive
+>;
 
 // ── Tests ──────────────────────────────────────────────────────
 
@@ -139,6 +150,12 @@ describe("importDriveLinks", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Restore real getAllFilesRecursive behaviour for importDriveLinks tests
+    const realUtils = jest.requireActual<typeof import("../src/server/utils")>(
+      "../src/server/utils",
+    );
+    mockGetAllFilesRecursive.mockImplementation(realUtils.getAllFilesRecursive);
+
     mockActiveSheet.getRange.mockReturnValue({ setValues: mockSetValues });
     mockActiveSheet.getLastColumn.mockReturnValue(1);
     mockActiveSheet.getLastRow.mockReturnValue(0);
@@ -148,7 +165,7 @@ describe("importDriveLinks", () => {
         if (row === 1 && col === 1 && numRows === 1) {
           return { getValues: () => [["source_drive"]] };
         }
-        return { setValues: mockSetValues };
+        return { setValues: mockSetValues, setWrapStrategy: jest.fn() };
       },
     );
   });
@@ -302,5 +319,275 @@ describe("runBatchAI", () => {
       undefined,
       undefined,
     );
+  });
+});
+
+// ── prepRecipe helpers ─────────────────────────────────────────
+
+const mockWriteColumnCalls: Array<{ colIdx: number; values: string[] }> = [];
+const mockFindOrCreateColumnResults: Map<string, number> = new Map();
+
+describe("prepRecipe", () => {
+  const mockFlushPrep = jest.fn();
+
+  // Track writeColumn calls by spying on mockActiveSheet.getRange behaviour.
+  // findOrCreateColumn and writeColumn use the real util implementations,
+  // which call sheet.getRange / setValues under the hood.
+  // We capture calls via mockActiveSheet.getRange mock.
+
+  let findOrCreateColumnColCounter: number;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAllFilesRecursive.mockReset();
+    mockWriteColumnCalls.length = 0;
+    mockFindOrCreateColumnResults.clear();
+    findOrCreateColumnColCounter = 2; // start at col 2 (after existing header col)
+
+    // SpreadsheetApp.flush is called at the end of prepRecipe
+    (globalThis as unknown as { SpreadsheetApp: typeof mockSpreadsheetApp & { flush: jest.Mock } })
+      .SpreadsheetApp.flush = mockFlushPrep;
+
+    // Sheet setup for findOrCreateColumn + writeColumn:
+    //   - getLastColumn returns 0 so findOrCreateColumn always appends a new col
+    //   - getRange(1, 1, 1, ...) returns a header row (empty so no match → append)
+    //   - getRange(2, colIdx, numRows, 1) is called by writeColumn → setValues
+    mockActiveSheet.getLastColumn.mockReturnValue(0);
+    mockActiveSheet.getLastRow.mockReturnValue(10);
+
+    mockActiveSheet.getRange.mockImplementation(
+      (row: number, col: number, numRows?: number, numCols?: number) => {
+        // Header row read by findOrCreateColumn (getRange(1, 1, 1, lastCol))
+        if (row === 1 && col === 1 && numRows === 1) {
+          return { getValues: () => [[]] };
+        }
+        // Header cell title write by findOrCreateColumn: getRange(1, newCol)
+        if (row === 1 && numRows === undefined) {
+          return { setValue: jest.fn() };
+        }
+        // Wrap strategy range: getRange(1, newCol, maxRows, 1) — row=1, numRows>1
+        if (row === 1 && numRows !== undefined && numRows > 1 && numCols === 1) {
+          return { setWrapStrategy: jest.fn() };
+        }
+        // writeColumn range: (2, colIdx, n, 1)
+        if (row === 2 && numRows !== undefined && numCols === 1) {
+          const captured = { colIdx: col, values: [] as string[] };
+          mockWriteColumnCalls.push(captured);
+          return {
+            setValues: (vals: string[][]) => {
+              captured.values = vals.map((r) => r[0]);
+            },
+            setWrapStrategy: jest.fn(),
+          };
+        }
+        // Fallback
+        return { setValue: jest.fn(), setValues: jest.fn(), setWrapStrategy: jest.fn() };
+      },
+    );
+
+    // DriveApp.getFolderById — always returns a stub folder
+    (globalThis as unknown as { DriveApp: unknown }).DriveApp = {
+      getFolderById: jest.fn().mockReturnValue({}),
+    };
+  });
+
+  it("writes drive-file-folder column and sets rowRange from file count", () => {
+    // getAllFilesRecursive mutates files array — inject 3 entries
+    mockGetAllFilesRecursive.mockImplementation(
+      (_folder: unknown, files: { url: string }[]) => {
+        files.push(
+          { url: "https://drive.google.com/file/a" },
+          { url: "https://drive.google.com/file/b" },
+          { url: "https://drive.google.com/file/c" },
+        );
+      },
+    );
+
+    const result = prepRecipe({
+      columns: [
+        {
+          kind: "drive-file-folder",
+          colTitle: "Drive Link",
+          url: "https://drive.google.com/drive/folders/abc1234567890123456789012345",
+        },
+      ],
+    });
+
+    expect(result.rowRange).toEqual({ start: 2, end: 4 });
+    expect(result.columns).toEqual([{ kind: "drive-file-folder", colTitle: "Drive Link" }]);
+    expect(mockWriteColumnCalls).toHaveLength(1);
+    expect(mockWriteColumnCalls[0].values).toEqual([
+      "https://drive.google.com/file/a",
+      "https://drive.google.com/file/b",
+      "https://drive.google.com/file/c",
+    ]);
+  });
+
+  it("writes drive-file-constant same URL to every row", () => {
+    // First column: folder with 2 files → numRows = 2
+    mockGetAllFilesRecursive.mockImplementation(
+      (_folder: unknown, files: { url: string }[]) => {
+        files.push(
+          { url: "https://drive.google.com/file/x" },
+          { url: "https://drive.google.com/file/y" },
+        );
+      },
+    );
+
+    const constUrl = "https://drive.google.com/file/d/xyz123456789012345678901234/view";
+
+    const result = prepRecipe({
+      columns: [
+        {
+          kind: "drive-file-folder",
+          colTitle: "Drive Link",
+          url: "https://drive.google.com/drive/folders/abc1234567890123456789012345",
+        },
+        {
+          kind: "drive-file-constant",
+          colTitle: "Ref File",
+          url: constUrl,
+        },
+      ],
+    });
+
+    expect(result.rowRange).toEqual({ start: 2, end: 3 });
+    // Find the writeColumn call for "Ref File" — it's the second call
+    const refFileWrite = mockWriteColumnCalls[1];
+    expect(refFileWrite).toBeDefined();
+    expect(refFileWrite.values).toEqual([constUrl, constUrl]);
+  });
+
+  it("writes system-prompt text to every row", () => {
+    mockGetAllFilesRecursive.mockImplementation(
+      (_folder: unknown, files: { url: string }[]) => {
+        files.push(
+          { url: "https://drive.google.com/file/p" },
+          { url: "https://drive.google.com/file/q" },
+        );
+      },
+    );
+
+    const result = prepRecipe({
+      columns: [
+        {
+          kind: "drive-file-folder",
+          colTitle: "Drive Link",
+          url: "https://drive.google.com/drive/folders/abc1234567890123456789012345",
+        },
+        {
+          kind: "system-prompt",
+          colTitle: "System Prompt",
+          text: "You are an analyst.",
+        },
+      ],
+    });
+
+    expect(result.rowRange).toEqual({ start: 2, end: 3 });
+    const sysPromptWrite = mockWriteColumnCalls[1];
+    expect(sysPromptWrite).toBeDefined();
+    expect(sysPromptWrite.values).toEqual(["You are an analyst.", "You are an analyst."]);
+  });
+
+  it("writes user-prompt text to every row", () => {
+    mockGetAllFilesRecursive.mockImplementation(
+      (_folder: unknown, files: { url: string }[]) => {
+        files.push({ url: "https://drive.google.com/file/r" });
+      },
+    );
+
+    prepRecipe({
+      columns: [
+        {
+          kind: "drive-file-folder",
+          colTitle: "Drive Link",
+          url: "https://drive.google.com/drive/folders/abc1234567890123456789012345",
+        },
+        {
+          kind: "user-prompt",
+          colTitle: "User Prompt",
+          text: "Summarize this document.",
+        },
+      ],
+    });
+
+    const userPromptWrite = mockWriteColumnCalls[1];
+    expect(userPromptWrite).toBeDefined();
+    expect(userPromptWrite.values).toEqual(["Summarize this document."]);
+  });
+
+  it("creates output column without writing data", () => {
+    // No folder column — numRows stays 1, but output column should only be created
+    const result = prepRecipe({
+      columns: [{ kind: "output", colTitle: "AI_Output" }],
+    });
+
+    expect(result.columns).toEqual([{ kind: "output", colTitle: "AI_Output" }]);
+    // writeColumn should NOT have been called (no data written for output)
+    expect(mockWriteColumnCalls).toHaveLength(0);
+    // rowRange defaults to { start: 2, end: 2 } (numRows=1)
+    expect(result.rowRange).toEqual({ start: 2, end: 2 });
+  });
+
+  it("echoes settings in result", () => {
+    const result = prepRecipe({
+      columns: [{ kind: "output", colTitle: "Out" }],
+      settings: { tools: ["google_search"], applyMarkdown: true },
+    });
+
+    expect(result.settings).toEqual({ tools: ["google_search"], applyMarkdown: true });
+  });
+
+  it("returns columns in input order", () => {
+    mockGetAllFilesRecursive.mockImplementation(
+      (_folder: unknown, files: { url: string }[]) => {
+        files.push({ url: "https://drive.google.com/file/s" });
+      },
+    );
+
+    const result = prepRecipe({
+      columns: [
+        {
+          kind: "drive-file-folder",
+          colTitle: "Drive Link",
+          url: "https://drive.google.com/drive/folders/abc1234567890123456789012345",
+        },
+        {
+          kind: "user-prompt",
+          colTitle: "User Prompt",
+          text: "Describe the file.",
+        },
+        { kind: "output", colTitle: "Result" },
+      ],
+    });
+
+    expect(result.columns.map((c) => c.kind)).toEqual([
+      "drive-file-folder",
+      "user-prompt",
+      "output",
+    ]);
+    expect(result.columns.map((c) => c.colTitle)).toEqual([
+      "Drive Link",
+      "User Prompt",
+      "Result",
+    ]);
+  });
+
+  it("uses numRows=1 for drive-file-constant when no folder column precedes it", () => {
+    const constUrl = "https://drive.google.com/file/d/xyz123456789012345678901234/view";
+
+    const result = prepRecipe({
+      columns: [
+        {
+          kind: "drive-file-constant",
+          colTitle: "Ref File",
+          url: constUrl,
+        },
+      ],
+    });
+
+    expect(result.rowRange).toEqual({ start: 2, end: 2 });
+    expect(mockWriteColumnCalls).toHaveLength(1);
+    expect(mockWriteColumnCalls[0].values).toEqual([constUrl]);
   });
 });

--- a/__tests__/panels/configure-ai-run.test.ts
+++ b/__tests__/panels/configure-ai-run.test.ts
@@ -105,6 +105,15 @@ describe("ConfigureAIRunPanel — mount", () => {
     const selected = container.querySelectorAll("#user-prompt-cols .tag.selected");
     expect(selected[0].getAttribute("data-value")).toBe("col_b");
   });
+
+  it("pre-selects drive-file-cols from file parts in userPromptParts", async () => {
+    const { container } = await mountAndLoad({
+      userPromptParts: [{ kind: "file", col: "col_b" }],
+    });
+    const selected = container.querySelectorAll("#drive-file-cols .tag.selected");
+    expect(selected).toHaveLength(1);
+    expect(selected[0].getAttribute("data-value")).toBe("col_b");
+  });
 });
 
 describe("ConfigureAIRunPanel — Run AI", () => {

--- a/__tests__/panels/configure-ai-run.test.ts
+++ b/__tests__/panels/configure-ai-run.test.ts
@@ -84,7 +84,9 @@ describe("ConfigureAIRunPanel — mount", () => {
   });
 
   it("pre-selects params on mount", async () => {
-    const { container } = await mountAndLoad({ userPromptCols: ["col_a"] });
+    const { container } = await mountAndLoad({
+      userPromptParts: [{ kind: "text", col: "col_a" }],
+    });
     const selected = container.querySelectorAll("#user-prompt-cols .tag.selected");
     expect(selected).toHaveLength(1);
     expect(selected[0].getAttribute("data-value")).toBe("col_a");
@@ -92,12 +94,14 @@ describe("ConfigureAIRunPanel — mount", () => {
 
   it("restores savedState over params", async () => {
     const savedState = {
-      userPromptCols: ["col_b"],
-      driveFileCols: [],
+      userPromptParts: [{ kind: "text" as const, col: "col_b" }],
       systemPromptCol: "",
       outputCol: "ai_inference",
     };
-    const { container } = await mountAndLoad({ userPromptCols: ["col_a"] }, savedState);
+    const { container } = await mountAndLoad(
+      { userPromptParts: [{ kind: "text", col: "col_a" }] },
+      savedState,
+    );
     const selected = container.querySelectorAll("#user-prompt-cols .tag.selected");
     expect(selected[0].getAttribute("data-value")).toBe("col_b");
   });
@@ -140,13 +144,16 @@ describe("ConfigureAIRunPanel — Run AI", () => {
   it("calls runBatchAI with correctly assembled RunConfig and a jobId", async () => {
     (services.runBatchAI as jest.Mock).mockResolvedValue(undefined);
     const { container } = await mountAndLoad({
-      userPromptCols: ["col_a"],
+      userPromptParts: [{ kind: "text", col: "col_a" }],
       outputCol: "ai_inference",
     });
     container.querySelector<HTMLButtonElement>("#run-btn")!.click();
     await Promise.resolve();
     expect(services.runBatchAI).toHaveBeenCalledWith(
-      expect.objectContaining({ userPromptCols: ["col_a"], outputCol: "ai_inference" }),
+      expect.objectContaining({
+        userPromptParts: [{ kind: "text", col: "col_a" }],
+        outputCol: "ai_inference",
+      }),
       expect.stringMatching(/^batch-ai-\d+$/),
     );
   });
@@ -154,7 +161,7 @@ describe("ConfigureAIRunPanel — Run AI", () => {
   it("stays on panel after run is dispatched and refetches headers", async () => {
     (services.runBatchAI as jest.Mock).mockResolvedValue(undefined);
     const { container } = await mountAndLoad({
-      userPromptCols: ["col_a"],
+      userPromptParts: [{ kind: "text", col: "col_a" }],
       outputCol: "ai_inference",
     });
     container.querySelector<HTMLButtonElement>("#run-btn")!.click();
@@ -166,7 +173,7 @@ describe("ConfigureAIRunPanel — Run AI", () => {
   it("alerts on failure via jobStore catch handler", async () => {
     (services.runBatchAI as jest.Mock).mockRejectedValue(new Error("API error"));
     const { container } = await mountAndLoad({
-      userPromptCols: ["col_a"],
+      userPromptParts: [{ kind: "text", col: "col_a" }],
       outputCol: "ai_inference",
     });
     container.querySelector<HTMLButtonElement>("#run-btn")!.click();
@@ -187,7 +194,10 @@ describe("ConfigureAIRunPanel — back", () => {
 describe("ConfigureAIRunPanel — refresh", () => {
   it("refresh-btn refetches headers preserving current selections", async () => {
     (services.getSheetHeaders as jest.Mock).mockResolvedValue(["col_a", "col_b"]);
-    const { container } = await mountAndLoad({ userPromptCols: ["col_a"], outputCol: "col_b" });
+    const { container } = await mountAndLoad({
+      userPromptParts: [{ kind: "text", col: "col_a" }],
+      outputCol: "col_b",
+    });
     expect(services.getSheetHeaders).toHaveBeenCalledTimes(1);
     container.querySelector<HTMLButtonElement>("#refresh-btn")!.click();
     await Promise.resolve();
@@ -222,7 +232,7 @@ describe("ConfigureAIRunPanel — tools TagList", () => {
   it("includes selected tool IDs in runBatchAI call", async () => {
     (services.runBatchAI as jest.Mock).mockResolvedValue(undefined);
     const { container } = await mountAndLoad({
-      userPromptCols: ["col_a"],
+      userPromptParts: [{ kind: "text", col: "col_a" }],
       outputCol: "ai_inference",
     });
     container.querySelector<HTMLButtonElement>('[data-value="google_search"]')!.click();
@@ -244,7 +254,7 @@ describe("includeGrounding checkbox", () => {
   it("assembleRunConfig includes includeGrounding: true when checkbox is checked", async () => {
     (services.runBatchAI as jest.Mock).mockResolvedValue(undefined);
     const { container } = await mountAndLoad({
-      userPromptCols: ["col_a"],
+      userPromptParts: [{ kind: "text", col: "col_a" }],
       outputCol: "ai_inference",
     });
     const cb = container.querySelector<HTMLInputElement>("#include-grounding-cb")!;
@@ -258,7 +268,7 @@ describe("includeGrounding checkbox", () => {
   it("assembleRunConfig omits includeGrounding when checkbox is unchecked", async () => {
     (services.runBatchAI as jest.Mock).mockResolvedValue(undefined);
     const { container } = await mountAndLoad({
-      userPromptCols: ["col_a"],
+      userPromptParts: [{ kind: "text", col: "col_a" }],
       outputCol: "ai_inference",
     });
     container.querySelector<HTMLInputElement>("#include-grounding-cb")!.checked = false;
@@ -288,11 +298,10 @@ describe("includeGrounding checkbox", () => {
 
   it("restores includeGrounding from savedState", async () => {
     const { container } = await mountAndLoad(undefined, {
-      userPromptCols: ["col_a"],
-      driveFileCols: [],
+      userPromptParts: [{ kind: "text" as const, col: "col_a" }],
       systemPromptCol: "",
       outputCol: "ai_inference",
-      tools: ["google_search"], // ← add this line
+      tools: ["google_search"],
       includeGrounding: true,
     });
     const cb = container.querySelector<HTMLInputElement>("#include-grounding-cb")!;
@@ -314,8 +323,7 @@ describe("includeGrounding checkbox", () => {
 
   it("shows the grounding group on mount when tools are pre-selected in savedState", async () => {
     const { container } = await mountAndLoad(undefined, {
-      userPromptCols: ["col_a"],
-      driveFileCols: [],
+      userPromptParts: [{ kind: "text" as const, col: "col_a" }],
       systemPromptCol: "",
       outputCol: "ai_inference",
       tools: ["google_search"],
@@ -344,7 +352,7 @@ describe("ConfigureAIRunPanel — unmount", () => {
       .click();
     const state = panel.unmount();
     expect(state).not.toBeUndefined();
-    expect((state as { userPromptCols: string[] }).userPromptCols).toContain("col_a");
+    expect(state?.userPromptParts).toContainEqual({ kind: "text", col: "col_a" });
     expect((state as { tools: string[] }).tools).toEqual([]); // no tools selected
   });
 

--- a/__tests__/panels/recipe.test.ts
+++ b/__tests__/panels/recipe.test.ts
@@ -8,7 +8,7 @@ jest.mock("../../src/client/services", () => ({
 import { RecipePanel } from "../../src/client/panels/recipe";
 import * as services from "../../src/client/services";
 import type { PrepRecipeResult } from "../../src/shared/types";
-import type { RecipeParams } from "../../src/client/types";
+import type { RecipeParams, ColumnSpec } from "../../src/client/types";
 import type { NavigationContext, RecipeDefinition } from "../../src/client/types";
 
 const mockPrepRecipe = services.prepRecipe as jest.Mock;
@@ -45,62 +45,109 @@ async function flush() {
 // ── rendering ───────────────────────────────────────────────────
 
 describe("rendering", () => {
-  it("renders drive folder input when driveFolder param present", () => {
-    const { container } = mount({ driveFolder: { colTitle: "Drive Link" } });
-    expect(container.querySelector("#drive-folder-input")).not.toBeNull();
-  });
-
-  it("does not render drive folder input when driveFolder absent", () => {
-    const { container } = mount({});
-    expect(container.querySelector("#drive-folder-input")).toBeNull();
-  });
-
-  it("renders system prompt fields when systemPrompt param present", () => {
-    const { container } = mount({
-      systemPrompt: {
+  it("renders a section card for each column in params.columns", () => {
+    const columns: ColumnSpec[] = [
+      { kind: "drive-file-folder", colTitle: { value: "Drive Link" }, url: { value: "" } },
+      {
+        kind: "system-prompt",
         colTitle: { value: "System Prompt", locked: true },
         prompt: { value: "You are helpful.", locked: true },
       },
-    });
-    expect(container.querySelector("#system-prompt-title-container")).not.toBeNull();
-    expect(container.querySelector("#system-prompt-value-container")).not.toBeNull();
+      { kind: "output", colTitle: { value: "AI_Out", locked: true } },
+    ];
+    const { container } = mount({ columns });
+    const cards = container.querySelectorAll(".recipe-section-card");
+    expect(cards.length).toBe(3);
   });
 
-  it("renders one user prompt section per userPrompts entry", () => {
-    const { container } = mount({
-      userPrompts: [
-        {
-          colTitle: { value: "User Prompt", locked: true },
-          prompt: { value: "Summarize.", locked: true },
-        },
-        {
-          colTitle: { value: "User Prompt 2", locked: true },
-          prompt: { value: "Also this.", locked: true },
-        },
-      ],
-    });
-    expect(container.querySelector("#user-prompt-title-0-container")).not.toBeNull();
-    expect(container.querySelector("#user-prompt-title-1-container")).not.toBeNull();
+  it("renders col-title container for each column", () => {
+    const columns: ColumnSpec[] = [
+      { kind: "drive-file-folder", colTitle: { value: "Drive Link" }, url: { value: "" } },
+      { kind: "output", colTitle: { value: "AI_Out", locked: true } },
+    ];
+    const { container } = mount({ columns });
+    expect(container.querySelector("#col-title-0-container")).not.toBeNull();
+    expect(container.querySelector("#col-title-1-container")).not.toBeNull();
+  });
+
+  it("renders url container for drive columns", () => {
+    const columns: ColumnSpec[] = [
+      { kind: "drive-file-folder", colTitle: { value: "Drive Link" }, url: { value: "" } },
+    ];
+    const { container } = mount({ columns });
+    expect(container.querySelector("#col-url-0-container")).not.toBeNull();
+  });
+
+  it("renders prompt container for prompt columns", () => {
+    const columns: ColumnSpec[] = [
+      {
+        kind: "user-prompt",
+        colTitle: { value: "User Prompt", locked: true },
+        prompt: { value: "Summarize.", locked: true },
+      },
+    ];
+    const { container } = mount({ columns });
+    expect(container.querySelector("#col-prompt-0-container")).not.toBeNull();
+  });
+
+  it("renders appendField textareas for prompt columns", () => {
+    const columns: ColumnSpec[] = [
+      {
+        kind: "system-prompt",
+        colTitle: { value: "System Prompt", locked: true },
+        prompt: { value: "You are an expert.", locked: true },
+        appendFields: [
+          { id: "types", label: "Document types", prefix: "\n\nYou are looking for:\n\n" },
+        ],
+      },
+    ];
+    const { container } = mount({ columns });
+    expect(container.querySelector("#append-field-0-types")).not.toBeNull();
+  });
+
+  it("does not render url container for non-drive columns", () => {
+    const columns: ColumnSpec[] = [
+      { kind: "output", colTitle: { value: "AI_Out", locked: true } },
+    ];
+    const { container } = mount({ columns });
+    expect(container.querySelector("#col-url-0-container")).toBeNull();
+  });
+
+  it("renders helper text when helperText is present", () => {
+    const columns: ColumnSpec[] = [
+      {
+        kind: "drive-file-folder",
+        colTitle: { value: "Drive Link" },
+        url: { value: "" },
+        helperText: "Make sure you have access",
+      },
+    ];
+    const { container } = mount({ columns });
+    expect(container.querySelector(".field-helper")?.textContent).toContain(
+      "Make sure you have access",
+    );
   });
 });
 
 // ── LockableField defaults ────────────────────────────────────────
 
 describe("LockableField defaults", () => {
-  it("initialises fields with locked: true values from params", () => {
-    const { container } = mount({
-      outputCol: { colTitle: { value: "AI_Summarization", locked: true } },
-    });
-    const input = container.querySelector<HTMLInputElement>("#output-col-title-container input")!;
+  it("initialises colTitle field with locked: true value from params", () => {
+    const columns: ColumnSpec[] = [
+      { kind: "output", colTitle: { value: "AI_Summarization", locked: true } },
+    ];
+    const { container } = mount({ columns });
+    const input = container.querySelector<HTMLInputElement>("#col-title-0-container input")!;
     expect(input.value).toBe("AI_Summarization");
     expect(input.disabled).toBe(true);
   });
 
-  it("initialises fields with locked: false as unlocked", () => {
-    const { container } = mount({
-      outputCol: { colTitle: { value: "AI_Output", locked: false } },
-    });
-    const input = container.querySelector<HTMLInputElement>("#output-col-title-container input")!;
+  it("initialises colTitle field with locked: false as unlocked", () => {
+    const columns: ColumnSpec[] = [
+      { kind: "output", colTitle: { value: "AI_Output", locked: false } },
+    ];
+    const { container } = mount({ columns });
+    const input = container.querySelector<HTMLInputElement>("#col-title-0-container input")!;
     expect(input.disabled).toBe(false);
   });
 });
@@ -111,56 +158,157 @@ describe("Prep flow", () => {
   beforeEach(() => {
     mockPrepRecipe.mockClear();
   });
-  const fullParams: RecipeParams = {
-    driveFolder: { colTitle: "Drive Link", helperText: "Check access" },
-    systemPrompt: {
+
+  const fullColumns: ColumnSpec[] = [
+    {
+      kind: "drive-file-folder",
+      colTitle: { value: "Drive Link", locked: true },
+      url: { value: "", locked: false },
+      helperText: "Check access",
+    },
+    {
+      kind: "system-prompt",
       colTitle: { value: "System Prompt", locked: true },
       prompt: { value: "You are helpful.", locked: true },
     },
-    userPrompts: [
-      {
-        colTitle: { value: "User Prompt", locked: true },
-        prompt: { value: "Summarize.", locked: true },
-      },
-    ],
-    outputCol: { colTitle: { value: "AI_Out", locked: true } },
-  };
+    {
+      kind: "user-prompt",
+      colTitle: { value: "User Prompt", locked: true },
+      prompt: { value: "Summarize.", locked: true },
+    },
+    { kind: "output", colTitle: { value: "AI_Out", locked: true } },
+  ];
 
   const mockResult: PrepRecipeResult = {
     rowRange: { start: 2, end: 11 },
-    colNames: {
-      driveLink: "Drive Link",
-      systemPrompt: "System Prompt",
-      userPrompts: ["User Prompt"],
-      outputCol: "AI_Out",
-    },
+    columns: [
+      { kind: "drive-file-folder", colTitle: "Drive Link" },
+      { kind: "system-prompt", colTitle: "System Prompt" },
+      { kind: "user-prompt", colTitle: "User Prompt" },
+      { kind: "output", colTitle: "AI_Out" },
+    ],
   };
 
   it("calls services.prepRecipe with resolved form values", async () => {
     mockPrepRecipe.mockResolvedValue(mockResult);
-    const { container } = mount(fullParams);
-    container.querySelector<HTMLInputElement>("#drive-folder-input")!.value =
-      "https://drive.google.com/drive/folders/abc123";
+    const { container } = mount({ columns: fullColumns });
+    // Fill in the url LockableField for the drive-file-folder column
+    const urlInput = container.querySelector<HTMLInputElement>("#col-url-0-container input")!;
+    urlInput.disabled = false;
+    urlInput.value = "https://drive.google.com/drive/folders/abc123";
     container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
     await flush();
     expect(mockPrepRecipe).toHaveBeenCalledWith(
       expect.objectContaining({
-        driveFolder: expect.objectContaining({ colTitle: "Drive Link" }),
-        systemPrompt: { colTitle: "System Prompt", value: "You are helpful." },
-        userPrompts: [{ colTitle: "User Prompt", value: "Summarize." }],
-        outputCol: { colTitle: "AI_Out" },
+        columns: expect.arrayContaining([
+          expect.objectContaining({
+            kind: "drive-file-folder",
+            url: "https://drive.google.com/drive/folders/abc123",
+          }),
+          expect.objectContaining({ kind: "system-prompt", colTitle: "System Prompt" }),
+          expect.objectContaining({ kind: "user-prompt", colTitle: "User Prompt" }),
+          expect.objectContaining({ kind: "output", colTitle: "AI_Out" }),
+        ]),
       }),
     );
   });
 
-  it("shows alert and does not proceed if drive folder is empty", async () => {
+  it("shows alert and does not proceed if drive-file-folder url is empty", async () => {
     const alertMock = jest.fn();
     globalThis.alert = alertMock;
-    const { container } = mount(fullParams);
+    const { container } = mount({ columns: fullColumns });
     container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
     await flush();
     expect(alertMock).toHaveBeenCalledTimes(1);
     expect(alertMock).toHaveBeenCalledWith(expect.stringContaining("folder"));
+    expect(mockPrepRecipe).not.toHaveBeenCalled();
+  });
+
+  it("omits drive-file-constant from PrepRecipeParams when url is empty", async () => {
+    const columns: ColumnSpec[] = [
+      {
+        kind: "drive-file-constant",
+        colTitle: { value: "Constant File", locked: true },
+        url: { value: "", locked: false },
+      },
+      { kind: "output", colTitle: { value: "AI_Out", locked: true } },
+    ];
+    const result: PrepRecipeResult = {
+      rowRange: { start: 2, end: 5 },
+      columns: [{ kind: "output", colTitle: "AI_Out" }],
+    };
+    mockPrepRecipe.mockResolvedValue(result);
+    const { container } = mount({ columns });
+    // Leave url empty — should not alert, should skip that column
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    expect(mockPrepRecipe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        columns: [expect.objectContaining({ kind: "output", colTitle: "AI_Out" })],
+      }),
+    );
+  });
+
+  it("concatenates appendFields onto prompt text with prefix", async () => {
+    const columns: ColumnSpec[] = [
+      {
+        kind: "system-prompt",
+        colTitle: { value: "System Prompt", locked: true },
+        prompt: { value: "You are an expert.", locked: true },
+        appendFields: [
+          {
+            id: "types",
+            label: "Document types",
+            prefix: "\n\nYou are specifically looking for:\n\n",
+          },
+        ],
+      },
+      { kind: "output", colTitle: { value: "AI_Out", locked: true } },
+    ];
+    const result: PrepRecipeResult = {
+      rowRange: { start: 2, end: 5 },
+      columns: [
+        { kind: "system-prompt", colTitle: "System Prompt" },
+        { kind: "output", colTitle: "AI_Out" },
+      ],
+    };
+    mockPrepRecipe.mockResolvedValue(result);
+    const { container } = mount({ columns });
+    const textarea = container.querySelector<HTMLTextAreaElement>("#append-field-0-types")!;
+    textarea.value = "photographs and drawings";
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    expect(mockPrepRecipe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        columns: expect.arrayContaining([
+          expect.objectContaining({
+            kind: "system-prompt",
+            text: "You are an expert.\n\nYou are specifically looking for:\n\nphotographs and drawings",
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it("alerts and returns null when required appendField is empty", async () => {
+    const alertMock = jest.fn();
+    globalThis.alert = alertMock;
+    const columns: ColumnSpec[] = [
+      {
+        kind: "user-prompt",
+        colTitle: { value: "User Prompt", locked: true },
+        prompt: { value: "Analyze this.", locked: true },
+        appendFields: [
+          { id: "focus", label: "Focus area", prefix: "\n\nFocus on:\n\n" },
+        ],
+      },
+      { kind: "output", colTitle: { value: "AI_Out", locked: true } },
+    ];
+    const { container } = mount({ columns });
+    // Leave appendField empty
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    expect(alertMock).toHaveBeenCalledWith(expect.stringContaining("Focus area"));
     expect(mockPrepRecipe).not.toHaveBeenCalled();
   });
 });
@@ -168,86 +316,211 @@ describe("Prep flow", () => {
 // ── Cook flow ──────────────────────────────────────────────────
 
 describe("Cook flow", () => {
-  it("navigates to configure-ai-run with preppedRunConfig assembled from PrepRecipeResult", async () => {
+  it("buildRunConfig assembles userPromptParts in column order", async () => {
+    const columns: ColumnSpec[] = [
+      {
+        kind: "drive-file-folder",
+        colTitle: { value: "Drive Link", locked: true },
+        url: { value: "", locked: false },
+      },
+      {
+        kind: "user-prompt",
+        colTitle: { value: "User Prompt", locked: true },
+        prompt: { value: "Summarize.", locked: true },
+      },
+      { kind: "output", colTitle: { value: "AI_Out", locked: true } },
+    ];
     const result: PrepRecipeResult = {
       rowRange: { start: 2, end: 5 },
-      colNames: {
-        driveLink: "Drive Link",
-        systemPrompt: "Sys",
-        userPrompts: ["User"],
-        outputCol: "Out",
-      },
+      columns: [
+        { kind: "drive-file-folder", colTitle: "Drive Link" },
+        { kind: "user-prompt", colTitle: "User Prompt" },
+        { kind: "output", colTitle: "AI_Out" },
+      ],
     };
     mockPrepRecipe.mockResolvedValue(result);
-    const { container, nav } = mount({
-      driveFolder: { colTitle: "Drive Link" },
-      systemPrompt: {
-        colTitle: { value: "Sys", locked: true },
-        prompt: { value: "p", locked: true },
-      },
-      userPrompts: [
-        { colTitle: { value: "User", locked: true }, prompt: { value: "q", locked: true } },
-      ],
-      outputCol: { colTitle: { value: "Out", locked: true } },
-    });
-    container.querySelector<HTMLInputElement>("#drive-folder-input")!.value =
-      "https://drive.google.com/abc";
+    const { container, nav } = mount({ columns });
+    const urlInput = container.querySelector<HTMLInputElement>("#col-url-0-container input")!;
+    urlInput.disabled = false;
+    urlInput.value = "https://drive.google.com/abc";
     container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
     await flush();
     container.querySelector<HTMLButtonElement>("#cook-btn")!.click();
-    expect(nav.navigate).toHaveBeenCalledWith("configure-ai-run", {
-      driveFileCols: ["Drive Link"],
-      systemPromptCol: "Sys",
-      userPromptCols: ["User"],
-      outputCol: "Out",
+    expect(nav.navigate).toHaveBeenCalledWith(
+      "configure-ai-run",
+      expect.objectContaining({
+        userPromptParts: [
+          { kind: "file", col: "Drive Link" },
+          { kind: "text", col: "User Prompt" },
+        ],
+        outputCol: "AI_Out",
+        rowRange: { start: 2, end: 5 },
+      }),
+    );
+  });
+
+  it("navigates to configure-ai-run with full RunConfig assembled from PrepRecipeResult", async () => {
+    const columns: ColumnSpec[] = [
+      {
+        kind: "drive-file-folder",
+        colTitle: { value: "Drive Link", locked: true },
+        url: { value: "", locked: false },
+      },
+      {
+        kind: "system-prompt",
+        colTitle: { value: "Sys", locked: true },
+        prompt: { value: "p", locked: true },
+      },
+      {
+        kind: "user-prompt",
+        colTitle: { value: "User", locked: true },
+        prompt: { value: "q", locked: true },
+      },
+      { kind: "output", colTitle: { value: "Out", locked: true } },
+    ];
+    const result: PrepRecipeResult = {
       rowRange: { start: 2, end: 5 },
-    });
+      columns: [
+        { kind: "drive-file-folder", colTitle: "Drive Link" },
+        { kind: "system-prompt", colTitle: "Sys" },
+        { kind: "user-prompt", colTitle: "User" },
+        { kind: "output", colTitle: "Out" },
+      ],
+    };
+    mockPrepRecipe.mockResolvedValue(result);
+    const { container, nav } = mount({ columns });
+    const urlInput = container.querySelector<HTMLInputElement>("#col-url-0-container input")!;
+    urlInput.disabled = false;
+    urlInput.value = "https://drive.google.com/abc";
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    container.querySelector<HTMLButtonElement>("#cook-btn")!.click();
+    expect(nav.navigate).toHaveBeenCalledWith(
+      "configure-ai-run",
+      expect.objectContaining({
+        userPromptParts: [
+          { kind: "file", col: "Drive Link" },
+          { kind: "text", col: "User" },
+        ],
+        systemPromptCol: "Sys",
+        outputCol: "Out",
+        rowRange: { start: 2, end: 5 },
+      }),
+    );
+  });
+
+  it("applies settings from PrepRecipeResult to RunConfig", async () => {
+    const columns: ColumnSpec[] = [
+      {
+        kind: "user-prompt",
+        colTitle: { value: "User Prompt", locked: true },
+        prompt: { value: "Analyze.", locked: true },
+      },
+      { kind: "output", colTitle: { value: "AI_Out", locked: true } },
+    ];
+    const result: PrepRecipeResult = {
+      rowRange: { start: 2, end: 5 },
+      columns: [
+        { kind: "user-prompt", colTitle: "User Prompt" },
+        { kind: "output", colTitle: "AI_Out" },
+      ],
+      settings: { tools: ["google_search"] },
+    };
+    mockPrepRecipe.mockResolvedValue(result);
+    const { container, nav } = mount({ columns });
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    container.querySelector<HTMLButtonElement>("#cook-btn")!.click();
+    expect(nav.navigate).toHaveBeenCalledWith(
+      "configure-ai-run",
+      expect.objectContaining({
+        tools: ["google_search"],
+      }),
+    );
   });
 });
 
 // ── saved state ────────────────────────────────────────────────
 
 describe("unmount / saved state", () => {
-  it("unmount returns form values and prepComplete: false when not prepped", () => {
-    const { container, panel } = mount({
-      driveFolder: { colTitle: "Drive Link" },
-      outputCol: { colTitle: { value: "AI_Out", locked: true } },
-    });
-    container.querySelector<HTMLInputElement>("#drive-folder-input")!.value = "my-folder";
+  it("unmount returns columnStates and prepComplete: false when not prepped", () => {
+    const columns: ColumnSpec[] = [
+      {
+        kind: "drive-file-folder",
+        colTitle: { value: "Drive Link", locked: true },
+        url: { value: "", locked: false },
+      },
+      { kind: "output", colTitle: { value: "AI_Out", locked: true } },
+    ];
+    const { panel } = mount({ columns });
     const state = panel.unmount();
     expect(state).toMatchObject({
-      driveFolderValue: "my-folder",
+      columnStates: expect.any(Array),
       prepComplete: false,
     });
+    expect(state!.columnStates.length).toBe(2);
   });
 
-  it("mounts with savedState — restores form values", () => {
+  it("mounts with savedState — restores colTitle values", () => {
+    const columns: ColumnSpec[] = [
+      { kind: "output", colTitle: { value: "AI_Out", locked: false } },
+    ];
     const savedState = {
-      driveFolderValue: "restored-folder",
-      outputColTitle: "MyOutput",
+      columnStates: [{ colTitle: "MyOutput" }],
       prepComplete: false,
     };
-    const { container } = mount(
-      {
-        driveFolder: { colTitle: "Drive Link" },
-        outputCol: { colTitle: { value: "AI_Out", locked: true } },
-      },
-      savedState,
-    );
-    expect(container.querySelector<HTMLInputElement>("#drive-folder-input")!.value).toBe(
-      "restored-folder",
-    );
+    const { container } = mount({ columns }, savedState);
+    const input = container.querySelector<HTMLInputElement>("#col-title-0-container input")!;
+    expect(input.value).toBe("MyOutput");
   });
 
   it("mounts with savedState prepComplete: true — Cook is enabled", () => {
+    const columns: ColumnSpec[] = [
+      { kind: "output", colTitle: { value: "Out", locked: true } },
+    ];
     const savedState = {
+      columnStates: [{ colTitle: "Out" }],
       prepComplete: true,
-      preppedRunConfig: { outputCol: "Out", userPromptCols: ["User"] },
+      preppedRunConfig: {
+        outputCol: "Out",
+        userPromptParts: [{ kind: "text" as const, col: "User" }],
+      },
     };
-    const { container } = mount(
-      { outputCol: { colTitle: { value: "Out", locked: true } } },
-      savedState,
-    );
+    const { container } = mount({ columns }, savedState);
     expect(container.querySelector<HTMLButtonElement>("#cook-btn")!.disabled).toBe(false);
+  });
+
+  it("unmount preserves appendField values", () => {
+    const columns: ColumnSpec[] = [
+      {
+        kind: "system-prompt",
+        colTitle: { value: "System Prompt", locked: true },
+        prompt: { value: "You are an expert.", locked: true },
+        appendFields: [{ id: "types", label: "Types", prefix: "\n\n" }],
+      },
+    ];
+    const { container, panel } = mount({ columns });
+    const textarea = container.querySelector<HTMLTextAreaElement>("#append-field-0-types")!;
+    textarea.value = "some value";
+    const state = panel.unmount();
+    expect(state!.columnStates[0].appendFieldValues?.["types"]).toBe("some value");
+  });
+
+  it("mounts with savedState — restores appendField values", () => {
+    const columns: ColumnSpec[] = [
+      {
+        kind: "system-prompt",
+        colTitle: { value: "System Prompt", locked: true },
+        prompt: { value: "You are an expert.", locked: true },
+        appendFields: [{ id: "types", label: "Types", prefix: "\n\n" }],
+      },
+    ];
+    const savedState = {
+      columnStates: [{ appendFieldValues: { types: "restored value" } }],
+      prepComplete: false,
+    };
+    const { container } = mount({ columns }, savedState);
+    const textarea = container.querySelector<HTMLTextAreaElement>("#append-field-0-types")!;
+    expect(textarea.value).toBe("restored value");
   });
 });

--- a/__tests__/services.test.ts
+++ b/__tests__/services.test.ts
@@ -68,7 +68,7 @@ describe("getSheetHeaders", () => {
 describe("runBatchAI", () => {
   it("calls google.script.run.runBatchAI with config and resolves", async () => {
     const handlers = captureHandlers();
-    const config = { userPromptCols: ["col_a"], outputCol: "out" };
+    const config = { userPromptParts: [{ kind: "text" as const, col: "col_a" }], outputCol: "out" };
     const promise = services.runBatchAI(config as import("../src/shared/types").RunConfig);
     handlers.resolve(undefined);
     await expect(promise).resolves.toBeUndefined();
@@ -78,7 +78,7 @@ describe("runBatchAI", () => {
   it("rejects on failure", async () => {
     const handlers = captureHandlers();
     const promise = services.runBatchAI({
-      userPromptCols: [],
+      userPromptParts: [],
       outputCol: "out",
     });
     handlers.reject(new Error("api error"));
@@ -107,12 +107,17 @@ describe("prepRecipe", () => {
   it("calls google.script.run.prepRecipe with params and resolves with result", async () => {
     const handlers = captureHandlers();
     const params: import("../src/shared/types").PrepRecipeParams = {
-      driveFolder: { url: "https://drive.google.com/folder/abc", colTitle: "Drive Link" },
-      outputCol: { colTitle: "AI_Summarization" },
+      columns: [
+        { kind: "drive-file-folder", colTitle: "Drive Link", url: "https://drive.google.com/folder/abc" },
+        { kind: "output", colTitle: "AI_Summarization" },
+      ],
     };
     const result: import("../src/shared/types").PrepRecipeResult = {
       rowRange: { start: 2, end: 5 },
-      colNames: { driveLink: "Drive Link", outputCol: "AI_Summarization" },
+      columns: [
+        { kind: "drive-file-folder", colTitle: "Drive Link" },
+        { kind: "output", colTitle: "AI_Summarization" },
+      ],
     };
     const promise = services.prepRecipe(params);
     handlers.resolve(result);
@@ -122,7 +127,7 @@ describe("prepRecipe", () => {
 
   it("rejects on failure", async () => {
     const handlers = captureHandlers();
-    const promise = services.prepRecipe({});
+    const promise = services.prepRecipe({ columns: [] });
     handlers.reject(new Error("prep error"));
     await expect(promise).rejects.toThrow("prep error");
   });

--- a/docs/plans/2026-03-25-find-a-thing-recipe-design.md
+++ b/docs/plans/2026-03-25-find-a-thing-recipe-design.md
@@ -1,0 +1,444 @@
+# Design: "Find a Thing in a Thing" Recipe + Recipe System Foundations
+
+**Date:** 2026-03-25
+**Status:** Design complete, ready for implementation
+
+---
+
+## Motivation
+
+A reporter has a stack of files — court documents, PDFs, images, audio, video. They want to
+know which ones contain a specific thing: a photograph, a signature, an exhibit sticker, a
+person's name used in a particular legal context. Simple string matching won't work. The
+question requires semantic understanding.
+
+This document designs a new "Find a thing in a thing" recipe that supports this use case,
+and in doing so, establishes a stronger foundational type system for the recipe layer that
+will support future recipes cleanly.
+
+---
+
+## Part 1: Recipe System Foundations
+
+The existing `RecipeParams` interface used named top-level fields (`driveFolder`,
+`systemPrompt`, `userPrompts`, `outputCol`). Adding `referenceFile` as a peer to
+`driveFolder` exposed the underlying problem: the named-field approach conflates
+sheet structure, population strategy, and RunConfig role all in one shape.
+
+The deeper insight is that drive file links and user prompt text are both **parts of the
+user message** sent to Gemini. The `driveFileCols` / `userPromptCols` split in `RunConfig`
+is an implementation detail about encoding (inline data vs. text), not a meaningful
+semantic distinction. In the Gemini API, both land in `contents[0].parts`.
+
+This redesign unifies them.
+
+### 1.1 New `RecipeParams` shape
+
+```ts
+interface PromptAppendField {
+  id: string;
+  label: string;
+  placeholder?: string;
+  /**
+   * Text injected before the reporter's value when concatenating onto the base prompt.
+   * e.g. "\n\nYou are specifically looking for:\n\n"
+   */
+  prefix?: string;
+}
+
+interface DriveColumnSpec {
+  colTitle: RecipeFieldConfig;
+  url: RecipeFieldConfig;
+  helperText?: string;
+}
+
+interface PromptColumnSpec {
+  colTitle: RecipeFieldConfig;
+  prompt: RecipeFieldConfig;
+  appendFields?: PromptAppendField[];
+  helperText?: string;
+}
+
+/**
+ * A ColumnSpec defines one column in the recipe's sheet setup.
+ *
+ * `kind` encodes both the population strategy (how Prep fills the column)
+ * and the RunConfig role (how the column is used during inference):
+ *
+ *   drive-file-folder   → one Drive link per row, imported from a folder
+ *   drive-file-constant → same Drive link in every row (a reference file)
+ *   system-prompt       → same text every row → systemPromptCol in RunConfig
+ *   user-prompt         → same text every row → part of userPromptParts (kind: "text")
+ *   output              → written by the AI run
+ *
+ * drive-file-folder and drive-file-constant both become entries in
+ * userPromptParts (kind: "file") in RunConfig. The population strategy
+ * difference is only relevant during Prep.
+ */
+type ColumnSpec =
+  | ({ kind: "drive-file-folder"   } & DriveColumnSpec)
+  | ({ kind: "drive-file-constant" } & DriveColumnSpec)
+  | ({ kind: "system-prompt"       } & PromptColumnSpec)
+  | ({ kind: "user-prompt"         } & PromptColumnSpec)
+  | ({ kind: "output"              } & { colTitle: RecipeFieldConfig; helperText?: string })
+
+/**
+ * Non-column AI run settings that a recipe can pre-configure.
+ * These flow through PrepRecipeParams → PrepRecipeResult via echo
+ * (server does not process them) and are applied when assembling RunConfig.
+ */
+interface RecipeSettings {
+  tools?: ToolId[];
+  applyMarkdown?: boolean;
+  includeGrounding?: boolean;
+  // future: modelId?: string;
+}
+
+interface RecipeParams {
+  columns: ColumnSpec[];
+  /**
+   * Optional recipe-level AI run settings. When present, these are pre-applied
+   * to RunConfig after Prep — reporters can still adjust them in ConfigureAIRunPanel.
+   */
+  settings?: RecipeSettings;
+}
+```
+
+The `columns` array is ordered. `RecipePanel` renders each entry in sequence. The order
+of `user-prompt` and `drive-file-*` columns in the array determines the order of parts
+sent to Gemini — this is intentional and meaningful.
+
+`DriveColumnSpec` and `PromptColumnSpec` are named atoms, reusable across `kind` variants.
+
+### 1.2 `appendFields` — dynamic prompt injection
+
+`appendFields` on a `PromptColumnSpec` allows reporter-editable text to be concatenated
+onto a locked base prompt during Prep. Each field has a `prefix` that provides context
+to the model:
+
+```
+final prompt = base + prefix_1 + field_value_1 + prefix_2 + field_value_2 + ...
+```
+
+`appendFields` applies to both `system-prompt` and `user-prompt` column specs, for
+different reasons:
+
+- **`system-prompt`** — the Gemini API's `systemInstruction` field is a single string.
+  It cannot be fragmented across multiple parts. If a reporter's customizable input
+  (e.g. a search description) must live in the system instruction, concatenation into
+  one column is the only option. `appendFields` is load-bearing here.
+
+- **`user-prompt`** — multiple `user-prompt` columns could technically serve the same
+  purpose, but consolidating tightly related inputs into one column prevents visual
+  clutter in the reporter's sheet. A recipe asking three reporter inputs should not
+  produce three fragmented prompt columns when one coherent column serves better.
+  `appendFields` is a deliberate UX choice here.
+
+Limitations to know:
+- Dynamic content always **appends** — it cannot be interleaved into the middle of the
+  base prompt. If mid-prompt injection is needed in a future recipe, the `segments`
+  approach (static/dynamic segments in order) would be required.
+
+### 1.3 Updated `RunConfig`
+
+```ts
+// shared/types.ts
+
+export interface RunConfig {
+  /**
+   * Ordered parts of the user message. Each part references a column by header name.
+   * Text parts are read as strings; file parts are fetched from Drive and encoded
+   * as inline data. Order is preserved in the Gemini request.
+   */
+  userPromptParts: Array<{ kind: "text" | "file"; col: string }>;
+  systemPromptCol?: string;
+  outputCol: string;
+  rowRange?: { start: number; end: number };
+  tools?: ToolId[];
+  includeGrounding?: boolean;
+  applyMarkdown?: boolean;
+}
+```
+
+`userPromptCols` and `driveFileCols` are removed. All user message content — text and
+files — is expressed as ordered parts.
+
+### 1.4 Updated `PrepRecipeParams` and `PrepRecipeResult`
+
+```ts
+// shared/types.ts
+
+export interface PrepRecipeParams {
+  columns: Array<
+    | { kind: "drive-file-folder";   colTitle: string; url: string }
+    | { kind: "drive-file-constant"; colTitle: string; url: string }
+    | { kind: "system-prompt";       colTitle: string; text: string }
+    | { kind: "user-prompt";         colTitle: string; text: string }
+    | { kind: "output";              colTitle: string }
+  >;
+  /**
+   * Non-column settings echoed back in PrepRecipeResult without server processing.
+   * Preserves single-source-of-truth for RunConfig assembly on the client.
+   */
+  settings?: {
+    tools?: ToolId[];
+    applyMarkdown?: boolean;
+    includeGrounding?: boolean;
+    // future: modelId?: string;
+  };
+}
+
+export interface PrepRecipeResult {
+  rowRange: { start: number; end: number };
+  /**
+   * Column names as written to the sheet, in the same order as PrepRecipeParams.columns.
+   * The client uses this to assemble RunConfig — it is the single source of truth.
+   */
+  columns: Array<{
+    kind: "drive-file-folder" | "drive-file-constant" | "system-prompt" | "user-prompt" | "output";
+    colTitle: string;
+  }>;
+  /** Echoed from PrepRecipeParams.settings — no server-side processing. */
+  settings?: {
+    tools?: ToolId[];
+    applyMarkdown?: boolean;
+    includeGrounding?: boolean;
+    // future: modelId?: string;
+  };
+}
+```
+
+The client's `buildRunConfig()` in `RecipePanel` assembles `RunConfig` from
+`PrepRecipeResult.columns` by scanning for kinds:
+- `system-prompt` → `systemPromptCol`
+- `user-prompt` + `drive-file-folder` + `drive-file-constant` → `userPromptParts` (in order)
+- `output` → `outputCol`
+
+### 1.5 Updated `runInference` signature
+
+```ts
+// server/inference.ts
+
+export function runInference(
+  userPromptParts: Array<{ kind: "text" | "file"; value: unknown }>,
+  systemPrompt?: unknown,
+  tools?: ToolId[],
+): GeminiResponse | null
+```
+
+`runBatchAI` in `index.ts` constructs `userPromptParts` from `RunConfig` by reading each
+column in order and tagging values with their kind. Text parts pass through `flattenArg`;
+file parts are filtered with `isValidDriveLink`, extracted with `extractId`, and encoded
+via `prepareDriveAttachments`.
+
+---
+
+## Part 2: ConfigureAIRunPanel — Now and Later
+
+### 2.1 Minimal change (this implementation)
+
+`ConfigureAIRunPanel` keeps its existing two-TagList UX ("User prompt columns" and "Drive
+file columns"). Only `assembleRunConfig()` changes — it maps the two selections into
+`userPromptParts` with a fixed convention: text parts first, file parts after.
+
+```ts
+userPromptParts: [
+  ...userPromptCols.map(col => ({ kind: "text" as const, col })),
+  ...driveFileCols.map(col => ({ kind: "file" as const, col })),
+]
+```
+
+Reporters experience no UX change. The underlying data model is correct.
+
+### 2.2 Future: ordered parts UX
+
+> **Note for future implementation.**
+>
+> The two-bucket UX ("text columns" / "file columns") does not expose the ordering that
+> `userPromptParts` now supports. When there is a concrete reporter need for controlling
+> the sequence in which context is presented to the model, replace the two TagLists with
+> an **ordered parts builder**:
+>
+> - A single "Message parts" list, rendered in sequence
+> - Each row: a column picker + a type badge ("Text" / "File"), type inferred or manually set
+> - Up/down controls or drag handles for reordering
+> - An "Add part" button to append a new row
+>
+> Example sequence a reporter might construct:
+> ```
+> 1. [System Context]     Text  ↑↓ ✕
+> 2. [Court Document]     File  ↑↓ ✕
+> 3. [Reference Exhibit]  File  ↑↓ ✕
+> 4. [Search Question]    Text  ↑↓ ✕
+> ```
+>
+> This is a new `OrderedPartsList` component. The `ConfigureAIRunPanel` template and
+> wiring change significantly; `RunConfig` and inference layer are already correct by
+> then. The `SavedState` type in `ConfigureAIRunPanel` would drop `userPromptCols` and
+> `driveFileCols` in favour of `userPromptParts`.
+
+---
+
+## Part 3: "Find a Thing in a Thing" Recipe
+
+### 3.1 Purpose
+
+Given a folder of files (documents, PDFs, images, audio, video), determine which files
+contain a reporter-described item. Supports an optional reference file — any Drive file
+type — that illustrates what to look for visually or structurally.
+
+### 3.2 Output format
+
+Each row receives one of: `yes`, `no`, or `unsure`, followed by a single sentence of
+reasoning. No other commentary.
+
+### 3.3 Prompt design
+
+**System prompt** (locked base + one `appendField`):
+
+Base:
+```
+You are a document analyst helping a reporter identify specific items within a collection
+of files. For each file you receive, determine whether it contains the item described
+below. Respond with exactly one of: "yes", "no", or "unsure". Follow your answer with a
+single sentence explaining your reasoning. Do not add any other commentary.
+
+If a reference file is attached, it is a concrete example of what you are looking for —
+use it as a visual or structural guide when evaluating the document.
+```
+
+AppendField:
+```
+prefix:  "\n\nYou are specifically looking for:\n\n"
+label:   "What are you looking for?"
+placeholder: "Describe the item, person, pattern, or visual artifact you want to find"
+```
+
+**User prompt** (locked):
+```
+Analyze the attached file and determine whether it contains the item described in your
+instructions.
+```
+
+### 3.4 Recipe definition
+
+```ts
+{
+  id: "find-a-thing",
+  name: "Find a Thing in a Thing",
+  icon: "🔍",
+  description: "Scan a folder of files to find which ones contain a specific item",
+  panelId: "recipe",
+  params: {
+    columns: [
+      {
+        kind: "drive-file-folder",
+        colTitle: { value: "Drive Link", locked: false },
+        url: { value: "", locked: false, placeholder: "Paste Google Drive folder URL" },
+        helperText: "The folder of files to scan",
+      },
+      {
+        kind: "drive-file-constant",
+        colTitle: { value: "Reference File", locked: false },
+        url: { value: "", locked: false, placeholder: "Paste a Drive link to a reference file (optional)" },
+        helperText: "Optional. Any file type — attach an example of what you're looking for.",
+      },
+      {
+        kind: "system-prompt",
+        colTitle: { value: "System Prompt", locked: true },
+        prompt: {
+          value:
+            "You are a document analyst helping a reporter identify specific items within " +
+            "a collection of files. For each file you receive, determine whether it contains " +
+            "the item described below. Respond with exactly one of: \"yes\", \"no\", or " +
+            "\"unsure\". Follow your answer with a single sentence explaining your reasoning. " +
+            "Do not add any other commentary.\n\nIf a reference file is attached, it is a " +
+            "concrete example of what you are looking for — use it as a visual or structural " +
+            "guide when evaluating the document.",
+          locked: true,
+        },
+        appendFields: [
+          {
+            id: "searchDescription",
+            label: "What are you looking for?",
+            placeholder: "Describe the item, person, pattern, or visual artifact you want to find",
+            prefix: "\n\nYou are specifically looking for:\n\n",
+          },
+        ],
+      },
+      {
+        kind: "user-prompt",
+        colTitle: { value: "User Prompt", locked: true },
+        prompt: {
+          value:
+            "Analyze the attached file and determine whether it contains the item described " +
+            "in your instructions.",
+          locked: true,
+        },
+      },
+      {
+        kind: "output",
+        colTitle: { value: "AI_FindAThing", locked: false },
+      },
+    ],
+  },
+}
+```
+
+Note: the `drive-file-constant` column (Reference File) is only written to the sheet and
+added to `userPromptParts` if the reporter provides a URL. `RecipePanel.buildPrepParams()`
+omits it from `PrepRecipeParams` when the url field is empty; `buildRunConfig()` omits it
+from `userPromptParts` when absent from `PrepRecipeResult.columns`.
+
+---
+
+## Part 4: Implementation Scope
+
+### Files to change
+
+**Shared types** (`src/shared/types.ts`):
+- Replace `userPromptCols` + `driveFileCols` in `RunConfig` with `userPromptParts`
+- Replace `PrepRecipeParams` named fields with `columns` array
+- Replace `PrepRecipeResult.colNames` with `columns` array
+
+**Client types** (`src/client/types.ts`):
+- Replace `RecipeParams` named fields with `columns: ColumnSpec[]`
+- Add `PromptAppendField`, `DriveColumnSpec`, `PromptColumnSpec`, `ColumnSpec`
+- Remove `RecipeFieldConfig` from `driveFolder`/`referenceFile` (those fields are gone)
+
+**Server — inference** (`src/server/inference.ts`):
+- Update `runInference` to accept `userPromptParts: Array<{kind, value}>` instead of
+  separate `userPrompts` + `driveLinks` params
+
+**Server — index** (`src/server/index.ts`):
+- Update `runBatchAI` to build `userPromptParts` from `RunConfig` and pass to `runInference`
+- Update `prepRecipe` to handle the new `PrepRecipeParams.columns` array
+
+**Client — RecipePanel** (`src/client/panels/recipe.ts`):
+- Rewrite `mountFields()` to render `ColumnSpec[]` generically
+- Rewrite `buildPrepParams()` to produce the new `PrepRecipeParams` shape
+- Rewrite `buildRunConfig()` to assemble `userPromptParts` from `PrepRecipeResult.columns`
+- Handle `appendFields` concatenation before sending to Prep
+- Handle optional `drive-file-constant` (omit when url is empty)
+
+**Client — ConfigureAIRunPanel** (`src/client/panels/configure-ai-run.ts`):
+- Update `assembleRunConfig()` to produce `userPromptParts` from the two TagLists
+- Update `SavedState` to use `userPromptParts` instead of `userPromptCols`/`driveFileCols`
+- Update `mount()` preset logic accordingly
+
+**Client — recipes** (`src/client/recipes.ts`):
+- Migrate `document-summarization` recipe to new `columns` shape
+- Add `find-a-thing` recipe definition
+
+**Tests** (`__tests__/inference.test.ts`, others):
+- Update `runInference` call sites to new signature
+
+### Order of changes
+
+1. `shared/types.ts` — establishes the new contracts everything else builds toward
+2. `server/inference.ts` + `server/index.ts` — unblocks server-side testing
+3. `client/types.ts` — unblocks panel work
+4. `client/panels/recipe.ts` — largest client change
+5. `client/panels/configure-ai-run.ts` — minimal wiring change
+6. `client/recipes.ts` — add new recipe, migrate existing
+7. Tests — update call sites, add coverage for new recipe prep logic

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -39,8 +39,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
 
     const preset: Partial<RunConfig> = savedState
       ? {
-          userPromptCols: savedState.userPromptCols,
-          driveFileCols: savedState.driveFileCols.length ? savedState.driveFileCols : undefined,
+          userPromptParts: savedState.userPromptParts,
           systemPromptCol: savedState.systemPromptCol || undefined,
           outputCol: savedState.outputCol || undefined,
           rowRange: savedState.rowRange,
@@ -88,15 +87,22 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
           return;
         }
 
+        const presetText = (preset.userPromptParts ?? [])
+          .filter((p) => p.kind === "text")
+          .map((p) => p.col);
+        const presetFile = (preset.userPromptParts ?? [])
+          .filter((p) => p.kind === "file")
+          .map((p) => p.col);
+
         this.userPromptList = new TagList(
           container.querySelector("#user-prompt-cols")!,
           headers,
-          preset.userPromptCols ?? [],
+          presetText,
         );
         this.driveFileList = new TagList(
           container.querySelector("#drive-file-cols")!,
           headers,
-          preset.driveFileCols ?? [],
+          presetFile,
         );
         this.systemPromptList = new SingleTagList(
           container.querySelector("#system-prompt-col")!,
@@ -143,8 +149,10 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
   unmount(): SavedState | undefined {
     if (!this.userPromptList) return undefined;
     return {
-      userPromptCols: this.userPromptList.getValue(),
-      driveFileCols: this.driveFileList?.getValue() ?? [],
+      userPromptParts: [
+        ...(this.userPromptList?.getValue() ?? []).map((col) => ({ kind: "text" as const, col })),
+        ...(this.driveFileList?.getValue() ?? []).map((col) => ({ kind: "file" as const, col })),
+      ],
       systemPromptCol: this.systemPromptList?.getValue() ?? "",
       outputCol: this.outputColList?.getValue() ?? "",
       rowRange: this.rowRangeComp?.getValue(),
@@ -169,8 +177,10 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
 
   private currentPreset(): Partial<RunConfig> {
     return {
-      userPromptCols: this.userPromptList?.getValue(),
-      driveFileCols: this.driveFileList?.getValue(),
+      userPromptParts: [
+        ...(this.userPromptList?.getValue() ?? []).map((col) => ({ kind: "text" as const, col })),
+        ...(this.driveFileList?.getValue() ?? []).map((col) => ({ kind: "file" as const, col })),
+      ],
       systemPromptCol: this.systemPromptList?.getValue() || undefined,
       outputCol: this.outputColList?.getValue() || undefined,
       rowRange: this.rowRangeComp?.getValue(),
@@ -216,8 +226,10 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
     const applyMarkdown = this.applyMarkdownCb?.checked ?? false;
 
     return {
-      userPromptCols,
-      driveFileCols: driveFileCols.length > 0 ? driveFileCols : undefined,
+      userPromptParts: [
+        ...userPromptCols.map((col) => ({ kind: "text" as const, col })),
+        ...driveFileCols.map((col) => ({ kind: "file" as const, col })),
+      ],
       systemPromptCol,
       outputCol,
       rowRange,

--- a/src/client/panels/recipe.ts
+++ b/src/client/panels/recipe.ts
@@ -75,11 +75,7 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
     };
   }
 
-  private mountFields(
-    container: HTMLElement,
-    params: RecipeParams,
-    savedState?: SavedState,
-  ): void {
+  private mountFields(container: HTMLElement, params: RecipeParams, savedState?: SavedState): void {
     const reset = (): void => this.prepCook?.reset();
 
     params.columns.forEach((col, i) => {
@@ -110,9 +106,7 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
       }
 
       if (col.kind === "system-prompt" || col.kind === "user-prompt") {
-        const promptContainer = container.querySelector<HTMLElement>(
-          `#col-prompt-${i}-container`,
-        );
+        const promptContainer = container.querySelector<HTMLElement>(`#col-prompt-${i}-container`);
         if (promptContainer) {
           colFields.prompt = new LockableField(promptContainer, {
             label: "Prompt",

--- a/src/client/panels/recipe.ts
+++ b/src/client/panels/recipe.ts
@@ -1,17 +1,19 @@
 import type { NavigationContext, Panel, RecipeDefinition } from "../types";
-import type { RecipeParams } from "../types";
+import type { ColumnSpec, PromptAppendField, RecipeParams } from "../types";
 import type { PrepRecipeParams, PrepRecipeResult, RunConfig } from "../../shared/types";
 import { LockableField } from "../components/lockable-field";
 import { RecipePrepCook } from "../components/recipe-prep-cook";
 import { prepRecipe } from "../services";
 
+type ColumnSavedState = {
+  colTitle?: string;
+  url?: string;
+  prompt?: string;
+  appendFieldValues?: Record<string, string>; // keyed by PromptAppendField.id
+};
+
 type SavedState = {
-  driveFolderValue?: string;
-  systemPromptTitle?: string;
-  systemPromptValue?: string;
-  userPromptTitles?: string[];
-  userPromptValues?: string[];
-  outputColTitle?: string;
+  columnStates: ColumnSavedState[];
   prepComplete: boolean;
   preppedRunConfig?: Partial<RunConfig>;
 };
@@ -22,15 +24,13 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
   private params: RecipeParams | null = null;
   private prepCook: RecipePrepCook | null = null;
   private preppedRunConfig: Partial<RunConfig> | null = null;
-  private driveFolderInput: HTMLInputElement | null = null;
 
-  private fields: {
-    systemPromptTitle?: LockableField;
-    systemPromptValue?: LockableField;
-    userPromptTitles: LockableField[];
-    userPromptValues: LockableField[];
-    outputColTitle?: LockableField;
-  } = { userPromptTitles: [], userPromptValues: [] };
+  private columnFields: Array<{
+    colTitle?: LockableField;
+    url?: LockableField;
+    prompt?: LockableField;
+    appendFieldInputs?: Map<string, HTMLTextAreaElement>;
+  }> = [];
 
   mount(
     container: HTMLElement,
@@ -40,8 +40,8 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
   ): void {
     this.nav = nav;
     this.definition = definition ?? null;
-    this.params = definition?.params ?? {};
-    this.fields = { userPromptTitles: [], userPromptValues: [] };
+    this.params = definition?.params ?? { columns: [] };
+    this.columnFields = [];
     this.preppedRunConfig = savedState?.preppedRunConfig ?? null;
 
     container.innerHTML = this.template(this.definition);
@@ -49,97 +49,101 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
     container.querySelector("#back-btn")?.addEventListener("click", () => nav.back());
 
     this.mountFields(container, this.params, savedState);
-    this.mountPrepCook(container, savedState?.prepComplete ?? false, container);
+    this.mountPrepCook(container, savedState?.prepComplete ?? false);
   }
 
   unmount(): SavedState {
+    const columnStates: ColumnSavedState[] = this.columnFields.map((cf) => {
+      const state: ColumnSavedState = {};
+      if (cf.colTitle) state.colTitle = cf.colTitle.getValue();
+      if (cf.url) state.url = cf.url.getValue();
+      if (cf.prompt) state.prompt = cf.prompt.getValue();
+      if (cf.appendFieldInputs) {
+        const appendFieldValues: Record<string, string> = {};
+        cf.appendFieldInputs.forEach((el, id) => {
+          appendFieldValues[id] = el.value;
+        });
+        state.appendFieldValues = appendFieldValues;
+      }
+      return state;
+    });
+
     return {
-      driveFolderValue: this.driveFolderInput?.value,
-      systemPromptTitle: this.fields.systemPromptTitle?.getValue(),
-      systemPromptValue: this.fields.systemPromptValue?.getValue(),
-      userPromptTitles: this.fields.userPromptTitles.map((f) => f.getValue()),
-      userPromptValues: this.fields.userPromptValues.map((f) => f.getValue()),
-      outputColTitle: this.fields.outputColTitle?.getValue(),
+      columnStates,
       prepComplete: this.prepCook?.isPrepComplete() ?? false,
       preppedRunConfig: this.preppedRunConfig ?? undefined,
     };
   }
 
-  private mountFields(container: HTMLElement, params: RecipeParams, savedState?: SavedState): void {
+  private mountFields(
+    container: HTMLElement,
+    params: RecipeParams,
+    savedState?: SavedState,
+  ): void {
     const reset = (): void => this.prepCook?.reset();
 
-    if (params.driveFolder) {
-      this.driveFolderInput = container.querySelector<HTMLInputElement>("#drive-folder-input");
-      if (savedState?.driveFolderValue && this.driveFolderInput) {
-        this.driveFolderInput.value = savedState.driveFolderValue;
-      }
-      this.driveFolderInput?.addEventListener("input", reset);
-    }
+    params.columns.forEach((col, i) => {
+      const colFields: (typeof this.columnFields)[number] = {};
 
-    if (params.systemPrompt) {
-      this.fields.systemPromptTitle = new LockableField(
-        container.querySelector("#system-prompt-title-container")!,
-        {
+      // Mount colTitle LockableField for all column kinds
+      const colTitleContainer = container.querySelector<HTMLElement>(`#col-title-${i}-container`);
+      if (colTitleContainer) {
+        colFields.colTitle = new LockableField(colTitleContainer, {
           label: "Column",
-          defaultValue: savedState?.systemPromptTitle ?? params.systemPrompt.colTitle.value,
-          locked: params.systemPrompt.colTitle.locked,
+          defaultValue: savedState?.columnStates?.[i]?.colTitle ?? col.colTitle.value,
+          locked: col.colTitle.locked ?? true,
           onUnlock: reset,
-        },
-      );
-      this.fields.systemPromptValue = new LockableField(
-        container.querySelector("#system-prompt-value-container")!,
-        {
-          label: "Prompt",
-          defaultValue: savedState?.systemPromptValue ?? params.systemPrompt.prompt.value,
-          locked: params.systemPrompt.prompt.locked,
-          multiline: true,
-          onUnlock: reset,
-        },
-      );
-    }
+        });
+      }
 
-    if (params.userPrompts) {
-      params.userPrompts.forEach((up, i) => {
-        this.fields.userPromptTitles[i] = new LockableField(
-          container.querySelector(`#user-prompt-title-${i}-container`)!,
-          {
-            label: "Column",
-            defaultValue: savedState?.userPromptTitles?.[i] ?? up.colTitle.value,
-            locked: up.colTitle.locked,
+      if (col.kind === "drive-file-folder" || col.kind === "drive-file-constant") {
+        const urlContainer = container.querySelector<HTMLElement>(`#col-url-${i}-container`);
+        if (urlContainer) {
+          colFields.url = new LockableField(urlContainer, {
+            label: "URL",
+            defaultValue: savedState?.columnStates?.[i]?.url ?? col.url.value,
+            locked: col.url.locked ?? true,
+            placeholder: col.url.placeholder,
             onUnlock: reset,
-          },
+          });
+        }
+      }
+
+      if (col.kind === "system-prompt" || col.kind === "user-prompt") {
+        const promptContainer = container.querySelector<HTMLElement>(
+          `#col-prompt-${i}-container`,
         );
-        this.fields.userPromptValues[i] = new LockableField(
-          container.querySelector(`#user-prompt-value-${i}-container`)!,
-          {
+        if (promptContainer) {
+          colFields.prompt = new LockableField(promptContainer, {
             label: "Prompt",
-            defaultValue: savedState?.userPromptValues?.[i] ?? up.prompt.value,
-            locked: up.prompt.locked,
+            defaultValue: savedState?.columnStates?.[i]?.prompt ?? col.prompt.value,
+            locked: col.prompt.locked ?? true,
             multiline: true,
             onUnlock: reset,
-          },
-        );
-      });
-    }
+          });
+        }
 
-    if (params.outputCol) {
-      this.fields.outputColTitle = new LockableField(
-        container.querySelector("#output-col-title-container")!,
-        {
-          label: "Column",
-          defaultValue: savedState?.outputColTitle ?? params.outputCol.colTitle.value,
-          locked: params.outputCol.colTitle.locked,
-          onUnlock: reset,
-        },
-      );
-    }
+        if (col.appendFields && col.appendFields.length > 0) {
+          colFields.appendFieldInputs = new Map<string, HTMLTextAreaElement>();
+          col.appendFields.forEach((af: PromptAppendField) => {
+            const textarea = container.querySelector<HTMLTextAreaElement>(
+              `#append-field-${i}-${af.id}`,
+            );
+            if (textarea) {
+              const savedVal = savedState?.columnStates?.[i]?.appendFieldValues?.[af.id];
+              if (savedVal !== undefined) textarea.value = savedVal;
+              textarea.addEventListener("input", reset);
+              colFields.appendFieldInputs!.set(af.id, textarea);
+            }
+          });
+        }
+      }
+
+      this.columnFields[i] = colFields;
+    });
   }
 
-  private mountPrepCook(
-    container: HTMLElement,
-    prepComplete: boolean,
-    _panelContainer: HTMLElement,
-  ): void {
+  private mountPrepCook(container: HTMLElement, prepComplete: boolean): void {
     this.prepCook = new RecipePrepCook(container.querySelector("#prep-cook-container")!, {
       onPrep: async (): Promise<void> => {
         const params = this.buildPrepParams();
@@ -159,100 +163,151 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
 
   private buildPrepParams(): PrepRecipeParams | null {
     const params = this.params!;
-    const result: PrepRecipeParams = {};
+    const columns: PrepRecipeParams["columns"] = [];
 
-    if (params.driveFolder) {
-      const url = this.driveFolderInput?.value.trim() ?? "";
-      if (!url) {
-        globalThis.alert("Please enter a Google Drive folder link.");
-        return null;
+    for (let i = 0; i < params.columns.length; i++) {
+      const col = params.columns[i];
+      const cf = this.columnFields[i];
+      const colTitle = cf?.colTitle?.getValue() ?? col.colTitle.value;
+
+      switch (col.kind) {
+        case "drive-file-folder": {
+          const url = cf?.url?.getValue()?.trim() ?? "";
+          if (!url) {
+            globalThis.alert("Please enter a Google Drive folder link.");
+            return null;
+          }
+          columns.push({ kind: "drive-file-folder", colTitle, url });
+          break;
+        }
+        case "drive-file-constant": {
+          const url = cf?.url?.getValue()?.trim() ?? "";
+          if (!url) break; // optional field — skip silently
+          columns.push({ kind: "drive-file-constant", colTitle, url });
+          break;
+        }
+        case "system-prompt":
+        case "user-prompt": {
+          let text = cf?.prompt?.getValue() ?? col.prompt.value;
+          if (col.appendFields) {
+            for (const af of col.appendFields) {
+              const textarea = cf?.appendFieldInputs?.get(af.id);
+              const val = textarea?.value?.trim() ?? "";
+              if (!val) {
+                globalThis.alert(`Please fill in: ${af.label}`);
+                return null;
+              }
+              text += (af.prefix ?? "") + val;
+            }
+          }
+          columns.push({ kind: col.kind, colTitle, text });
+          break;
+        }
+        case "output": {
+          columns.push({ kind: "output", colTitle });
+          break;
+        }
       }
-      result.driveFolder = { url, colTitle: params.driveFolder.colTitle };
     }
 
-    if (params.systemPrompt) {
-      result.systemPrompt = {
-        colTitle: this.fields.systemPromptTitle?.getValue() ?? params.systemPrompt.colTitle.value,
-        value: this.fields.systemPromptValue?.getValue() ?? params.systemPrompt.prompt.value,
-      };
-    }
-
-    if (params.userPrompts) {
-      result.userPrompts = params.userPrompts.map((up, i) => ({
-        colTitle: this.fields.userPromptTitles[i]?.getValue() ?? up.colTitle.value,
-        value: this.fields.userPromptValues[i]?.getValue() ?? up.prompt.value,
-      }));
-    }
-
-    if (params.outputCol) {
-      result.outputCol = {
-        colTitle: this.fields.outputColTitle?.getValue() ?? params.outputCol.colTitle.value,
-      };
-    }
-
-    return result;
+    return { columns, settings: this.definition?.params?.settings };
   }
 
   private buildRunConfig(result: PrepRecipeResult): Partial<RunConfig> {
+    const userPromptParts: RunConfig["userPromptParts"] = [];
+    let systemPromptCol: string | undefined;
+    let outputCol = "";
+
+    for (const col of result.columns) {
+      switch (col.kind) {
+        case "drive-file-folder":
+        case "drive-file-constant":
+          userPromptParts.push({ kind: "file", col: col.colTitle });
+          break;
+        case "user-prompt":
+          userPromptParts.push({ kind: "text", col: col.colTitle });
+          break;
+        case "system-prompt":
+          systemPromptCol = col.colTitle;
+          break;
+        case "output":
+          outputCol = col.colTitle;
+          break;
+      }
+    }
+
     return {
-      driveFileCols: result.colNames.driveLink ? [result.colNames.driveLink] : undefined,
-      systemPromptCol: result.colNames.systemPrompt,
-      userPromptCols: result.colNames.userPrompts ?? [],
-      outputCol: result.colNames.outputCol ?? "",
+      userPromptParts,
+      systemPromptCol,
+      outputCol,
       rowRange: result.rowRange,
+      tools: result.settings?.tools,
+      applyMarkdown: result.settings?.applyMarkdown,
+      includeGrounding: result.settings?.includeGrounding,
     };
   }
 
   private template(definition: RecipeDefinition | null): string {
-    const params = definition?.params ?? {};
+    const params = definition?.params ?? { columns: [] };
     const title = definition ? `${definition.icon} ${definition.name}` : "Recipe";
-    const numUserPrompts = params.userPrompts?.length ?? 0;
+
+    const sectionTitle = (col: ColumnSpec): string => {
+      switch (col.kind) {
+        case "drive-file-folder":
+          return "Drive Folder";
+        case "drive-file-constant":
+          return "Drive File";
+        case "system-prompt":
+          return "System Prompt";
+        case "user-prompt":
+          return "User Prompt";
+        case "output":
+          return "Output Column";
+      }
+    };
+
+    const columnCards = params.columns
+      .map((col, i) => {
+        const appendFieldsHtml =
+          col.kind === "system-prompt" || col.kind === "user-prompt"
+            ? (col.appendFields ?? [])
+                .map(
+                  (af) => `
+          <div class="append-field-group">
+            <label class="field-label" for="append-field-${i}-${af.id}">${af.label}</label>
+            <textarea id="append-field-${i}-${af.id}" class="text-input"${af.placeholder ? ` placeholder="${af.placeholder}"` : ""}></textarea>
+          </div>`,
+                )
+                .join("")
+            : "";
+
+        const urlContainerHtml =
+          col.kind === "drive-file-folder" || col.kind === "drive-file-constant"
+            ? `<div id="col-url-${i}-container"></div>`
+            : "";
+
+        const promptContainerHtml =
+          col.kind === "system-prompt" || col.kind === "user-prompt"
+            ? `<div id="col-prompt-${i}-container"></div>${appendFieldsHtml}`
+            : "";
+
+        return `
+      <div class="recipe-section-card">
+        <div class="recipe-section-card-title">${sectionTitle(col)}</div>
+        ${col.helperText ? `<p class="field-helper">${col.helperText}</p>` : ""}
+        <div id="col-title-${i}-container"></div>
+        ${urlContainerHtml}
+        ${promptContainerHtml}
+      </div>`;
+      })
+      .join("");
 
     return `
       <div class="panel-header">
         <button id="back-btn" class="back-btn">← Back</button>
         <span class="panel-title">${title}</span>
       </div>
-      ${
-        params.driveFolder
-          ? `
-      <div class="recipe-section-card">
-        <div class="recipe-section-card-title">Drive Folder <span class="required">*</span></div>
-        ${params.driveFolder.helperText ? `<p class="field-helper">${params.driveFolder.helperText}</p>` : ""}
-        <input id="drive-folder-input" type="text" class="text-input"
-          placeholder="Paste Google Drive folder URL or ID" />
-      </div>`
-          : ""
-      }
-      ${
-        params.systemPrompt
-          ? `
-      <div class="recipe-section-card">
-        <div class="recipe-section-card-title">System Prompt</div>
-        <div id="system-prompt-title-container"></div>
-        <div id="system-prompt-value-container"></div>
-      </div>`
-          : ""
-      }
-      ${(params.userPrompts ?? [])
-        .map(
-          (_, i) => `
-      <div class="recipe-section-card">
-        <div class="recipe-section-card-title">User Prompt${numUserPrompts > 1 ? ` ${i + 1}` : ""}</div>
-        <div id="user-prompt-title-${i}-container"></div>
-        <div id="user-prompt-value-${i}-container"></div>
-      </div>`,
-        )
-        .join("")}
-      ${
-        params.outputCol
-          ? `
-      <div class="recipe-section-card">
-        <div class="recipe-section-card-title">Output Column</div>
-        <div id="output-col-title-container"></div>
-      </div>`
-          : ""
-      }
+      ${columnCards}
       <div id="prep-cook-container"></div>
     `;
   }

--- a/src/client/panels/recipe.ts
+++ b/src/client/panels/recipe.ts
@@ -128,13 +128,11 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
           col.appendFields.forEach((af: PromptAppendField) => {
             const textarea = container.querySelector<HTMLTextAreaElement>(
               `#append-field-${i}-${af.id}`,
-            );
-            if (textarea) {
-              const savedVal = savedState?.columnStates?.[i]?.appendFieldValues?.[af.id];
-              if (savedVal !== undefined) textarea.value = savedVal;
-              textarea.addEventListener("input", reset);
-              colFields.appendFieldInputs!.set(af.id, textarea);
-            }
+            )!;
+            const savedVal = savedState?.columnStates?.[i]?.appendFieldValues?.[af.id];
+            if (savedVal !== undefined) textarea.value = savedVal;
+            textarea.addEventListener("input", reset);
+            colFields.appendFieldInputs!.set(af.id, textarea);
           });
         }
       }
@@ -194,7 +192,7 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
               const textarea = cf?.appendFieldInputs?.get(af.id);
               const val = textarea?.value?.trim() ?? "";
               if (!val) {
-                globalThis.alert(`Please fill in: ${af.label}`);
+                globalThis.alert(`Please fill in "${af.label}".`);
                 return null;
               }
               text += (af.prefix ?? "") + val;

--- a/src/client/recipes.ts
+++ b/src/client/recipes.ts
@@ -9,21 +9,25 @@ export const RECIPES: RecipeDefinition[] = [
     description: "Summarize each file in a Google Drive folder",
     panelId: "recipe",
     params: {
-      driveFolder: {
-        colTitle: "Drive Link",
-        helperText: "Make sure you have access to this folder",
-      },
-      systemPrompt: {
-        colTitle: { value: "System Prompt", locked: true },
-        prompt: {
-          value:
-            "You are an expert document analyst. Produce clear, structured summaries " +
-            "focusing on key themes, main arguments, important data points, and actionable conclusions.",
-          locked: true,
-        },
-      },
-      userPrompts: [
+      columns: [
         {
+          kind: "drive-file-folder",
+          colTitle: { value: "Drive Link", locked: false },
+          url: { value: "", locked: false, placeholder: "Paste Google Drive folder URL" },
+          helperText: "Make sure you have access to this folder",
+        },
+        {
+          kind: "system-prompt",
+          colTitle: { value: "System Prompt", locked: true },
+          prompt: {
+            value:
+              "You are an expert document analyst. Produce clear, structured summaries " +
+              "focusing on key themes, main arguments, important data points, and actionable conclusions.",
+            locked: true,
+          },
+        },
+        {
+          kind: "user-prompt",
           colTitle: { value: "User Prompt", locked: true },
           prompt: {
             value:
@@ -32,10 +36,72 @@ export const RECIPES: RecipeDefinition[] = [
             locked: true,
           },
         },
+        {
+          kind: "output",
+          colTitle: { value: "AI_Summarization", locked: true },
+        },
       ],
-      outputCol: {
-        colTitle: { value: "AI_Summarization", locked: true },
-      },
+    } satisfies RecipeParams,
+  },
+  {
+    id: "find-a-thing",
+    name: "Find a Thing in a Thing",
+    icon: "🔍",
+    description: "Scan a folder of files to find which ones contain a specific item",
+    panelId: "recipe",
+    params: {
+      columns: [
+        {
+          kind: "drive-file-folder",
+          colTitle: { value: "Drive Link", locked: false },
+          url: { value: "", locked: false, placeholder: "Paste Google Drive folder URL" },
+          helperText: "The folder of files to scan",
+        },
+        {
+          kind: "drive-file-constant",
+          colTitle: { value: "Reference File", locked: false },
+          url: { value: "", locked: false, placeholder: "Paste a Drive link to a reference file" },
+          helperText: "Optional. Any file type — attach an example of what you're looking for.",
+        },
+        {
+          kind: "system-prompt",
+          colTitle: { value: "System Prompt", locked: true },
+          prompt: {
+            value:
+              "You are a document analyst helping a reporter identify specific items within " +
+              "a collection of files. For each file you receive, determine whether it contains " +
+              "the item described below. Respond with exactly one of: \"yes\", \"no\", or " +
+              "\"unsure\". Follow your answer with a single sentence explaining your reasoning. " +
+              "Do not add any other commentary.\n\n" +
+              "If a reference file is attached, it is a concrete example of what you are looking " +
+              "for — use it as a visual or structural guide when evaluating the document.",
+            locked: true,
+          },
+          appendFields: [
+            {
+              id: "searchDescription",
+              label: "What are you looking for?",
+              placeholder:
+                "Describe the item, person, pattern, or visual artifact you want to find",
+              prefix: "\n\nYou are specifically looking for:\n\n",
+            },
+          ],
+        },
+        {
+          kind: "user-prompt",
+          colTitle: { value: "User Prompt", locked: true },
+          prompt: {
+            value:
+              "Analyze the attached file and determine whether it contains the item described " +
+              "in your instructions.",
+            locked: true,
+          },
+        },
+        {
+          kind: "output",
+          colTitle: { value: "AI_FindAThing", locked: false },
+        },
+      ],
     } satisfies RecipeParams,
   },
 ];

--- a/src/client/recipes.ts
+++ b/src/client/recipes.ts
@@ -70,8 +70,8 @@ export const RECIPES: RecipeDefinition[] = [
             value:
               "You are a document analyst helping a reporter identify specific items within " +
               "a collection of files. For each file you receive, determine whether it contains " +
-              "the item described below. Respond with exactly one of: \"yes\", \"no\", or " +
-              "\"unsure\". Follow your answer with a single sentence explaining your reasoning. " +
+              'the item described below. Respond with exactly one of: "yes", "no", or ' +
+              '"unsure". Follow your answer with a single sentence explaining your reasoning. ' +
               "Do not add any other commentary.\n\n" +
               "If a reference file is attached, it is a concrete example of what you are looking " +
               "for — use it as a visual or structural guide when evaluating the document.",

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,3 +1,5 @@
+import type { ToolId } from "../shared/types";
+
 // ── Loading / Progress types ─────────────────────────────────────────────────
 
 export type LoadingStatus = "idle" | "loading" | "progress" | "complete" | "error";
@@ -26,22 +28,55 @@ export interface RecipeFieldConfig {
   placeholder?: string;
 }
 
+// ── Recipe column specs ──────────────────────────────────────────────────────
+
+export interface PromptAppendField {
+  id: string;
+  label: string;
+  placeholder?: string;
+  /**
+   * Text injected before the reporter's value when concatenating onto the base prompt.
+   * e.g. "\n\nYou are specifically looking for:\n\n"
+   * For system-prompt columns: required because Gemini systemInstruction is a single string.
+   * For user-prompt columns: preferred to keep related inputs in one column (less sheet clutter).
+   */
+  prefix?: string;
+}
+
+export interface DriveColumnSpec {
+  colTitle: RecipeFieldConfig;
+  url: RecipeFieldConfig;
+  helperText?: string;
+}
+
+export interface PromptColumnSpec {
+  colTitle: RecipeFieldConfig;
+  prompt: RecipeFieldConfig;
+  appendFields?: PromptAppendField[];
+  helperText?: string;
+}
+
+export type ColumnSpec =
+  | ({ kind: "drive-file-folder" } & DriveColumnSpec)
+  | ({ kind: "drive-file-constant" } & DriveColumnSpec)
+  | ({ kind: "system-prompt" } & PromptColumnSpec)
+  | ({ kind: "user-prompt" } & PromptColumnSpec)
+  | ({ kind: "output" } & { colTitle: RecipeFieldConfig; helperText?: string });
+
+export interface RecipeSettings {
+  tools?: ToolId[];
+  applyMarkdown?: boolean;
+  includeGrounding?: boolean;
+  // future: modelId?: string;
+}
+
 export interface RecipeParams {
-  driveFolder?: {
-    colTitle: string;
-    helperText?: string;
-  };
-  systemPrompt?: {
-    colTitle: RecipeFieldConfig;
-    prompt: RecipeFieldConfig;
-  };
-  userPrompts?: Array<{
-    colTitle: RecipeFieldConfig;
-    prompt: RecipeFieldConfig;
-  }>;
-  outputCol?: {
-    colTitle: RecipeFieldConfig;
-  };
+  columns: ColumnSpec[];
+  /**
+   * Optional recipe-level AI run settings pre-applied to RunConfig after Prep.
+   * Reporters can still adjust them in ConfigureAIRunPanel.
+   */
+  settings?: RecipeSettings;
 }
 
 /**

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -56,12 +56,17 @@ export interface PromptColumnSpec {
   helperText?: string;
 }
 
+export interface OutputColumnSpec {
+  colTitle: RecipeFieldConfig;
+  helperText?: string;
+}
+
 export type ColumnSpec =
   | ({ kind: "drive-file-folder" } & DriveColumnSpec)
   | ({ kind: "drive-file-constant" } & DriveColumnSpec)
   | ({ kind: "system-prompt" } & PromptColumnSpec)
   | ({ kind: "user-prompt" } & PromptColumnSpec)
-  | ({ kind: "output" } & { colTitle: RecipeFieldConfig; helperText?: string });
+  | ({ kind: "output" } & OutputColumnSpec);
 
 export interface RecipeSettings {
   tools?: ToolId[];

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -350,11 +350,13 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
       });
     }
 
-    const userPrompts = userPromptIdxs.map((idx) => row[idx]);
-    const driveLinks = driveFileIdxs.length > 0 ? driveFileIdxs.map((idx) => row[idx]) : undefined;
+    const userPromptParts: Array<{ kind: "text" | "file"; value: unknown }> = [
+      ...userPromptIdxs.map((idx) => ({ kind: "text" as const, value: row[idx] })),
+      ...driveFileIdxs.map((idx) => ({ kind: "file" as const, value: row[idx] })),
+    ];
     const systemPrompt = systemPromptIdx >= 0 ? row[systemPromptIdx] : undefined;
 
-    const result = runInference(userPrompts, driveLinks, systemPrompt, config.tools);
+    const result = runInference(userPromptParts, systemPrompt, config.tools);
     if (result === null) continue;
 
     if (config.applyMarkdown) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -256,32 +256,24 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
     return;
   }
 
-  // Validate user prompt columns (required)
-  const userPromptIdxs = resolveColumns(headers, config.userPromptCols);
-  const missingUserPrompt = config.userPromptCols.filter((_, i) => userPromptIdxs[i] === -1);
-  if (missingUserPrompt.length > 0) {
+  // Resolve all userPromptParts columns once before the row loop
+  const partCols = config.userPromptParts.map((p) => p.col);
+  const partIdxs = resolveColumns(headers, partCols);
+  const missingParts = partCols.filter((_, i) => partIdxs[i] === -1);
+  if (missingParts.length > 0) {
     ui.alert(
       "Error: Missing Columns",
-      `Could not find columns: ${missingUserPrompt.join(", ")}`,
+      `Could not find columns: ${missingParts.join(", ")}`,
       ui.ButtonSet.OK,
     );
     return;
   }
 
-  // Validate drive file columns (if selected)
-  let driveFileIdxs: number[] = [];
-  if (config.driveFileCols && config.driveFileCols.length > 0) {
-    driveFileIdxs = resolveColumns(headers, config.driveFileCols);
-    const missingDrive = config.driveFileCols.filter((_, i) => driveFileIdxs[i] === -1);
-    if (missingDrive.length > 0) {
-      ui.alert(
-        "Error: Missing Columns",
-        `Could not find columns: ${missingDrive.join(", ")}`,
-        ui.ButtonSet.OK,
-      );
-      return;
-    }
-  }
+  // Build a header→0-based-index map for O(1) lookup inside the row loop
+  const resolvedCols: Record<string, number> = {};
+  config.userPromptParts.forEach((p, i) => {
+    resolvedCols[p.col] = partIdxs[i];
+  });
 
   // Validate system prompt column (if selected)
   let systemPromptIdx = -1;
@@ -350,13 +342,14 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
       });
     }
 
-    const userPromptParts: Array<{ kind: "text" | "file"; value: unknown }> = [
-      ...userPromptIdxs.map((idx) => ({ kind: "text" as const, value: row[idx] })),
-      ...driveFileIdxs.map((idx) => ({ kind: "file" as const, value: row[idx] })),
-    ];
+    // Build parts for this row in declared order
+    const rowParts = config.userPromptParts.map((part) => ({
+      kind: part.kind,
+      value: row[resolvedCols[part.col]],
+    }));
     const systemPrompt = systemPromptIdx >= 0 ? row[systemPromptIdx] : undefined;
 
-    const result = runInference(userPromptParts, systemPrompt, config.tools);
+    const result = runInference(rowParts, systemPrompt, config.tools);
     if (result === null) continue;
 
     if (config.applyMarkdown) {
@@ -405,69 +398,74 @@ export function runTool(functionName: string, jobId?: string): void {
 
 export function prepRecipe(params: PrepRecipeParams): PrepRecipeResult {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
-  const colNames: PrepRecipeResult["colNames"] = {};
   let numRows = 1;
+  const resultColumns: PrepRecipeResult["columns"] = [];
 
-  if (params.driveFolder) {
-    const folderId = extractId(params.driveFolder.url);
-    const folder = DriveApp.getFolderById(folderId);
-    const files: { url: string }[] = [];
-    getAllFilesRecursive(folder, files);
-    numRows = files.length || 1;
-    const col = findOrCreateColumn(
-      sheet,
-      params.driveFolder.colTitle,
-      SpreadsheetApp.WrapStrategy.CLIP,
-    );
-    writeColumn(
-      sheet,
-      col,
-      files.map((f) => f.url),
-      SpreadsheetApp.WrapStrategy.CLIP,
-    );
-    colNames.driveLink = params.driveFolder.colTitle;
-  }
-
-  if (params.systemPrompt) {
-    const col = findOrCreateColumn(
-      sheet,
-      params.systemPrompt.colTitle,
-      SpreadsheetApp.WrapStrategy.CLIP,
-    );
-    writeColumn(
-      sheet,
-      col,
-      Array(numRows).fill(params.systemPrompt.value) as string[],
-      SpreadsheetApp.WrapStrategy.CLIP,
-    );
-    colNames.systemPrompt = params.systemPrompt.colTitle;
-  }
-
-  if (params.userPrompts) {
-    colNames.userPrompts = [];
-    for (const up of params.userPrompts) {
-      const col = findOrCreateColumn(sheet, up.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
-      writeColumn(
-        sheet,
-        col,
-        Array(numRows).fill(up.value) as string[],
-        SpreadsheetApp.WrapStrategy.CLIP,
-      );
-      colNames.userPrompts.push(up.colTitle);
+  for (const col of params.columns) {
+    switch (col.kind) {
+      case "drive-file-folder": {
+        const folderId = extractId(col.url);
+        const folder = DriveApp.getFolderById(folderId);
+        const files: { url: string }[] = [];
+        getAllFilesRecursive(folder, files);
+        numRows = files.length || 1;
+        const colIdx = findOrCreateColumn(sheet, col.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
+        writeColumn(
+          sheet,
+          colIdx,
+          files.map((f) => f.url),
+          SpreadsheetApp.WrapStrategy.CLIP,
+        );
+        resultColumns.push({ kind: col.kind, colTitle: col.colTitle });
+        break;
+      }
+      case "drive-file-constant": {
+        const colIdx = findOrCreateColumn(sheet, col.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
+        writeColumn(
+          sheet,
+          colIdx,
+          Array(numRows).fill(col.url) as string[],
+          SpreadsheetApp.WrapStrategy.CLIP,
+        );
+        resultColumns.push({ kind: col.kind, colTitle: col.colTitle });
+        break;
+      }
+      case "system-prompt": {
+        const colIdx = findOrCreateColumn(sheet, col.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
+        writeColumn(
+          sheet,
+          colIdx,
+          Array(numRows).fill(col.text) as string[],
+          SpreadsheetApp.WrapStrategy.CLIP,
+        );
+        resultColumns.push({ kind: col.kind, colTitle: col.colTitle });
+        break;
+      }
+      case "user-prompt": {
+        const colIdx = findOrCreateColumn(sheet, col.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
+        writeColumn(
+          sheet,
+          colIdx,
+          Array(numRows).fill(col.text) as string[],
+          SpreadsheetApp.WrapStrategy.CLIP,
+        );
+        resultColumns.push({ kind: col.kind, colTitle: col.colTitle });
+        break;
+      }
+      case "output": {
+        findOrCreateColumn(sheet, col.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
+        resultColumns.push({ kind: col.kind, colTitle: col.colTitle });
+        break;
+      }
     }
-  }
-
-  if (params.outputCol) {
-    findOrCreateColumn(sheet, params.outputCol.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
-    colNames.outputCol = params.outputCol.colTitle;
   }
 
   SpreadsheetApp.flush();
 
   return {
     rowRange: { start: 2, end: 2 + numRows - 1 },
-    colNames,
-    tools: params.tools,
+    columns: resultColumns,
+    settings: params.settings,
   };
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -269,12 +269,6 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
     return;
   }
 
-  // Build a header→0-based-index map for O(1) lookup inside the row loop
-  const resolvedCols: Record<string, number> = {};
-  config.userPromptParts.forEach((p, i) => {
-    resolvedCols[p.col] = partIdxs[i];
-  });
-
   // Validate system prompt column (if selected)
   let systemPromptIdx = -1;
   if (config.systemPromptCol) {
@@ -343,9 +337,9 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
     }
 
     // Build parts for this row in declared order
-    const rowParts = config.userPromptParts.map((part) => ({
+    const rowParts = config.userPromptParts.map((part, i) => ({
       kind: part.kind,
-      value: row[resolvedCols[part.col]],
+      value: row[partIdxs[i]],
     }));
     const systemPrompt = systemPromptIdx >= 0 ? row[systemPromptIdx] : undefined;
 

--- a/src/server/inference.ts
+++ b/src/server/inference.ts
@@ -12,33 +12,41 @@ import { flattenArg, isValidDriveLink, extractId } from "./utils";
 import type { GeminiResponse } from "./types";
 import type { ToolId } from "../shared/types";
 
+/** A single part of the user prompt — either a text value or a Drive file link. */
+export interface UserPromptPart {
+  kind: "text" | "file";
+  value: unknown;
+}
+
 /**
- * Execute a single Gemini inference from raw cell values.
+ * Execute a single Gemini inference from an ordered array of prompt parts.
  *
- * @param userPrompts  Cell value(s) for the user message — scalar or 2D range.
- * @param driveLinks   Cell value(s) containing Drive URLs to attach as inline
- *                     data. Invalid or non-Drive strings are silently filtered.
- *                     Omit or pass `undefined` to skip Drive attachment.
- * @param systemPrompt Cell value for the system instruction. First non-empty
- *                     string is used. Omit or pass `undefined` to use the model default.
- * @param tools        Tool IDs to enable for this inference call.
+ * @param userPromptParts  Ordered parts — text cell values and/or Drive URLs to
+ *                         attach as inline data. Invalid or non-Drive strings are
+ *                         silently filtered from file parts.
+ * @param systemPrompt     Cell value for the system instruction. First non-empty
+ *                         string is used. Omit or pass `undefined` to use the model default.
+ * @param tools            Tool IDs to enable for this inference call.
  * @returns The model response object, an object with "Error: ..." text on failure,
- *          or null if userPrompts is empty (signals caller to skip this row).
+ *          or null if all text parts are empty (signals caller to skip this row).
  */
 export function runInference(
-  userPrompts: unknown,
-  driveLinks?: unknown,
+  userPromptParts: UserPromptPart[],
   systemPrompt?: unknown,
   tools?: ToolId[],
 ): GeminiResponse | null {
-  const userTexts = flattenArg(userPrompts);
-  if (userTexts.length === 0) return null;
+  const textParts = userPromptParts.filter((p) => p.kind === "text");
+  const userTexts = textParts.flatMap((p) => flattenArg(p.value));
+  if (userTexts.filter(Boolean).length === 0) return null;
 
   try {
-    const inlineData =
-      driveLinks !== undefined
-        ? prepareDriveAttachments(flattenArg(driveLinks).filter(isValidDriveLink).map(extractId))
-        : [];
+    const fileParts = userPromptParts.filter((p) => p.kind === "file");
+    const driveIds = fileParts
+      .flatMap((p) => flattenArg(p.value))
+      .filter(isValidDriveLink)
+      .map(extractId);
+
+    const inlineData = driveIds.length > 0 ? prepareDriveAttachments(driveIds) : [];
 
     return invokeGemini({
       systemPrompt: systemPrompt !== undefined ? flattenArg(systemPrompt)[0] : undefined,

--- a/src/server/inference.ts
+++ b/src/server/inference.ts
@@ -48,6 +48,10 @@ export function runInference(
 
     const inlineData = driveIds.length > 0 ? prepareDriveAttachments(driveIds) : [];
 
+    // Note: buildGeminiPayload groups all text parts before all inline_data parts
+    // in the Gemini request — interleaved text/file ordering is not currently preserved
+    // through to the API call. For most recipes this is acceptable. See docs/plans/
+    // 2026-03-25-find-a-thing-recipe-design.md §2.2 for future ordering work.
     return invokeGemini({
       systemPrompt: systemPrompt !== undefined ? flattenArg(systemPrompt)[0] : undefined,
       userTexts,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -20,51 +20,62 @@ export type ToolId = "google_search" | "url_context" | "code_execution";
 // ── Configuration ───────────────────────────────────────────────
 
 export interface RunConfig {
-  userPromptCols: string[];
-  driveFileCols?: string[];
+  /**
+   * Ordered parts of the user message. Each part references a column by header name.
+   * Text parts are read as strings; file parts are fetched from Drive and encoded
+   * as inline data. Order is preserved in the Gemini request.
+   */
+  userPromptParts: Array<{ kind: "text" | "file"; col: string }>;
   systemPromptCol?: string;
   outputCol: string;
   rowRange?: { start: number; end: number };
-  /** Tool IDs to enable for every row in this run. */
   tools?: ToolId[];
-  /** When true, runBatchAI writes a {outputCol}_grounding column with source attribution. */
   includeGrounding?: boolean;
-  /**
-   * When true, runBatchAI applies markdown parsing and rich text formatting to the output
-   * column. When false (default), result.text is written directly via setValue.
-   * The grounding column is unaffected by this setting.
-   *
-   * Future: recipes could pre-set this via PrepRecipeParams/PrepRecipeResult —
-   * follow the tools echo pattern if needed.
-   */
   applyMarkdown?: boolean;
 }
 
 // ── Recipes ─────────────────────────────────────────────────────
 
 export interface PrepRecipeParams {
-  driveFolder?: { url: string; colTitle: string };
-  systemPrompt?: { colTitle: string; value: string };
-  userPrompts?: Array<{ colTitle: string; value: string }>;
-  outputCol?: { colTitle: string };
+  columns: Array<
+    | { kind: "drive-file-folder"; colTitle: string; url: string }
+    | { kind: "drive-file-constant"; colTitle: string; url: string }
+    | { kind: "system-prompt"; colTitle: string; text: string }
+    | { kind: "user-prompt"; colTitle: string; text: string }
+    | { kind: "output"; colTitle: string }
+  >;
   /**
-   * Tool IDs to pass through to PrepRecipeResult.
-   * The server does not process these during prep — they are echoed back
-   * to preserve the single-source-of-truth invariant for preppedRunConfig.
+   * Non-column settings echoed back in PrepRecipeResult without server processing.
+   * Preserves single-source-of-truth for RunConfig assembly on the client.
    */
-  tools?: ToolId[];
+  settings?: {
+    tools?: ToolId[];
+    applyMarkdown?: boolean;
+    includeGrounding?: boolean;
+  };
 }
 
 export interface PrepRecipeResult {
   rowRange: { start: number; end: number };
-  colNames: {
-    driveLink?: string;
-    systemPrompt?: string;
-    userPrompts?: string[];
-    outputCol?: string;
+  /**
+   * Columns as written to the sheet, in the same order as PrepRecipeParams.columns.
+   * The client assembles RunConfig from this — it is the single source of truth.
+   */
+  columns: Array<{
+    kind:
+      | "drive-file-folder"
+      | "drive-file-constant"
+      | "system-prompt"
+      | "user-prompt"
+      | "output";
+    colTitle: string;
+  }>;
+  /** Echoed from PrepRecipeParams.settings — no server-side processing. */
+  settings?: {
+    tools?: ToolId[];
+    applyMarkdown?: boolean;
+    includeGrounding?: boolean;
   };
-  /** Echoed from PrepRecipeParams — no server-side processing. */
-  tools?: ToolId[];
 }
 
 // ── Import Drive Links ───────────────────────────────────────────

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -29,12 +29,26 @@ export interface RunConfig {
   systemPromptCol?: string;
   outputCol: string;
   rowRange?: { start: number; end: number };
+  /** Tool IDs to enable for every row in this run. */
   tools?: ToolId[];
+  /** When true, runBatchAI writes a {outputCol}_grounding column with source attribution. */
   includeGrounding?: boolean;
+  /**
+   * When true, runBatchAI applies markdown parsing and rich text formatting to the output
+   * column. When false (default), result.text is written directly via setValue.
+   * Recipe settings can pre-set this via PrepRecipeParams/PrepRecipeResult settings echo.
+   */
   applyMarkdown?: boolean;
 }
 
 // ── Recipes ─────────────────────────────────────────────────────
+
+export type ColumnKind =
+  | "drive-file-folder"
+  | "drive-file-constant"
+  | "system-prompt"
+  | "user-prompt"
+  | "output";
 
 export interface PrepRecipeParams {
   columns: Array<
@@ -61,15 +75,7 @@ export interface PrepRecipeResult {
    * Columns as written to the sheet, in the same order as PrepRecipeParams.columns.
    * The client assembles RunConfig from this — it is the single source of truth.
    */
-  columns: Array<{
-    kind:
-      | "drive-file-folder"
-      | "drive-file-constant"
-      | "system-prompt"
-      | "user-prompt"
-      | "output";
-    colTitle: string;
-  }>;
+  columns: Array<{ kind: ColumnKind; colTitle: string }>;
   /** Echoed from PrepRecipeParams.settings — no server-side processing. */
   settings?: {
     tools?: ToolId[];


### PR DESCRIPTION
## Summary

- Redesigns the recipe type system around a `ColumnSpec` discriminated union (5 kinds: `drive-file-folder`, `drive-file-constant`, `system-prompt`, `user-prompt`, `output`), replacing the old named-field `RecipeParams`
- Replaces `userPromptCols`/`driveFileCols` in `RunConfig` with an ordered `userPromptParts` array, unifying text and file inputs as message parts
- Adds `appendFields` support for dynamic reporter input concatenated onto locked base prompts
- Adds the "Find a Thing in a Thing" recipe: scan a folder of files to determine which contain a reporter-described item, with optional visual reference file
- Migrates the existing `document-summarization` recipe to the new `ColumnSpec` shape

## Test Plan
- [ ] `npm test` — 352 tests passing
- [ ] `npm run test:coverage` — all per-file thresholds met
- [ ] `npm run typecheck` — no type errors
- [ ] `npm run lint` — no lint errors
- [ ] Manual: open SSI Toolkit sidebar → Recipes → "Find a Thing in a Thing" → fill out folder URL and search description → Prep → Cook

## Design

See `docs/plans/2026-03-25-find-a-thing-recipe-design.md` for full architecture rationale.
