### PR TITLE
refactor: replace GeminiRequest userTexts/inlineData with ordered parts array

### DIFF
--- a/__tests__/api-function-tools.test.ts
+++ b/__tests__/api-function-tools.test.ts
@@ -21,7 +21,7 @@ import type { ToolId } from "../src/shared/types";
 
 const baseReq: GeminiRequest = {
   apiKey: "key",
-  userTexts: ["hello"],
+  parts: [{ kind: "text", text: "hello" }],
 };
 
 describe("buildGeminiPayload — function-calling tool", () => {

--- a/__tests__/api-function-tools.test.ts
+++ b/__tests__/api-function-tools.test.ts
@@ -21,7 +21,7 @@ import type { ToolId } from "../src/shared/types";
 
 const baseReq: GeminiRequest = {
   apiKey: "key",
-  parts: [{ kind: "text", text: "hello" }],
+  userParts: [{ kind: "text", text: "hello" }],
 };
 
 describe("buildGeminiPayload — function-calling tool", () => {

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -34,7 +34,7 @@ function mockFetchResponse(body: unknown) {
 const baseReq: GeminiRequest = {
   apiKey: "key123",
   systemPrompt: "Be helpful",
-  parts: [{ kind: "text", text: "Summarize this" }],
+  userParts: [{ kind: "text", text: "Summarize this" }],
 };
 
 // ── buildGeminiPayload tests ───────────────────────────────────
@@ -50,7 +50,7 @@ describe("buildGeminiPayload", () => {
   it("assembles multiple text parts in order", () => {
     const req: GeminiRequest = {
       ...baseReq,
-      parts: [
+      userParts: [
         { kind: "text", text: "Prompt" },
         { kind: "text", text: "Context" },
       ],
@@ -65,7 +65,7 @@ describe("buildGeminiPayload", () => {
   it("includes an inline_data part in the REST output", () => {
     const req: GeminiRequest = {
       ...baseReq,
-      parts: [
+      userParts: [
         { kind: "text", text: "What is this?" },
         { kind: "inline_data", data: { mime_type: "application/pdf", data: "base64==" } },
       ],
@@ -79,7 +79,7 @@ describe("buildGeminiPayload", () => {
   it("maps multiple inline_data parts to the REST payload in order", () => {
     const req: GeminiRequest = {
       ...baseReq,
-      parts: [
+      userParts: [
         { kind: "text", text: "Describe both files" },
         { kind: "inline_data", data: { mime_type: "application/pdf", data: "file1==" } },
         { kind: "inline_data", data: { mime_type: "image/jpeg", data: "file2==" } },
@@ -93,7 +93,7 @@ describe("buildGeminiPayload", () => {
   });
 
   it("uses default system prompt when systemPrompt is omitted", () => {
-    const req: GeminiRequest = { apiKey: "k", parts: [{ kind: "text", text: "hi" }] };
+    const req: GeminiRequest = { apiKey: "k", userParts: [{ kind: "text", text: "hi" }] };
     const payload = buildGeminiPayload(req);
     expect((payload.system_instruction as any).parts[0].text).toBe("You are a helpful assistant.");
   });
@@ -121,7 +121,7 @@ describe("buildGeminiPayload", () => {
     it("maps a text part to a REST text part", () => {
       const payload = buildGeminiPayload({
         apiKey: "k",
-        parts: [{ kind: "text", text: "Hello" }],
+        userParts: [{ kind: "text", text: "Hello" }],
       });
       const parts = (payload.contents as any)[0].parts;
       expect(parts).toHaveLength(1);
@@ -131,7 +131,7 @@ describe("buildGeminiPayload", () => {
     it("maps an inline_data part to a REST inline_data part", () => {
       const payload = buildGeminiPayload({
         apiKey: "k",
-        parts: [
+        userParts: [
           { kind: "text", text: "Describe this" },
           { kind: "inline_data", data: { mime_type: "application/pdf", data: "base64==" } },
         ],
@@ -144,12 +144,14 @@ describe("buildGeminiPayload", () => {
     it("maps a file_uri part to a REST file_data part", () => {
       const payload = buildGeminiPayload({
         apiKey: "k",
-        parts: [
+        userParts: [
           { kind: "text", text: "Describe this" },
           {
             kind: "file_uri",
-            mimeType: "application/pdf",
-            fileUri: "https://generativelanguage.googleapis.com/v1beta/files/abc123",
+            data: {
+              mime_type: "application/pdf",
+              file_uri: "https://generativelanguage.googleapis.com/v1beta/files/abc123",
+            },
           },
         ],
       });
@@ -166,7 +168,7 @@ describe("buildGeminiPayload", () => {
     it("preserves declared part order in the REST payload", () => {
       const payload = buildGeminiPayload({
         apiKey: "k",
-        parts: [
+        userParts: [
           { kind: "text", text: "First" },
           { kind: "inline_data", data: { mime_type: "image/jpeg", data: "img==" } },
           { kind: "text", text: "Last" },
@@ -334,7 +336,7 @@ describe("invokeGemini", () => {
 
   it("returns a GeminiResponse with text from the first candidate", () => {
     mockFetchResponse({ candidates: [{ content: { parts: [{ text: "result" }] } }] });
-    const result = invokeGemini({ parts: [{ kind: "text", text: "hello" }] });
+    const result = invokeGemini({ userParts: [{ kind: "text", text: "hello" }] });
     expect(result.text).toBe("result");
     const url = (UrlFetchApp.fetch as jest.Mock).mock.calls[0][0] as string;
     expect(url).toContain("test-api-key");
@@ -342,14 +344,14 @@ describe("invokeGemini", () => {
 
   it("throws when the API key property is not set", () => {
     (PropertiesService.getScriptProperties().getProperty as jest.Mock).mockReturnValueOnce(null);
-    expect(() => invokeGemini({ parts: [{ kind: "text", text: "hello" }] })).toThrow(
+    expect(() => invokeGemini({ userParts: [{ kind: "text", text: "hello" }] })).toThrow(
       /GEMINI_API_KEY/,
     );
   });
 
   it("passes systemPrompt through to the payload", () => {
     mockFetchResponse({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
-    invokeGemini({ systemPrompt: "Be concise", parts: [{ kind: "text", text: "hello" }] });
+    invokeGemini({ systemPrompt: "Be concise", userParts: [{ kind: "text", text: "hello" }] });
     const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
     expect(payload.system_instruction.parts[0].text).toBe("Be concise");
   });
@@ -357,7 +359,7 @@ describe("invokeGemini", () => {
   it("passes inlineData through to the payload", () => {
     mockFetchResponse({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
     invokeGemini({
-      parts: [
+      userParts: [
         { kind: "text", text: "describe this" },
         { kind: "inline_data", data: { mime_type: "application/pdf", data: "base64==" } },
       ],

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -34,7 +34,7 @@ function mockFetchResponse(body: unknown) {
 const baseReq: GeminiRequest = {
   apiKey: "key123",
   systemPrompt: "Be helpful",
-  userTexts: ["Summarize this"],
+  parts: [{ kind: "text", text: "Summarize this" }],
 };
 
 // ── buildGeminiPayload tests ───────────────────────────────────
@@ -48,7 +48,13 @@ describe("buildGeminiPayload", () => {
   });
 
   it("assembles multiple text parts in order", () => {
-    const req: GeminiRequest = { ...baseReq, userTexts: ["Prompt", "Context"] };
+    const req: GeminiRequest = {
+      ...baseReq,
+      parts: [
+        { kind: "text", text: "Prompt" },
+        { kind: "text", text: "Context" },
+      ],
+    };
     const payload = buildGeminiPayload(req);
     const parts = (payload.contents as any)[0].parts;
     expect(parts).toHaveLength(2);
@@ -59,8 +65,10 @@ describe("buildGeminiPayload", () => {
   it("appends inline_data as the final part when provided", () => {
     const req: GeminiRequest = {
       ...baseReq,
-      userTexts: ["What is this?"],
-      inlineData: [{ mime_type: "application/pdf", data: "base64==" }],
+      parts: [
+        { kind: "text", text: "What is this?" },
+        { kind: "inline_data", data: { mime_type: "application/pdf", data: "base64==" } },
+      ],
     };
     const payload = buildGeminiPayload(req);
     const parts = (payload.contents as any)[0].parts;
@@ -71,10 +79,10 @@ describe("buildGeminiPayload", () => {
   it("appends multiple inline_data parts when inlineData has multiple items", () => {
     const req: GeminiRequest = {
       ...baseReq,
-      userTexts: ["Describe both files"],
-      inlineData: [
-        { mime_type: "application/pdf", data: "file1==" },
-        { mime_type: "image/jpeg", data: "file2==" },
+      parts: [
+        { kind: "text", text: "Describe both files" },
+        { kind: "inline_data", data: { mime_type: "application/pdf", data: "file1==" } },
+        { kind: "inline_data", data: { mime_type: "image/jpeg", data: "file2==" } },
       ],
     };
     const payload = buildGeminiPayload(req);
@@ -85,7 +93,7 @@ describe("buildGeminiPayload", () => {
   });
 
   it("uses default system prompt when systemPrompt is omitted", () => {
-    const req: GeminiRequest = { apiKey: "k", userTexts: ["hi"] };
+    const req: GeminiRequest = { apiKey: "k", parts: [{ kind: "text", text: "hi" }] };
     const payload = buildGeminiPayload(req);
     expect((payload.system_instruction as any).parts[0].text).toBe("You are a helpful assistant.");
   });
@@ -106,6 +114,68 @@ describe("buildGeminiPayload", () => {
       const tools = payload.tools as unknown[];
       expect(tools).toHaveLength(1);
       expect(tools[0]).toEqual({ google_search: {} });
+    });
+  });
+
+  describe("parts-based assembly", () => {
+    it("maps a text part to a REST text part", () => {
+      const payload = buildGeminiPayload({
+        apiKey: "k",
+        parts: [{ kind: "text", text: "Hello" }],
+      });
+      const parts = (payload.contents as any)[0].parts;
+      expect(parts).toHaveLength(1);
+      expect(parts[0]).toEqual({ text: "Hello" });
+    });
+
+    it("maps an inline_data part to a REST inline_data part", () => {
+      const payload = buildGeminiPayload({
+        apiKey: "k",
+        parts: [
+          { kind: "text", text: "Describe this" },
+          { kind: "inline_data", data: { mime_type: "application/pdf", data: "base64==" } },
+        ],
+      });
+      const parts = (payload.contents as any)[0].parts;
+      expect(parts).toHaveLength(2);
+      expect(parts[1]).toEqual({ inline_data: { mime_type: "application/pdf", data: "base64==" } });
+    });
+
+    it("maps a file_uri part to a REST file_data part", () => {
+      const payload = buildGeminiPayload({
+        apiKey: "k",
+        parts: [
+          { kind: "text", text: "Describe this" },
+          {
+            kind: "file_uri",
+            mimeType: "application/pdf",
+            fileUri: "https://generativelanguage.googleapis.com/v1beta/files/abc123",
+          },
+        ],
+      });
+      const parts = (payload.contents as any)[0].parts;
+      expect(parts).toHaveLength(2);
+      expect(parts[1]).toEqual({
+        file_data: {
+          mime_type: "application/pdf",
+          file_uri: "https://generativelanguage.googleapis.com/v1beta/files/abc123",
+        },
+      });
+    });
+
+    it("preserves declared part order in the REST payload", () => {
+      const payload = buildGeminiPayload({
+        apiKey: "k",
+        parts: [
+          { kind: "text", text: "First" },
+          { kind: "inline_data", data: { mime_type: "image/jpeg", data: "img==" } },
+          { kind: "text", text: "Last" },
+        ],
+      });
+      const parts = (payload.contents as any)[0].parts;
+      expect(parts[0]).toEqual({ text: "First" });
+      expect(parts[1]).toEqual({ inline_data: { mime_type: "image/jpeg", data: "img==" } });
+      expect(parts[2]).toEqual({ text: "Last" });
     });
   });
 
@@ -264,7 +334,7 @@ describe("invokeGemini", () => {
 
   it("returns a GeminiResponse with text from the first candidate", () => {
     mockFetchResponse({ candidates: [{ content: { parts: [{ text: "result" }] } }] });
-    const result = invokeGemini({ userTexts: ["hello"] });
+    const result = invokeGemini({ parts: [{ kind: "text", text: "hello" }] });
     expect(result.text).toBe("result");
     const url = (UrlFetchApp.fetch as jest.Mock).mock.calls[0][0] as string;
     expect(url).toContain("test-api-key");
@@ -272,12 +342,14 @@ describe("invokeGemini", () => {
 
   it("throws when the API key property is not set", () => {
     (PropertiesService.getScriptProperties().getProperty as jest.Mock).mockReturnValueOnce(null);
-    expect(() => invokeGemini({ userTexts: ["hello"] })).toThrow(/GEMINI_API_KEY/);
+    expect(() => invokeGemini({ parts: [{ kind: "text", text: "hello" }] })).toThrow(
+      /GEMINI_API_KEY/,
+    );
   });
 
   it("passes systemPrompt through to the payload", () => {
     mockFetchResponse({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
-    invokeGemini({ systemPrompt: "Be concise", userTexts: ["hello"] });
+    invokeGemini({ systemPrompt: "Be concise", parts: [{ kind: "text", text: "hello" }] });
     const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
     expect(payload.system_instruction.parts[0].text).toBe("Be concise");
   });
@@ -285,8 +357,10 @@ describe("invokeGemini", () => {
   it("passes inlineData through to the payload", () => {
     mockFetchResponse({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
     invokeGemini({
-      userTexts: ["describe this"],
-      inlineData: [{ mime_type: "application/pdf", data: "base64==" }],
+      parts: [
+        { kind: "text", text: "describe this" },
+        { kind: "inline_data", data: { mime_type: "application/pdf", data: "base64==" } },
+      ],
     });
     const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
     expect(payload.contents[0].parts[1].inline_data.mime_type).toBe("application/pdf");

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -62,7 +62,7 @@ describe("buildGeminiPayload", () => {
     expect(parts[1].text).toBe("Context");
   });
 
-  it("appends inline_data as the final part when provided", () => {
+  it("includes an inline_data part in the REST output", () => {
     const req: GeminiRequest = {
       ...baseReq,
       parts: [
@@ -76,7 +76,7 @@ describe("buildGeminiPayload", () => {
     expect(parts[1].inline_data).toEqual({ mime_type: "application/pdf", data: "base64==" });
   });
 
-  it("appends multiple inline_data parts when inlineData has multiple items", () => {
+  it("maps multiple inline_data parts to the REST payload in order", () => {
     const req: GeminiRequest = {
       ...baseReq,
       parts: [

--- a/docs/plans/2026-03-25-gemini-request-ordered-parts-design.md
+++ b/docs/plans/2026-03-25-gemini-request-ordered-parts-design.md
@@ -1,0 +1,286 @@
+# GeminiRequest Ordered Parts — Design Document
+
+## Problem
+
+The Gemini REST API represents a user message as an ordered `parts` array. The sequence
+of parts matters — the model reads them left-to-right as a document. A text prompt
+followed by a file followed by a follow-up question is semantically distinct from the
+same three items in a different order.
+
+The current pipeline loses this ordering. `RunConfig` separates user input into two
+disjoint pools — `userPromptCols` (text) and `driveFileCols` (files) — and the
+assembly layer in `buildGeminiPayload` always emits all text parts first, then appends
+all inline-data parts:
+
+```typescript
+// api.ts (current)
+const parts: GeminiPart[] = req.userTexts.map((text) => ({ text }));
+req.inlineData?.forEach((d) => parts.push({ inline_data: d }));
+```
+
+This is reflected in `GeminiRequest`, which encodes the same split at the type level:
+
+```typescript
+userTexts: string[];
+inlineData?: GeminiInlineData[];
+```
+
+## Solution
+
+Replace the two-field model with a single ordered `parts: GeminiUserPart[]` array that
+directly mirrors the Gemini `contents[].parts` concept. Each part carries a `kind`
+discriminant so `buildGeminiPayload` can map it to the correct REST shape without any
+append logic.
+
+## Scope
+
+**Phase 1 (this plan):** Refactor the internal server layer only.
+
+- `GeminiRequest`, `buildGeminiPayload`, `runInference`, and `customFunctions.SSI` all
+  move to the new model.
+- `RunConfig` (the RPC boundary) is **unchanged**. The client still sends separate
+  `userPromptCols` and `driveFileCols` arrays. `runBatchAI` translates them into an
+  ordered `GeminiUserPart[]` using the existing text-first, files-appended strategy —
+  no semantic ordering change for end users yet.
+- `drive.ts` (`prepareDriveAttachments`) is **unchanged** — it continues to return
+  `GeminiInlineData[]`. The caller wraps each item into a `{ kind: "inline_data" }`
+  part.
+
+**Phase 2 (future):** Propagate ordered parts through the RPC boundary and simplify
+the shared type interfaces. See the Phase 2 design section below.
+
+**Phase 3 (future):** Wire up the Gemini Files API for files exceeding the inline size
+limit. The `file_uri` variant in `GeminiUserPart` is already present; this phase only
+requires adding a producer in `drive.ts`.
+
+## New Types
+
+### `GeminiUserPart` (added to `server/types.ts`)
+
+```typescript
+export type GeminiUserPart =
+  | { kind: "text"; text: string }
+  | { kind: "inline_data"; data: GeminiInlineData }
+  | { kind: "file_uri"; mimeType: string; fileUri: string };
+```
+
+Three variants, not two:
+
+- **`"text"`** — maps to `{ text: string }` in the REST payload.
+- **`"inline_data"`** — maps to `{ inline_data: { mime_type, data } }`. This is what
+  `prepareDriveAttachments` currently produces. Phase 1 only uses this variant.
+- **`"file_uri"`** — maps to `{ file_data: { mime_type, file_uri } }`. This is the
+  Gemini Files API path (for files > ~100 MB). Adding the variant now means Phase 3
+  (Files API upload support) only requires wiring up the producer; the type and
+  payload-assembly path already exist. `buildGeminiPayload` handles it; nothing in
+  Phase 1 produces it.
+
+### `GeminiRequest` (updated in `server/types.ts`)
+
+```typescript
+export interface GeminiRequest {
+  apiKey: string;
+  modelName?: string;
+  systemPrompt?: string;
+  parts: GeminiUserPart[];        // replaces userTexts + inlineData
+  tools?: ToolId[];
+  generationConfig?: GeminiGenerationConfig;
+}
+```
+
+`GeminiInlineData` is retained — `drive.ts` still uses it as its return type.
+
+## Layer Responsibilities After Phase 1
+
+| Layer | File | Responsibility |
+|---|---|---|
+| REST payload assembly | `api.ts` | Map `GeminiUserPart[]` → Gemini REST parts; no ordering logic |
+| Drive resolution | `drive.ts` | Fetch files, return `GeminiInlineData[]`; no knowledge of `GeminiUserPart` |
+| Inference assembly | `inference.ts` | Wrap text strings and `GeminiInlineData` into `GeminiUserPart[]`; text-first ordering |
+| Custom function | `customFunctions.ts` | Wrap text strings into `GeminiUserPart[]` before calling `invokeGemini` |
+| Batch orchestrator | `index.ts` | Unchanged — delegates assembly to `runInference` |
+
+## What Does Not Change (Phase 1)
+
+- `RunConfig` and all types in `shared/types.ts`
+- `drive.ts` (including `prepareDriveAttachments` return type)
+- `runInference` external signature
+- `runBatchAI` in `index.ts`
+- The REST payload shape emitted to Gemini (same JSON, assembled differently)
+- All `inference.test.ts` tests (they check the outgoing HTTP payload, which is
+  unchanged)
+
+---
+
+## Phase 2 Design
+
+Phase 2 has two goals: propagate ordered parts through the RPC boundary, and
+consolidate the shared type interfaces that have accumulated redundant structure.
+
+### The Redundancy Problem
+
+`PrepRecipeResult.colNames` exists solely to be translated into `RunConfig` fields by
+`buildRunConfig()` in `recipe.ts`:
+
+```typescript
+// recipe.ts — pure renaming, no logic
+private buildRunConfig(result: PrepRecipeResult): Partial<RunConfig> {
+  return {
+    driveFileCols: result.colNames.driveLink ? [result.colNames.driveLink] : undefined,
+    systemPromptCol: result.colNames.systemPrompt,
+    userPromptCols: result.colNames.userPrompts ?? [],
+    outputCol: result.colNames.outputCol ?? "",
+    rowRange: result.rowRange,
+  };
+}
+```
+
+`colNames` uses different field names than `RunConfig` for the same concepts, so a
+translation step is required. That translation is the symptom; the `colNames` nesting
+with mismatched names is the cause.
+
+### The `kind` Discriminant Across the Stack
+
+After Phase 2, a single `kind: "text" | "file"` discriminant flows consistently through
+every layer, getting richer or simpler depending on whether the layer is creating,
+referencing, or resolving columns:
+
+| Layer | Type | Role | Per-kind payload |
+|---|---|---|---|
+| `PrepRecipeParams` | `PrepRecipeColSpec[]` | Column creation | `text: { value }`, `file: { folderUrl? }` |
+| `PrepRecipeResult` | `PromptColumnSpec[]` | Column reference | none — bare col name + kind |
+| `RunConfig` | `PromptColumnSpec[]` | Run configuration | none — bare col name + kind |
+| `GeminiUserPart` | discriminated union | Gemini REST part | `text: { text }`, `inline_data: { data }`, `file_uri: { fileUri }` |
+
+The `kind` is richer at the creation layer (needs to know *what to write*), collapses to
+a bare reference in the middle (just *which column and what kind*), then expands again at
+the inference layer (needs to know *what to send to Gemini*).
+
+### New Shared Types
+
+**`PromptColumnSpec`** (added to `shared/types.ts`):
+
+```typescript
+export interface PromptColumnSpec {
+  col: string;
+  kind: "text" | "file";
+}
+```
+
+This is the user-facing column kind — `"text"` or `"file"`. The server-side distinction
+between `"inline_data"` and `"file_uri"` is a resolution concern internal to
+`drive.ts` and `inference.ts`; it never crosses the RPC boundary.
+
+**`RunConfig`** (updated in `shared/types.ts`):
+
+```typescript
+export interface RunConfig {
+  promptCols: PromptColumnSpec[];   // replaces userPromptCols + driveFileCols
+  systemPromptCol?: string;
+  outputCol: string;
+  rowRange?: { start: number; end: number };
+  tools?: ToolId[];
+  includeGrounding?: boolean;
+  applyMarkdown?: boolean;
+}
+```
+
+**`PrepRecipeResult`** (updated in `shared/types.ts`):
+
+```typescript
+export interface PrepRecipeResult {
+  rowRange: { start: number; end: number };
+  promptCols?: PromptColumnSpec[];  // replaces colNames.driveLink + colNames.userPrompts
+  systemPromptCol?: string;         // replaces colNames.systemPrompt
+  outputCol?: string;               // replaces colNames.outputCol
+  tools?: ToolId[];
+}
+```
+
+The `colNames` nesting is eliminated. Field names now match `RunConfig` directly.
+`PrepRecipeResult` is shaped like a `Partial<RunConfig>` with `rowRange` required —
+the server always detects the row range, and the client can trust it.
+
+**`PrepRecipeColSpec`** (added to `shared/types.ts`):
+
+```typescript
+export type PrepRecipeColSpec =
+  | { kind: "text"; colTitle: string; value: string }
+  | { kind: "file"; colTitle: string; folderUrl?: string };
+```
+
+Used in `PrepRecipeParams` to express ordered column creation instructions. Richer than
+`PromptColumnSpec` because it carries creation data (`value` for text columns,
+`folderUrl` for file columns). `folderUrl` is optional — some recipes pre-populate file
+columns via other means (e.g. a prior Import Drive Links step).
+
+**`PrepRecipeParams`** (updated in `shared/types.ts`):
+
+```typescript
+export interface PrepRecipeParams {
+  promptCols?: PrepRecipeColSpec[];   // replaces userPrompts + driveFolder
+  systemPrompt?: { colTitle: string; value: string };
+  outputCol?: { colTitle: string };
+  tools?: ToolId[];
+}
+```
+
+The `driveFolder` and `userPrompts` fields are replaced by an ordered `promptCols`
+array. The server iterates it in order, creates each column, populates it (Drive folder
+listing for `file` kind, static value for `text` kind), then emits `PrepRecipeResult`
+with `promptCols: PromptColumnSpec[]` preserving that same order.
+
+### Effect on `recipe.ts`
+
+`buildRunConfig()` becomes a trivial spread and can likely be inlined:
+
+```typescript
+private buildRunConfig(result: PrepRecipeResult): Partial<RunConfig> {
+  return {
+    promptCols: result.promptCols,
+    systemPromptCol: result.systemPromptCol,
+    outputCol: result.outputCol ?? "",
+    rowRange: result.rowRange,
+    tools: result.tools,
+  };
+}
+```
+
+### Effect on `index.ts` (`prepRecipe`)
+
+The server-side `prepRecipe` function currently assembles `colNames` with its own field
+names. In Phase 2 it assembles `promptCols: PromptColumnSpec[]` directly, ordering
+columns in the recipe's intended sequence. The recipe definition on the server carries
+this ordering knowledge; the client never needs to infer it.
+
+### Effect on `runBatchAI`
+
+`RunConfig.promptCols` replaces the two separate index arrays. `runBatchAI` iterates
+`promptCols` in order, resolving each column by header name and building a
+`GeminiUserPart[]` that preserves the declared sequence — text columns as
+`{ kind: "text" }` parts, file columns fetched via `prepareDriveAttachments` and
+wrapped as `{ kind: "inline_data" }` parts.
+
+### Phase 2 Files Touched
+
+| File | Change |
+|---|---|
+| `src/shared/types.ts` | Add `PromptColumnSpec`, `PrepRecipeColSpec`; update `RunConfig`, `PrepRecipeParams`, `PrepRecipeResult` |
+| `src/server/index.ts` | Update `prepRecipe` to accept `PrepRecipeColSpec[]` and emit ordered `PromptColumnSpec[]`; update `runBatchAI` to iterate `promptCols` |
+| `src/client/panels/recipe.ts` | Update `buildPrepParams` to assemble `promptCols`; simplify `buildRunConfig` to spread `PrepRecipeResult` |
+| `src/client/recipes.ts` | Update `RecipeDefinition` params to use ordered `PrepRecipeColSpec[]` format |
+| `src/client/panels/configure-ai-run.ts` | Redesign column-picker UI (separate design pass — do last) |
+| `src/client/google.d.ts` | Update RPC stubs if any signatures change |
+| Relevant tests | Update to new field names and structures |
+
+### Phase 2 Entry Point
+
+A new session picking up Phase 2 should start by reading:
+- This document
+- `src/shared/types.ts` — current RPC boundary types
+- `src/server/index.ts` — `prepRecipe` and `runBatchAI` implementations
+- `src/client/panels/recipe.ts` — `buildPrepParams` and `buildRunConfig`
+- `src/client/recipes.ts` — recipe definitions using the old format
+
+The `configure-ai-run.ts` UI redesign should be treated as a separate sub-task within
+Phase 2 and done last, after the data layer is working end-to-end.

--- a/docs/plans/2026-03-25-gemini-request-ordered-parts.md
+++ b/docs/plans/2026-03-25-gemini-request-ordered-parts.md
@@ -1,0 +1,648 @@
+# GeminiRequest Ordered Parts — Phase 1 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace `GeminiRequest.userTexts`/`inlineData` with an ordered `parts: GeminiUserPart[]` array that directly mirrors the Gemini REST API's `contents[].parts` structure.
+
+**Architecture:** Server-internal refactor only. `RunConfig` and `shared/types.ts` are untouched. The outgoing HTTP payload shape to Gemini is identical — only the internal representation changes. `drive.ts` is untouched. `runInference`'s external signature is unchanged.
+
+**Design doc:** `docs/plans/2026-03-25-gemini-request-ordered-parts-design.md`
+
+**Tech Stack:** TypeScript, Jest/ts-jest, Rollup (GAS bundle)
+
+---
+
+## Context: TDD approach for this type refactor
+
+Tasks 1–3 form one atomic Red→Green cycle. Changing `GeminiRequest` (Task 2) simultaneously breaks old tests (which use `userTexts`) and unblocks new tests (which use `parts`). You cannot make new tests green without changing both the type and the implementation. Tasks 4–5 then restore the old tests to green. This is the correct TDD sequence for a breaking type rename.
+
+Tests that check the **outgoing HTTP payload** shape do NOT need changes — the REST JSON Gemini receives is identical before and after this refactor. This covers all of `inference.test.ts` and `customFunctions.test.ts`.
+
+---
+
+## Task 1: Write new failing tests for `buildGeminiPayload`
+
+**Files:**
+- Modify: `__tests__/api.test.ts`
+
+These tests describe the new `parts`-based interface. They will fail with a TypeScript
+error (`parts` does not exist on `GeminiRequest`) until Task 2 lands.
+
+**Step 1: Add four new tests at the bottom of the `buildGeminiPayload` describe block**
+
+Append these inside the `describe("buildGeminiPayload", ...)` block in `__tests__/api.test.ts`,
+after the existing `"passes through generationConfig"` and `maxOutputTokens` tests:
+
+```typescript
+describe("parts-based assembly", () => {
+  it("maps a text part to a REST text part", () => {
+    const payload = buildGeminiPayload({
+      apiKey: "k",
+      parts: [{ kind: "text", text: "Hello" }],
+    });
+    const parts = (payload.contents as any)[0].parts;
+    expect(parts).toHaveLength(1);
+    expect(parts[0]).toEqual({ text: "Hello" });
+  });
+
+  it("maps an inline_data part to a REST inline_data part", () => {
+    const payload = buildGeminiPayload({
+      apiKey: "k",
+      parts: [
+        { kind: "text", text: "Describe this" },
+        { kind: "inline_data", data: { mime_type: "application/pdf", data: "base64==" } },
+      ],
+    });
+    const parts = (payload.contents as any)[0].parts;
+    expect(parts).toHaveLength(2);
+    expect(parts[1]).toEqual({ inline_data: { mime_type: "application/pdf", data: "base64==" } });
+  });
+
+  it("maps a file_uri part to a REST file_data part", () => {
+    const payload = buildGeminiPayload({
+      apiKey: "k",
+      parts: [
+        { kind: "text", text: "Describe this" },
+        {
+          kind: "file_uri",
+          mimeType: "application/pdf",
+          fileUri: "https://generativelanguage.googleapis.com/v1beta/files/abc123",
+        },
+      ],
+    });
+    const parts = (payload.contents as any)[0].parts;
+    expect(parts).toHaveLength(2);
+    expect(parts[1]).toEqual({
+      file_data: {
+        mime_type: "application/pdf",
+        file_uri: "https://generativelanguage.googleapis.com/v1beta/files/abc123",
+      },
+    });
+  });
+
+  it("preserves declared part order in the REST payload", () => {
+    const payload = buildGeminiPayload({
+      apiKey: "k",
+      parts: [
+        { kind: "text", text: "First" },
+        { kind: "inline_data", data: { mime_type: "image/jpeg", data: "img==" } },
+        { kind: "text", text: "Last" },
+      ],
+    });
+    const parts = (payload.contents as any)[0].parts;
+    expect(parts[0]).toEqual({ text: "First" });
+    expect(parts[1]).toEqual({ inline_data: { mime_type: "image/jpeg", data: "img==" } });
+    expect(parts[2]).toEqual({ text: "Last" });
+  });
+});
+```
+
+**Step 2: Run the new tests and confirm they fail with a TypeScript error**
+
+```bash
+npx jest __tests__/api.test.ts --testNamePattern="parts-based assembly"
+```
+
+Expected: compile error — `Argument of type '{ apiKey: string; parts: ... }' is not assignable to parameter of type 'GeminiRequest'`. Property `parts` does not exist.
+
+---
+
+## Task 2: Add `GeminiUserPart` and update `GeminiRequest` in `server/types.ts`
+
+**Files:**
+- Modify: `src/server/types.ts`
+
+**Step 1: Add `GeminiUserPart` below the `GeminiInlineData` interface**
+
+```typescript
+export type GeminiUserPart =
+  | { kind: "text"; text: string }
+  | { kind: "inline_data"; data: GeminiInlineData }
+  | { kind: "file_uri"; mimeType: string; fileUri: string };
+```
+
+**Step 2: Replace `userTexts` and `inlineData` in `GeminiRequest`**
+
+Old:
+```typescript
+export interface GeminiRequest {
+  apiKey: string;
+  modelName?: string;
+  systemPrompt?: string;
+  userTexts: string[];
+  inlineData?: GeminiInlineData[];
+  tools?: ToolId[];
+  generationConfig?: GeminiGenerationConfig;
+}
+```
+
+New:
+```typescript
+export interface GeminiRequest {
+  apiKey: string;
+  modelName?: string;
+  systemPrompt?: string;
+  parts: GeminiUserPart[];
+  tools?: ToolId[];
+  generationConfig?: GeminiGenerationConfig;
+}
+```
+
+**Step 3: Run the new tests — they should still fail, now with a logic error not a type error**
+
+```bash
+npx jest __tests__/api.test.ts --testNamePattern="parts-based assembly"
+```
+
+Expected: tests fail because `buildGeminiPayload` still tries to read `req.userTexts` (which no longer exists on the type). You may see a runtime error or wrong output. Existing tests will also fail to compile — that is expected and will be fixed in Tasks 3–5.
+
+---
+
+## Task 3: Update `buildGeminiPayload` in `api.ts`
+
+**Files:**
+- Modify: `src/server/api.ts`
+
+**Step 1: Rename the internal REST part interface and add `file_data`**
+
+Old:
+```typescript
+interface GeminiPart {
+  text?: string;
+  inline_data?: GeminiInlineData;
+}
+```
+
+New:
+```typescript
+interface GeminiRestPart {
+  text?: string;
+  inline_data?: GeminiInlineData;
+  file_data?: { mime_type: string; file_uri: string };
+}
+```
+
+**Step 2: Replace the append logic with a flat map over `parts`**
+
+Old:
+```typescript
+export function buildGeminiPayload(req: GeminiRequest): Record<string, unknown> {
+  const parts: GeminiPart[] = req.userTexts.map((text) => ({ text }));
+  req.inlineData?.forEach((d) => parts.push({ inline_data: d }));
+
+  const payload: Record<string, unknown> = {
+    system_instruction: {
+      parts: [{ text: req.systemPrompt || "You are a helpful assistant." }],
+    },
+    contents: [{ role: "user", parts }],
+  };
+  // ...
+```
+
+New:
+```typescript
+export function buildGeminiPayload(req: GeminiRequest): Record<string, unknown> {
+  const parts: GeminiRestPart[] = req.parts.map((p) => {
+    if (p.kind === "text") return { text: p.text };
+    if (p.kind === "inline_data") return { inline_data: p.data };
+    return { file_data: { mime_type: p.mimeType, file_uri: p.fileUri } };
+  });
+
+  const payload: Record<string, unknown> = {
+    system_instruction: {
+      parts: [{ text: req.systemPrompt || "You are a helpful assistant." }],
+    },
+    contents: [{ role: "user", parts }],
+  };
+  // ... remainder unchanged
+```
+
+**Step 3: Run the new tests — they should now pass**
+
+```bash
+npx jest __tests__/api.test.ts --testNamePattern="parts-based assembly"
+```
+
+Expected: 4 new tests pass. Existing tests in `api.test.ts` still fail due to `userTexts` in `baseReq` — fix next.
+
+---
+
+## Task 4: Update existing tests in `api.test.ts`
+
+**Files:**
+- Modify: `__tests__/api.test.ts`
+
+All changes here replace `userTexts`/`inlineData` with `parts`. The assertions do not change — the REST payload shape is identical.
+
+**Step 1: Update `baseReq`**
+
+Old:
+```typescript
+const baseReq: GeminiRequest = {
+  apiKey: "key123",
+  systemPrompt: "Be helpful",
+  userTexts: ["Summarize this"],
+};
+```
+
+New:
+```typescript
+const baseReq: GeminiRequest = {
+  apiKey: "key123",
+  systemPrompt: "Be helpful",
+  parts: [{ kind: "text", text: "Summarize this" }],
+};
+```
+
+**Step 2: Update the `buildGeminiPayload` tests that construct their own `req` objects**
+
+"assembles multiple text parts in order":
+```typescript
+// old
+const req: GeminiRequest = { ...baseReq, userTexts: ["Prompt", "Context"] };
+// new
+const req: GeminiRequest = {
+  ...baseReq,
+  parts: [
+    { kind: "text", text: "Prompt" },
+    { kind: "text", text: "Context" },
+  ],
+};
+```
+
+"appends inline_data as the final part when provided":
+```typescript
+// old
+const req: GeminiRequest = {
+  ...baseReq,
+  userTexts: ["What is this?"],
+  inlineData: [{ mime_type: "application/pdf", data: "base64==" }],
+};
+// new
+const req: GeminiRequest = {
+  ...baseReq,
+  parts: [
+    { kind: "text", text: "What is this?" },
+    { kind: "inline_data", data: { mime_type: "application/pdf", data: "base64==" } },
+  ],
+};
+// assertion is unchanged — still checks parts[1].inline_data
+```
+
+"appends multiple inline_data parts when inlineData has multiple items":
+```typescript
+// old
+const req: GeminiRequest = {
+  ...baseReq,
+  userTexts: ["Describe both files"],
+  inlineData: [
+    { mime_type: "application/pdf", data: "file1==" },
+    { mime_type: "image/jpeg", data: "file2==" },
+  ],
+};
+// new
+const req: GeminiRequest = {
+  ...baseReq,
+  parts: [
+    { kind: "text", text: "Describe both files" },
+    { kind: "inline_data", data: { mime_type: "application/pdf", data: "file1==" } },
+    { kind: "inline_data", data: { mime_type: "image/jpeg", data: "file2==" } },
+  ],
+};
+// assertions unchanged
+```
+
+"uses default system prompt when systemPrompt is omitted":
+```typescript
+// old
+const req: GeminiRequest = { apiKey: "k", userTexts: ["hi"] };
+// new
+const req: GeminiRequest = { apiKey: "k", parts: [{ kind: "text", text: "hi" }] };
+```
+
+"passes through generationConfig when provided":
+```typescript
+// old
+const req: GeminiRequest = {
+  ...baseReq,
+  generationConfig: { temperature: 0.5, maxOutputTokens: 1024 },
+};
+// new — no parts change needed, baseReq already updated
+```
+
+"applies CONFIG.MAX_OUTPUT_TOKENS as default when generationConfig omits maxOutputTokens":
+```typescript
+// old
+const req: GeminiRequest = { ...baseReq, generationConfig: { temperature: 0.7 } };
+// new — no parts change needed, baseReq already updated
+```
+
+"uses caller-supplied maxOutputTokens over CONFIG default":
+```typescript
+// old
+const req: GeminiRequest = { ...baseReq, generationConfig: { maxOutputTokens: 512 } };
+// new — no parts change needed, baseReq already updated
+```
+
+**Step 3: Update the `invokeGemini` tests that pass inline args**
+
+"returns a GeminiResponse with text from the first candidate":
+```typescript
+// old
+const result = invokeGemini({ userTexts: ["hello"] });
+// new
+const result = invokeGemini({ parts: [{ kind: "text", text: "hello" }] });
+```
+
+"throws when the API key property is not set":
+```typescript
+// old
+expect(() => invokeGemini({ userTexts: ["hello"] })).toThrow(/GEMINI_API_KEY/);
+// new
+expect(() => invokeGemini({ parts: [{ kind: "text", text: "hello" }] })).toThrow(/GEMINI_API_KEY/);
+```
+
+"passes systemPrompt through to the payload":
+```typescript
+// old
+invokeGemini({ systemPrompt: "Be concise", userTexts: ["hello"] });
+// new
+invokeGemini({ systemPrompt: "Be concise", parts: [{ kind: "text", text: "hello" }] });
+```
+
+"passes inlineData through to the payload":
+```typescript
+// old
+invokeGemini({
+  userTexts: ["describe this"],
+  inlineData: [{ mime_type: "application/pdf", data: "base64==" }],
+});
+// new
+invokeGemini({
+  parts: [
+    { kind: "text", text: "describe this" },
+    { kind: "inline_data", data: { mime_type: "application/pdf", data: "base64==" } },
+  ],
+});
+// assertion unchanged — still checks payload.contents[0].parts[1].inline_data.mime_type
+```
+
+**Step 4: Run all api.test.ts tests and confirm they pass**
+
+```bash
+npx jest __tests__/api.test.ts
+```
+
+Expected: all tests pass, no failures, no TypeScript errors.
+
+---
+
+## Task 5: Update `api-function-tools.test.ts`
+
+**Files:**
+- Modify: `__tests__/api-function-tools.test.ts`
+
+**Step 1: Update `baseReq`**
+
+Old:
+```typescript
+const baseReq: GeminiRequest = {
+  apiKey: "key",
+  userTexts: ["hello"],
+};
+```
+
+New:
+```typescript
+const baseReq: GeminiRequest = {
+  apiKey: "key",
+  parts: [{ kind: "text", text: "hello" }],
+};
+```
+
+No other changes needed — the assertions check tool payload structure, not parts.
+
+**Step 2: Run the file and confirm it passes**
+
+```bash
+npx jest __tests__/api-function-tools.test.ts
+```
+
+Expected: all tests pass.
+
+**Step 3: Commit**
+
+```bash
+git add src/server/types.ts src/server/api.ts __tests__/api.test.ts __tests__/api-function-tools.test.ts
+git commit -m "$(cat <<'EOF'
+refactor: replace GeminiRequest userTexts/inlineData with ordered parts array
+
+GeminiRequest now uses parts: GeminiUserPart[] (text | inline_data | file_uri)
+instead of separate userTexts and inlineData pools. buildGeminiPayload becomes
+a flat map with no append logic. Outgoing HTTP payload to Gemini is unchanged.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Update `inference.ts` internals
+
+**Files:**
+- Modify: `src/server/inference.ts`
+
+`runInference`'s external signature does not change. The internal assembly changes
+from passing two separate arguments to `invokeGemini` to building a single ordered
+`GeminiUserPart[]`.
+
+**Step 1: Add `GeminiUserPart` to the import from `./types`**
+
+Old:
+```typescript
+import type { GeminiResponse } from "./types";
+```
+
+New:
+```typescript
+import type { GeminiResponse, GeminiUserPart } from "./types";
+```
+
+**Step 2: Replace the body of `runInference`**
+
+Old:
+```typescript
+  try {
+    const inlineData =
+      driveLinks !== undefined
+        ? prepareDriveAttachments(flattenArg(driveLinks).filter(isValidDriveLink).map(extractId))
+        : [];
+
+    return invokeGemini({
+      systemPrompt: systemPrompt !== undefined ? flattenArg(systemPrompt)[0] : undefined,
+      userTexts,
+      inlineData: inlineData.length ? inlineData : undefined,
+      tools: tools?.length ? tools : undefined,
+    });
+  }
+```
+
+New:
+```typescript
+  try {
+    const textParts: GeminiUserPart[] = userTexts.map((text) => ({ kind: "text", text }));
+    const fileParts: GeminiUserPart[] =
+      driveLinks !== undefined
+        ? prepareDriveAttachments(
+            flattenArg(driveLinks).filter(isValidDriveLink).map(extractId),
+          ).map((data) => ({ kind: "inline_data", data }))
+        : [];
+
+    return invokeGemini({
+      systemPrompt: systemPrompt !== undefined ? flattenArg(systemPrompt)[0] : undefined,
+      parts: [...textParts, ...fileParts],
+      tools: tools?.length ? tools : undefined,
+    });
+  }
+```
+
+**Step 3: Run `inference.test.ts` and confirm all tests still pass without changes**
+
+```bash
+npx jest __tests__/inference.test.ts
+```
+
+Expected: all tests pass. These tests check the outgoing HTTP payload shape, which is
+unchanged — text parts still appear as `{ text }` and inline data still appears as
+`{ inline_data }` in the REST JSON.
+
+**Step 4: Commit**
+
+```bash
+git add src/server/inference.ts
+git commit -m "$(cat <<'EOF'
+refactor: update runInference to assemble GeminiUserPart[] for invokeGemini
+
+Text values and Drive inline data are now wrapped into an ordered GeminiUserPart[]
+before being passed to invokeGemini. Text-first ordering is preserved for Phase 1.
+External signature and outgoing payload shape are unchanged.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Update `customFunctions.ts`
+
+**Files:**
+- Modify: `src/server/customFunctions.ts`
+
+`SSI` calls `invokeGemini` directly with `userTexts`. This needs to wrap the flattened
+strings into text parts.
+
+**Step 1: Update the `invokeGemini` call in `SSI`**
+
+Old:
+```typescript
+    return invokeGemini({
+      systemPrompt: systemPrompt || undefined,
+      userTexts: flattenArg(userTexts),
+      tools: resolvedToolIds.length ? resolvedToolIds : undefined,
+    }).text;
+```
+
+New:
+```typescript
+    return invokeGemini({
+      systemPrompt: systemPrompt || undefined,
+      parts: flattenArg(userTexts).map((text): import("./types").GeminiUserPart => ({
+        kind: "text",
+        text,
+      })),
+      tools: resolvedToolIds.length ? resolvedToolIds : undefined,
+    }).text;
+```
+
+Alternatively, add `GeminiUserPart` to the import at the top of the file and use it
+directly:
+
+```typescript
+import { invokeGemini } from "./api";
+import { flattenArg } from "./utils";
+import { TOOL_REGISTRY } from "./tools";
+import type { ToolId } from "../shared/types";
+import type { GeminiUserPart } from "./types";
+```
+
+Then the call becomes:
+
+```typescript
+    return invokeGemini({
+      systemPrompt: systemPrompt || undefined,
+      parts: flattenArg(userTexts).map((text): GeminiUserPart => ({ kind: "text", text })),
+      tools: resolvedToolIds.length ? resolvedToolIds : undefined,
+    }).text;
+```
+
+**Step 2: Run `customFunctions.test.ts` and confirm all tests pass without changes**
+
+```bash
+npx jest __tests__/customFunctions.test.ts
+```
+
+Expected: all tests pass. Tests check the outgoing HTTP payload shape (`parts[0].text`,
+`parts.length`), which is unchanged.
+
+**Step 3: Commit**
+
+```bash
+git add src/server/customFunctions.ts
+git commit -m "$(cat <<'EOF'
+refactor: update SSI custom function to pass GeminiUserPart[] to invokeGemini
+
+SSI now wraps flattenArg output into text parts before calling invokeGemini,
+matching the updated GeminiRequest interface.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Full verification
+
+**Step 1: Run the full test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests pass, no failures, no TypeScript errors in output.
+
+**Step 2: Run typecheck across both tsconfigs**
+
+```bash
+npm run typecheck
+```
+
+Expected: clean output, no errors.
+
+**Step 3: Run a full build**
+
+```bash
+npm run build
+```
+
+Expected: build completes, `dist/index.js` and `dist/Sidebar.html` emitted without errors.
+
+**Step 4: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: no errors or warnings.

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -30,7 +30,9 @@ export function buildGeminiPayload(req: GeminiRequest): Record<string, unknown> 
   const userParts: GeminiUserApiPart[] = req.userParts.map((p) => {
     if (p.kind === "text") return { text: p.text };
     if (p.kind === "inline_data") return { inline_data: p.data };
-    return { file_data: p.data };
+    if (p.kind === "file_uri") return { file_data: p.data };
+    const _exhaustive: never = p;
+    throw new Error(`Unhandled GeminiUserPart kind: ${JSON.stringify(_exhaustive)}`);
   });
 
   const payload: Record<string, unknown> = {

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -9,30 +9,35 @@
 
 import { CONFIG } from "./config";
 import { TOOL_REGISTRY } from "./tools";
-import type { GeminiInlineData, GeminiRequest, GeminiResponse, GeminiCodePair } from "./types";
+import type {
+  GeminiFileApiData,
+  GeminiInlineData,
+  GeminiRequest,
+  GeminiResponse,
+  GeminiCodePair,
+} from "./types";
 
-interface GeminiRestPart {
-  text?: string;
-  inline_data?: GeminiInlineData;
-  file_data?: { mime_type: string; file_uri: string };
-}
+type GeminiUserApiPart =
+  | { text: string }
+  | { inline_data: GeminiInlineData }
+  | { file_data: GeminiFileApiData };
 
 /**
  * Assemble the Gemini generateContent request payload from a GeminiRequest.
  * Pure function — no GAS globals. Independently testable.
  */
 export function buildGeminiPayload(req: GeminiRequest): Record<string, unknown> {
-  const parts: GeminiRestPart[] = req.parts.map((p) => {
+  const userParts: GeminiUserApiPart[] = req.userParts.map((p) => {
     if (p.kind === "text") return { text: p.text };
     if (p.kind === "inline_data") return { inline_data: p.data };
-    return { file_data: { mime_type: p.mimeType, file_uri: p.fileUri } };
+    return { file_data: p.data };
   });
 
   const payload: Record<string, unknown> = {
     system_instruction: {
       parts: [{ text: req.systemPrompt || "You are a helpful assistant." }],
     },
-    contents: [{ role: "user", parts }],
+    contents: [{ role: "user", parts: userParts }],
   };
 
   payload.generationConfig = {

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -11,9 +11,10 @@ import { CONFIG } from "./config";
 import { TOOL_REGISTRY } from "./tools";
 import type { GeminiInlineData, GeminiRequest, GeminiResponse, GeminiCodePair } from "./types";
 
-interface GeminiPart {
+interface GeminiRestPart {
   text?: string;
   inline_data?: GeminiInlineData;
+  file_data?: { mime_type: string; file_uri: string };
 }
 
 /**
@@ -21,8 +22,11 @@ interface GeminiPart {
  * Pure function — no GAS globals. Independently testable.
  */
 export function buildGeminiPayload(req: GeminiRequest): Record<string, unknown> {
-  const parts: GeminiPart[] = req.userTexts.map((text) => ({ text }));
-  req.inlineData?.forEach((d) => parts.push({ inline_data: d }));
+  const parts: GeminiRestPart[] = req.parts.map((p) => {
+    if (p.kind === "text") return { text: p.text };
+    if (p.kind === "inline_data") return { inline_data: p.data };
+    return { file_data: { mime_type: p.mimeType, file_uri: p.fileUri } };
+  });
 
   const payload: Record<string, unknown> = {
     system_instruction: {

--- a/src/server/customFunctions.ts
+++ b/src/server/customFunctions.ts
@@ -15,6 +15,7 @@ import { invokeGemini } from "./api";
 import { flattenArg } from "./utils";
 import { TOOL_REGISTRY } from "./tools";
 import type { ToolId } from "../shared/types";
+import type { GeminiUserPart } from "./types";
 
 /**
  * Call the Gemini API from a spreadsheet cell.
@@ -38,7 +39,7 @@ export function SSI(userTexts: unknown, systemPrompt?: string, toolNames?: unkno
 
     return invokeGemini({
       systemPrompt: systemPrompt || undefined,
-      userTexts: flattenArg(userTexts),
+      parts: flattenArg(userTexts).map((text): GeminiUserPart => ({ kind: "text", text })),
       tools: resolvedToolIds.length ? resolvedToolIds : undefined,
     }).text;
   } catch (e) {

--- a/src/server/customFunctions.ts
+++ b/src/server/customFunctions.ts
@@ -39,7 +39,7 @@ export function SSI(userTexts: unknown, systemPrompt?: string, toolNames?: unkno
 
     return invokeGemini({
       systemPrompt: systemPrompt || undefined,
-      parts: flattenArg(userTexts).map((text): GeminiUserPart => ({ kind: "text", text })),
+      userParts: flattenArg(userTexts).map((text): GeminiUserPart => ({ kind: "text", text })),
       tools: resolvedToolIds.length ? resolvedToolIds : undefined,
     }).text;
   } catch (e) {

--- a/src/server/inference.ts
+++ b/src/server/inference.ts
@@ -9,7 +9,7 @@
 import { invokeGemini } from "./api";
 import { prepareDriveAttachments } from "./drive";
 import { flattenArg, isValidDriveLink, extractId } from "./utils";
-import type { GeminiResponse } from "./types";
+import type { GeminiResponse, GeminiUserPart } from "./types";
 import type { ToolId } from "../shared/types";
 
 /**
@@ -35,15 +35,17 @@ export function runInference(
   if (userTexts.length === 0) return null;
 
   try {
-    const inlineData =
+    const textParts: GeminiUserPart[] = userTexts.map((text) => ({ kind: "text", text }));
+    const fileParts: GeminiUserPart[] =
       driveLinks !== undefined
-        ? prepareDriveAttachments(flattenArg(driveLinks).filter(isValidDriveLink).map(extractId))
+        ? prepareDriveAttachments(
+            flattenArg(driveLinks).filter(isValidDriveLink).map(extractId),
+          ).map((data) => ({ kind: "inline_data", data }))
         : [];
 
     return invokeGemini({
       systemPrompt: systemPrompt !== undefined ? flattenArg(systemPrompt)[0] : undefined,
-      userTexts,
-      inlineData: inlineData.length ? inlineData : undefined,
+      parts: [...textParts, ...fileParts],
       tools: tools?.length ? tools : undefined,
     });
   } catch (e) {

--- a/src/server/inference.ts
+++ b/src/server/inference.ts
@@ -45,7 +45,7 @@ export function runInference(
 
     return invokeGemini({
       systemPrompt: systemPrompt !== undefined ? flattenArg(systemPrompt)[0] : undefined,
-      parts: [...textParts, ...fileParts],
+      userParts: [...textParts, ...fileParts],
       tools: tools?.length ? tools : undefined,
     });
   } catch (e) {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -39,6 +39,11 @@ export interface GeminiInlineData {
   data: string; // base64-encoded bytes
 }
 
+export type GeminiUserPart =
+  | { kind: "text"; text: string }
+  | { kind: "inline_data"; data: GeminiInlineData }
+  | { kind: "file_uri"; mimeType: string; fileUri: string };
+
 export interface GeminiFunctionDeclaration {
   name: string;
   description: string;
@@ -109,8 +114,7 @@ export interface GeminiRequest {
   apiKey: string;
   modelName?: string; // defaults to CONFIG.MODEL_NAME if omitted
   systemPrompt?: string;
-  userTexts: string[]; // assembled into parts: [{text}, {text}, ...]
-  inlineData?: GeminiInlineData[]; // each item appended as an inline_data part
+  parts: GeminiUserPart[];
   /** Tool IDs to enable. Resolved against TOOL_REGISTRY in buildGeminiPayload. */
   tools?: ToolId[];
   generationConfig?: GeminiGenerationConfig;

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -41,9 +41,22 @@ export interface GeminiInlineData {
 
 export interface GeminiFileApiData {
   mime_type: string;
+  /** URI returned by the Gemini Files API after uploading a file. */
   file_uri: string;
 }
 
+/**
+ * A single part of the user turn in a Gemini request.
+ *
+ * - "text"        — plain text; produced by userPromptCols in runBatchAI and SSI.
+ * - "inline_data" — base64-encoded file bytes; produced by prepareDriveAttachments
+ *                   for files within the inline size limit (~100 MB encoded).
+ * - "file_uri"    — reference to a file uploaded via the Gemini Files API (up to 2 GB).
+ *                   No producer exists yet; the type and payload path are reserved for
+ *                   a future phase when large-file support is wired up in drive.ts.
+ *
+ * Order within userParts[] is preserved through to the Gemini REST payload.
+ */
 export type GeminiUserPart =
   | { kind: "text"; text: string }
   | { kind: "inline_data"; data: GeminiInlineData }
@@ -119,6 +132,7 @@ export interface GeminiRequest {
   apiKey: string;
   modelName?: string; // defaults to CONFIG.MODEL_NAME if omitted
   systemPrompt?: string;
+  /** Ordered user-turn parts assembled by the caller. Maps 1:1 to contents[0].parts in the REST payload. */
   userParts: GeminiUserPart[];
   /** Tool IDs to enable. Resolved against TOOL_REGISTRY in buildGeminiPayload. */
   tools?: ToolId[];

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -48,12 +48,12 @@ export interface GeminiFileApiData {
 /**
  * A single part of the user turn in a Gemini request.
  *
- * - "text"        — plain text; produced by userPromptCols in runBatchAI and SSI.
- * - "inline_data" — base64-encoded file bytes; produced by prepareDriveAttachments
- *                   for files within the inline size limit (~100 MB encoded).
- * - "file_uri"    — reference to a file uploaded via the Gemini Files API (up to 2 GB).
- *                   No producer exists yet; the type and payload path are reserved for
- *                   a future phase when large-file support is wired up in drive.ts.
+ * - "text"        — plain text content in the user turn.
+ * - "inline_data" — base64-encoded file bytes embedded in the request body; used when
+ *                   file size is within the inline limit (~100 MB encoded).
+ * - "file_uri"    — reference to a file uploaded via the Gemini Files API (up to 2 GB);
+ *                   no producer exists yet. Type and payload path reserved for a future
+ *                   phase when large-file support is wired up in drive.ts.
  *
  * Order within userParts[] is preserved through to the Gemini REST payload.
  */

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -39,10 +39,15 @@ export interface GeminiInlineData {
   data: string; // base64-encoded bytes
 }
 
+export interface GeminiFileApiData {
+  mime_type: string;
+  file_uri: string;
+}
+
 export type GeminiUserPart =
   | { kind: "text"; text: string }
   | { kind: "inline_data"; data: GeminiInlineData }
-  | { kind: "file_uri"; mimeType: string; fileUri: string };
+  | { kind: "file_uri"; data: GeminiFileApiData };
 
 export interface GeminiFunctionDeclaration {
   name: string;
@@ -114,7 +119,7 @@ export interface GeminiRequest {
   apiKey: string;
   modelName?: string; // defaults to CONFIG.MODEL_NAME if omitted
   systemPrompt?: string;
-  parts: GeminiUserPart[];
+  userParts: GeminiUserPart[];
   /** Tool IDs to enable. Resolved against TOOL_REGISTRY in buildGeminiPayload. */
   tools?: ToolId[];
   generationConfig?: GeminiGenerationConfig;


### PR DESCRIPTION
## Summary

- Adds `GeminiUserPart` discriminated union (`text | inline_data | file_uri`) to `server/types.ts` — three variants matching the Gemini REST API's `contents[].parts` shapes
- Replaces `GeminiRequest.userTexts` + `inlineData` with `parts: GeminiUserPart[]`; `buildGeminiPayload` becomes a flat map with no append logic
- Updates `runInference` and `SSI` call sites to assemble ordered `GeminiUserPart[]` before calling `invokeGemini`

This is Phase 1 of a two-phase refactor. `RunConfig` and `shared/types.ts` are unchanged — the client still sends separate `userPromptCols` / `driveFileCols` arrays. Phase 2 will propagate the ordered parts model through the RPC boundary (design documented in `docs/plans/2026-03-25-gemini-request-ordered-parts-design.md`).

The outgoing HTTP payload to Gemini is identical; `inference.test.ts` and `customFunctions.test.ts` required no changes.

## Test Plan
- [x] 330/330 tests pass
- [x] `npm run typecheck` clean across both tsconfigs
- [x] `npm run build` clean
- [x] `npm run lint` clean