### PR TITLE
refactor: use Gemini REST-native shapes for GeminiUserPart

### DIFF
--- a/__tests__/api-function-tools.test.ts
+++ b/__tests__/api-function-tools.test.ts
@@ -21,7 +21,7 @@ import type { ToolId } from "../src/shared/types";
 
 const baseReq: GeminiRequest = {
   apiKey: "key",
-  userParts: [{ kind: "text", text: "hello" }],
+  userParts: [{ text: "hello" }],
 };
 
 describe("buildGeminiPayload — function-calling tool", () => {

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -34,7 +34,7 @@ function mockFetchResponse(body: unknown) {
 const baseReq: GeminiRequest = {
   apiKey: "key123",
   systemPrompt: "Be helpful",
-  userParts: [{ kind: "text", text: "Summarize this" }],
+  userParts: [{ text: "Summarize this" }],
 };
 
 // ── buildGeminiPayload tests ───────────────────────────────────
@@ -50,10 +50,7 @@ describe("buildGeminiPayload", () => {
   it("assembles multiple text parts in order", () => {
     const req: GeminiRequest = {
       ...baseReq,
-      userParts: [
-        { kind: "text", text: "Prompt" },
-        { kind: "text", text: "Context" },
-      ],
+      userParts: [{ text: "Prompt" }, { text: "Context" }],
     };
     const payload = buildGeminiPayload(req);
     const parts = (payload.contents as any)[0].parts;
@@ -66,8 +63,8 @@ describe("buildGeminiPayload", () => {
     const req: GeminiRequest = {
       ...baseReq,
       userParts: [
-        { kind: "text", text: "What is this?" },
-        { kind: "inline_data", data: { mime_type: "application/pdf", data: "base64==" } },
+        { text: "What is this?" },
+        { inline_data: { mime_type: "application/pdf", data: "base64==" } },
       ],
     };
     const payload = buildGeminiPayload(req);
@@ -80,9 +77,9 @@ describe("buildGeminiPayload", () => {
     const req: GeminiRequest = {
       ...baseReq,
       userParts: [
-        { kind: "text", text: "Describe both files" },
-        { kind: "inline_data", data: { mime_type: "application/pdf", data: "file1==" } },
-        { kind: "inline_data", data: { mime_type: "image/jpeg", data: "file2==" } },
+        { text: "Describe both files" },
+        { inline_data: { mime_type: "application/pdf", data: "file1==" } },
+        { inline_data: { mime_type: "image/jpeg", data: "file2==" } },
       ],
     };
     const payload = buildGeminiPayload(req);
@@ -93,7 +90,7 @@ describe("buildGeminiPayload", () => {
   });
 
   it("uses default system prompt when systemPrompt is omitted", () => {
-    const req: GeminiRequest = { apiKey: "k", userParts: [{ kind: "text", text: "hi" }] };
+    const req: GeminiRequest = { apiKey: "k", userParts: [{ text: "hi" }] };
     const payload = buildGeminiPayload(req);
     expect((payload.system_instruction as any).parts[0].text).toBe("You are a helpful assistant.");
   });
@@ -121,7 +118,7 @@ describe("buildGeminiPayload", () => {
     it("maps a text part to a REST text part", () => {
       const payload = buildGeminiPayload({
         apiKey: "k",
-        userParts: [{ kind: "text", text: "Hello" }],
+        userParts: [{ text: "Hello" }],
       });
       const parts = (payload.contents as any)[0].parts;
       expect(parts).toHaveLength(1);
@@ -132,8 +129,8 @@ describe("buildGeminiPayload", () => {
       const payload = buildGeminiPayload({
         apiKey: "k",
         userParts: [
-          { kind: "text", text: "Describe this" },
-          { kind: "inline_data", data: { mime_type: "application/pdf", data: "base64==" } },
+          { text: "Describe this" },
+          { inline_data: { mime_type: "application/pdf", data: "base64==" } },
         ],
       });
       const parts = (payload.contents as any)[0].parts;
@@ -145,10 +142,9 @@ describe("buildGeminiPayload", () => {
       const payload = buildGeminiPayload({
         apiKey: "k",
         userParts: [
-          { kind: "text", text: "Describe this" },
+          { text: "Describe this" },
           {
-            kind: "file_uri",
-            data: {
+            file_data: {
               mime_type: "application/pdf",
               file_uri: "https://generativelanguage.googleapis.com/v1beta/files/abc123",
             },
@@ -169,9 +165,9 @@ describe("buildGeminiPayload", () => {
       const payload = buildGeminiPayload({
         apiKey: "k",
         userParts: [
-          { kind: "text", text: "First" },
-          { kind: "inline_data", data: { mime_type: "image/jpeg", data: "img==" } },
-          { kind: "text", text: "Last" },
+          { text: "First" },
+          { inline_data: { mime_type: "image/jpeg", data: "img==" } },
+          { text: "Last" },
         ],
       });
       const parts = (payload.contents as any)[0].parts;
@@ -336,7 +332,7 @@ describe("invokeGemini", () => {
 
   it("returns a GeminiResponse with text from the first candidate", () => {
     mockFetchResponse({ candidates: [{ content: { parts: [{ text: "result" }] } }] });
-    const result = invokeGemini({ userParts: [{ kind: "text", text: "hello" }] });
+    const result = invokeGemini({ userParts: [{ text: "hello" }] });
     expect(result.text).toBe("result");
     const url = (UrlFetchApp.fetch as jest.Mock).mock.calls[0][0] as string;
     expect(url).toContain("test-api-key");
@@ -344,14 +340,12 @@ describe("invokeGemini", () => {
 
   it("throws when the API key property is not set", () => {
     (PropertiesService.getScriptProperties().getProperty as jest.Mock).mockReturnValueOnce(null);
-    expect(() => invokeGemini({ userParts: [{ kind: "text", text: "hello" }] })).toThrow(
-      /GEMINI_API_KEY/,
-    );
+    expect(() => invokeGemini({ userParts: [{ text: "hello" }] })).toThrow(/GEMINI_API_KEY/);
   });
 
   it("passes systemPrompt through to the payload", () => {
     mockFetchResponse({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
-    invokeGemini({ systemPrompt: "Be concise", userParts: [{ kind: "text", text: "hello" }] });
+    invokeGemini({ systemPrompt: "Be concise", userParts: [{ text: "hello" }] });
     const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
     expect(payload.system_instruction.parts[0].text).toBe("Be concise");
   });
@@ -360,8 +354,8 @@ describe("invokeGemini", () => {
     mockFetchResponse({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
     invokeGemini({
       userParts: [
-        { kind: "text", text: "describe this" },
-        { kind: "inline_data", data: { mime_type: "application/pdf", data: "base64==" } },
+        { text: "describe this" },
+        { inline_data: { mime_type: "application/pdf", data: "base64==" } },
       ],
     });
     const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -9,37 +9,18 @@
 
 import { CONFIG } from "./config";
 import { TOOL_REGISTRY } from "./tools";
-import type {
-  GeminiFileApiData,
-  GeminiInlineData,
-  GeminiRequest,
-  GeminiResponse,
-  GeminiCodePair,
-} from "./types";
-
-type GeminiUserApiPart =
-  | { text: string }
-  | { inline_data: GeminiInlineData }
-  | { file_data: GeminiFileApiData };
+import type { GeminiRequest, GeminiResponse, GeminiCodePair } from "./types";
 
 /**
  * Assemble the Gemini generateContent request payload from a GeminiRequest.
  * Pure function — no GAS globals. Independently testable.
  */
 export function buildGeminiPayload(req: GeminiRequest): Record<string, unknown> {
-  const userParts: GeminiUserApiPart[] = req.userParts.map((p) => {
-    if (p.kind === "text") return { text: p.text };
-    if (p.kind === "inline_data") return { inline_data: p.data };
-    if (p.kind === "file_uri") return { file_data: p.data };
-    const _exhaustive: never = p;
-    throw new Error(`Unhandled GeminiUserPart kind: ${JSON.stringify(_exhaustive)}`);
-  });
-
   const payload: Record<string, unknown> = {
     system_instruction: {
       parts: [{ text: req.systemPrompt || "You are a helpful assistant." }],
     },
-    contents: [{ role: "user", parts: userParts }],
+    contents: [{ role: "user", parts: req.userParts }],
   };
 
   payload.generationConfig = {

--- a/src/server/customFunctions.ts
+++ b/src/server/customFunctions.ts
@@ -39,7 +39,7 @@ export function SSI(userTexts: unknown, systemPrompt?: string, toolNames?: unkno
 
     return invokeGemini({
       systemPrompt: systemPrompt || undefined,
-      userParts: flattenArg(userTexts).map((text): GeminiUserPart => ({ kind: "text", text })),
+      userParts: flattenArg(userTexts).map((text): GeminiUserPart => ({ text })),
       tools: resolvedToolIds.length ? resolvedToolIds : undefined,
     }).text;
   } catch (e) {

--- a/src/server/inference.ts
+++ b/src/server/inference.ts
@@ -35,12 +35,12 @@ export function runInference(
   if (userTexts.length === 0) return null;
 
   try {
-    const textParts: GeminiUserPart[] = userTexts.map((text) => ({ kind: "text", text }));
+    const textParts: GeminiUserPart[] = userTexts.map((text) => ({ text }));
     const fileParts: GeminiUserPart[] =
       driveLinks !== undefined
         ? prepareDriveAttachments(
             flattenArg(driveLinks).filter(isValidDriveLink).map(extractId),
-          ).map((data) => ({ kind: "inline_data", data }))
+          ).map((inline_data) => ({ inline_data }))
         : [];
 
     return invokeGemini({

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -47,20 +47,21 @@ export interface GeminiFileApiData {
 
 /**
  * A single part of the user turn in a Gemini request.
+ * Shapes match the Gemini REST API directly — no translation needed in buildGeminiPayload.
  *
- * - "text"        — plain text content in the user turn.
- * - "inline_data" — base64-encoded file bytes embedded in the request body; used when
- *                   file size is within the inline limit (~100 MB encoded).
- * - "file_uri"    — reference to a file uploaded via the Gemini Files API (up to 2 GB);
- *                   no producer exists yet. Type and payload path reserved for a future
- *                   phase when large-file support is wired up in drive.ts.
+ * - { text }        — plain text content in the user turn.
+ * - { inline_data } — base64-encoded file bytes embedded in the request body; used when
+ *                     file size is within the inline limit (~100 MB encoded).
+ * - { file_data }   — reference to a file uploaded via the Gemini Files API (up to 2 GB);
+ *                     no producer exists yet. Type reserved for a future phase when
+ *                     large-file support is wired up in drive.ts.
  *
  * Order within userParts[] is preserved through to the Gemini REST payload.
  */
 export type GeminiUserPart =
-  | { kind: "text"; text: string }
-  | { kind: "inline_data"; data: GeminiInlineData }
-  | { kind: "file_uri"; data: GeminiFileApiData };
+  | { text: string }
+  | { inline_data: GeminiInlineData }
+  | { file_data: GeminiFileApiData };
 
 export interface GeminiFunctionDeclaration {
   name: string;


### PR DESCRIPTION
## Summary

- `GeminiUserPart` previously used a `kind`-discriminated union that required a translation step in `buildGeminiPayload` to map to the Gemini REST API shape
- The native REST shapes (`{ text }`, `{ inline_data }`, `{ file_data }`) are already structurally distinct, so `kind` was redundant
- Redefine `GeminiUserPart` to match the REST payload shapes directly, drop the local `GeminiUserApiPart` alias, and replace the `.map()` in `buildGeminiPayload` with a direct passthrough

## Test plan

- [ ] All 330 existing tests pass (`npm test`)
- [ ] Typecheck passes (`npm run typecheck`)
