### PR TITLE
refactor: introduce PromptColumnSpec and PromptInput for ordered prompt inputs

### DIFF
--- a/__tests__/inference.test.ts
+++ b/__tests__/inference.test.ts
@@ -63,17 +63,17 @@ describe("runInference", () => {
 
   it("returns the model response string for a scalar user prompt", () => {
     mockOkResponse("AI response");
-    expect(runInference("Hello AI")?.text).toBe("AI response");
+    expect(runInference([{ kind: "text", value: "Hello AI" }])?.text).toBe("AI response");
   });
 
-  it("returns null when userPrompts flattens to empty", () => {
-    expect(runInference(null)).toBeNull();
-    expect(runInference("")).toBeNull();
+  it("returns null when all inputs flatten to empty", () => {
+    expect(runInference([{ kind: "text", value: null }])).toBeNull();
+    expect(runInference([{ kind: "text", value: "" }])).toBeNull();
   });
 
   it("flattens a vertical range of user prompts", () => {
     mockOkResponse("ok");
-    runInference([["p1"], ["p2"]]);
+    runInference([{ kind: "text", value: [["p1"], ["p2"]] }]);
     const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
     expect(payload.contents[0].parts).toHaveLength(2);
     expect(payload.contents[0].parts[0].text).toBe("p1");
@@ -82,7 +82,10 @@ describe("runInference", () => {
 
   it("encodes a valid drive link as inlineData", () => {
     mockOkResponse("ok");
-    runInference("prompt", "https://drive.google.com/file/d/abc123/view");
+    runInference([
+      { kind: "text", value: "prompt" },
+      { kind: "file", value: "https://drive.google.com/file/d/abc123/view" },
+    ]);
     const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
     expect(payload.contents[0].parts[1].inline_data).toEqual({
       mime_type: "application/pdf",
@@ -92,49 +95,55 @@ describe("runInference", () => {
 
   it("filters out invalid drive links silently", () => {
     mockOkResponse("ok");
-    runInference("prompt", "not-a-drive-link");
+    runInference([
+      { kind: "text", value: "prompt" },
+      { kind: "file", value: "not-a-drive-link" },
+    ]);
     const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
     expect(payload.contents[0].parts).toHaveLength(1); // text only, no inline_data
   });
 
-  it("omits inlineData from payload when driveLinks is omitted", () => {
+  it("omits inlineData from payload when no file inputs given", () => {
     mockOkResponse("ok");
-    runInference("prompt");
+    runInference([{ kind: "text", value: "prompt" }]);
     const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
     expect(payload.contents[0].parts).toHaveLength(1);
   });
 
   it("passes systemPrompt to the payload", () => {
     mockOkResponse("ok");
-    runInference("prompt", undefined, "Be concise");
+    runInference([{ kind: "text", value: "prompt" }], "Be concise");
     const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
     expect(payload.system_instruction.parts[0].text).toBe("Be concise");
   });
 
   it("uses default system prompt when systemPrompt is omitted", () => {
     mockOkResponse("ok");
-    runInference("prompt");
+    runInference([{ kind: "text", value: "prompt" }]);
     const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
     expect(payload.system_instruction.parts[0].text).toBe("You are a helpful assistant.");
   });
 
   it("returns an error string when invokeGemini throws", () => {
     mockFetchResponse({ error: { message: "quota exceeded" } });
-    expect(runInference("prompt")?.text).toBe("Error: quota exceeded");
+    expect(runInference([{ kind: "text", value: "prompt" }])?.text).toBe("Error: quota exceeded");
   });
 
   it("returns an error string when Drive fetch throws", () => {
     (DriveApp.getFileById as jest.Mock).mockImplementationOnce(() => {
       throw new Error("File not found");
     });
-    expect(runInference("prompt", "https://drive.google.com/file/d/abc123/view")?.text).toBe(
-      "Error: File not found",
-    );
+    expect(
+      runInference([
+        { kind: "text", value: "prompt" },
+        { kind: "file", value: "https://drive.google.com/file/d/abc123/view" },
+      ])?.text,
+    ).toBe("Error: File not found");
   });
 
   it("passes tools to the payload when provided", () => {
     mockOkResponse("ok");
-    runInference("prompt", undefined, undefined, ["google_search"]);
+    runInference([{ kind: "text", value: "prompt" }], undefined, ["google_search"]);
     const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
     expect(payload.tools).toBeDefined();
     expect(payload.tools[0]).toHaveProperty("google_search");
@@ -142,7 +151,7 @@ describe("runInference", () => {
 
   it("omits tools from the payload when not provided", () => {
     mockOkResponse("ok");
-    runInference("prompt");
+    runInference([{ kind: "text", value: "prompt" }]);
     const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
     expect(payload.tools).toBeUndefined();
   });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -34,7 +34,7 @@ import type {
   ImportDriveLinksConfig,
   ExtractTextConfig,
 } from "../shared/types";
-import type { DriveFileInfo } from "./types";
+import type { DriveFileInfo, PromptInput } from "./types";
 
 // ==========================================
 // 🚀 MENU & INITIALIZATION
@@ -350,11 +350,13 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
       });
     }
 
-    const userPrompts = userPromptIdxs.map((idx) => row[idx]);
-    const driveLinks = driveFileIdxs.length > 0 ? driveFileIdxs.map((idx) => row[idx]) : undefined;
+    const promptInputs: PromptInput[] = [
+      ...userPromptIdxs.map((idx) => ({ kind: "text" as const, value: row[idx] })),
+      ...driveFileIdxs.map((idx) => ({ kind: "file" as const, value: row[idx] })),
+    ];
     const systemPrompt = systemPromptIdx >= 0 ? row[systemPromptIdx] : undefined;
 
-    const result = runInference(userPrompts, driveLinks, systemPrompt, config.tools);
+    const result = runInference(promptInputs, systemPrompt, config.tools);
     if (result === null) continue;
 
     if (config.applyMarkdown) {

--- a/src/server/inference.ts
+++ b/src/server/inference.ts
@@ -9,43 +9,50 @@
 import { invokeGemini } from "./api";
 import { prepareDriveAttachments } from "./drive";
 import { flattenArg, isValidDriveLink, extractId } from "./utils";
-import type { GeminiResponse, GeminiUserPart } from "./types";
+import type { GeminiResponse, GeminiUserPart, PromptInput } from "./types";
 import type { ToolId } from "../shared/types";
 
 /**
  * Execute a single Gemini inference from raw cell values.
  *
- * @param userPrompts  Cell value(s) for the user message — scalar or 2D range.
- * @param driveLinks   Cell value(s) containing Drive URLs to attach as inline
- *                     data. Invalid or non-Drive strings are silently filtered.
- *                     Omit or pass `undefined` to skip Drive attachment.
+ * @param promptInputs Ordered prompt inputs, each carrying a kind ("text" or
+ *                     "file") and a raw cell value. Iterated in declaration
+ *                     order to preserve the caller's intended part sequence.
+ *                     Text values are flattened via flattenArg; file values are
+ *                     resolved via prepareDriveAttachments after filtering for
+ *                     valid Drive links.
  * @param systemPrompt Cell value for the system instruction. First non-empty
  *                     string is used. Omit or pass `undefined` to use the model default.
  * @param tools        Tool IDs to enable for this inference call.
  * @returns The model response object, an object with "Error: ..." text on failure,
- *          or null if userPrompts is empty (signals caller to skip this row).
+ *          or null if no prompt inputs produce any content (signals caller to skip row).
  */
 export function runInference(
-  userPrompts: unknown,
-  driveLinks?: unknown,
+  promptInputs: PromptInput[],
   systemPrompt?: unknown,
   tools?: ToolId[],
 ): GeminiResponse | null {
-  const userTexts = flattenArg(userPrompts);
-  if (userTexts.length === 0) return null;
-
   try {
-    const textParts: GeminiUserPart[] = userTexts.map((text) => ({ text }));
-    const fileParts: GeminiUserPart[] =
-      driveLinks !== undefined
-        ? prepareDriveAttachments(
-            flattenArg(driveLinks).filter(isValidDriveLink).map(extractId),
-          ).map((inline_data) => ({ inline_data }))
-        : [];
+    const userParts: GeminiUserPart[] = [];
+
+    for (const input of promptInputs) {
+      if (input.kind === "text") {
+        const texts = flattenArg(input.value);
+        userParts.push(...texts.map((text) => ({ text })));
+      } else {
+        const fileIds = flattenArg(input.value).filter(isValidDriveLink).map(extractId);
+        if (fileIds.length > 0) {
+          const attachments = prepareDriveAttachments(fileIds);
+          userParts.push(...attachments.map((inline_data) => ({ inline_data })));
+        }
+      }
+    }
+
+    if (userParts.length === 0) return null;
 
     return invokeGemini({
       systemPrompt: systemPrompt !== undefined ? flattenArg(systemPrompt)[0] : undefined,
-      userParts: [...textParts, ...fileParts],
+      userParts,
       tools: tools?.length ? tools : undefined,
     });
   } catch (e) {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -8,7 +8,7 @@
  * tools array, but with different structures.
  */
 
-import type { ToolId } from "../shared/types";
+import type { PromptColumnSpec, ToolId } from "../shared/types";
 
 export interface AppConfig {
   API_KEY_PROPERTY: string;
@@ -124,6 +124,17 @@ export interface GeminiResponse {
 export type GeminiTool =
   | { kind: "grounding"; id: ToolId }
   | { kind: "function"; declaration: GeminiFunctionDeclaration };
+
+/**
+ * A single ordered prompt input from a spreadsheet row.
+ * Carries the raw cell value alongside the kind declared in PromptColumnSpec.
+ * Consumed by runInference, which resolves text values via flattenArg and
+ * file values via prepareDriveAttachments into an ordered GeminiUserPart[].
+ */
+export type PromptInput = {
+  kind: PromptColumnSpec["kind"];
+  value: unknown;
+};
 
 export interface DriveFileInfo {
   url: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -17,6 +17,18 @@
  */
 export type ToolId = "google_search" | "url_context" | "code_execution";
 
+// ── Prompt column spec ──────────────────────────────────────────
+
+/**
+ * A reference to a spreadsheet column together with its prompt kind.
+ * Crosses the RPC boundary in RunConfig.promptCols (Phase 2) and is
+ * echoed through PrepRecipeResult so the client never needs to infer kinds.
+ */
+export interface PromptColumnSpec {
+  col: string;
+  kind: "text" | "file";
+}
+
 // ── Configuration ───────────────────────────────────────────────
 
 export interface RunConfig {


### PR DESCRIPTION
## Summary

- Adds `PromptColumnSpec` to `shared/types.ts` as the single source of truth for the `"text" | "file"` kind discriminant that will cross the RPC boundary in Phase 2
- Adds `PromptInput` to `server/types.ts`, referencing `PromptColumnSpec["kind"]` so the two are linked at the type level
- Updates `runInference` to accept `PromptInput[]` in declaration order instead of separate `userPrompts`/`driveLinks` pools; null-check now fires when no parts are produced (not just when text is empty)
- Updates `runBatchAI` to build `PromptInput[]` from its existing index arrays before calling `runInference`

Ordering within a row is still text-first, files-appended for now — that improvement lands when `RunConfig.promptCols: PromptColumnSpec[]` replaces the two separate column arrays in Phase 2.

## Test plan

- [ ] All 330 existing tests pass
- [ ] `npm run typecheck` clean
- [ ] Inference tests updated to use new `PromptInput[]` signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)