### PR TITLE
refactor: replace RunConfig userPromptCols/driveFileCols with promptCols

### DIFF
--- a/__tests__/panels/configure-ai-run.test.ts
+++ b/__tests__/panels/configure-ai-run.test.ts
@@ -178,6 +178,28 @@ describe("ConfigureAIRunPanel — Run AI", () => {
     await Promise.resolve(); // flush rejection
     expect(globalThis.alert).toHaveBeenCalledWith("Error: API error");
   });
+
+  it("assembleRunConfig includes drive file cols as file entries in promptCols", async () => {
+    (services.runBatchAI as jest.Mock).mockResolvedValue(undefined);
+    const { container } = await mountAndLoad({
+      promptCols: [
+        { col: "col_a", kind: "text" },
+        { col: "col_b", kind: "file" },
+      ],
+      outputCol: "ai_inference",
+    });
+    container.querySelector<HTMLButtonElement>("#run-btn")!.click();
+    await Promise.resolve();
+    expect(services.runBatchAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        promptCols: expect.arrayContaining([
+          { col: "col_a", kind: "text" },
+          { col: "col_b", kind: "file" },
+        ]),
+      }),
+      expect.stringMatching(/^batch-ai-\d+$/),
+    );
+  });
 });
 
 describe("ConfigureAIRunPanel — back", () => {
@@ -360,5 +382,18 @@ describe("ConfigureAIRunPanel — unmount", () => {
     const panel = new ConfigureAIRunPanel();
     panel.mount(container, mockNav);
     expect(panel.unmount()).toBeUndefined();
+  });
+
+  it("unmount() saves drive file cols as kind: file entries in promptCols", async () => {
+    const { panel } = await mountAndLoad({
+      promptCols: [
+        { col: "col_a", kind: "text" },
+        { col: "col_b", kind: "file" },
+      ],
+    });
+    const state = panel.unmount();
+    expect(state).not.toBeUndefined();
+    const typedState = state as { promptCols: Array<{ col: string; kind: string }> };
+    expect(typedState.promptCols).toContainEqual({ col: "col_b", kind: "file" });
   });
 });

--- a/__tests__/panels/configure-ai-run.test.ts
+++ b/__tests__/panels/configure-ai-run.test.ts
@@ -17,7 +17,6 @@ jest.mock("../../src/client/job-store", () => ({
 import { ConfigureAIRunPanel } from "../../src/client/panels/configure-ai-run";
 import type { SavedState } from "../../src/client/panels/configure-ai-run";
 import * as services from "../../src/client/services";
-import { jobStore } from "../../src/client/job-store";
 import type { NavigationContext } from "../../src/client/types";
 import type { RunConfig } from "../../src/shared/types";
 
@@ -84,7 +83,7 @@ describe("ConfigureAIRunPanel — mount", () => {
   });
 
   it("pre-selects params on mount", async () => {
-    const { container } = await mountAndLoad({ userPromptCols: ["col_a"] });
+    const { container } = await mountAndLoad({ promptCols: [{ col: "col_a", kind: "text" }] });
     const selected = container.querySelectorAll("#user-prompt-cols .tag.selected");
     expect(selected).toHaveLength(1);
     expect(selected[0].getAttribute("data-value")).toBe("col_a");
@@ -92,12 +91,14 @@ describe("ConfigureAIRunPanel — mount", () => {
 
   it("restores savedState over params", async () => {
     const savedState = {
-      userPromptCols: ["col_b"],
-      driveFileCols: [],
+      promptCols: [{ col: "col_b", kind: "text" as const }],
       systemPromptCol: "",
       outputCol: "ai_inference",
     };
-    const { container } = await mountAndLoad({ userPromptCols: ["col_a"] }, savedState);
+    const { container } = await mountAndLoad(
+      { promptCols: [{ col: "col_a", kind: "text" }] },
+      savedState,
+    );
     const selected = container.querySelectorAll("#user-prompt-cols .tag.selected");
     expect(selected[0].getAttribute("data-value")).toBe("col_b");
   });
@@ -140,13 +141,16 @@ describe("ConfigureAIRunPanel — Run AI", () => {
   it("calls runBatchAI with correctly assembled RunConfig and a jobId", async () => {
     (services.runBatchAI as jest.Mock).mockResolvedValue(undefined);
     const { container } = await mountAndLoad({
-      userPromptCols: ["col_a"],
+      promptCols: [{ col: "col_a", kind: "text" }],
       outputCol: "ai_inference",
     });
     container.querySelector<HTMLButtonElement>("#run-btn")!.click();
     await Promise.resolve();
     expect(services.runBatchAI).toHaveBeenCalledWith(
-      expect.objectContaining({ userPromptCols: ["col_a"], outputCol: "ai_inference" }),
+      expect.objectContaining({
+        promptCols: [{ col: "col_a", kind: "text" }],
+        outputCol: "ai_inference",
+      }),
       expect.stringMatching(/^batch-ai-\d+$/),
     );
   });
@@ -154,7 +158,7 @@ describe("ConfigureAIRunPanel — Run AI", () => {
   it("stays on panel after run is dispatched and refetches headers", async () => {
     (services.runBatchAI as jest.Mock).mockResolvedValue(undefined);
     const { container } = await mountAndLoad({
-      userPromptCols: ["col_a"],
+      promptCols: [{ col: "col_a", kind: "text" }],
       outputCol: "ai_inference",
     });
     container.querySelector<HTMLButtonElement>("#run-btn")!.click();
@@ -166,7 +170,7 @@ describe("ConfigureAIRunPanel — Run AI", () => {
   it("alerts on failure via jobStore catch handler", async () => {
     (services.runBatchAI as jest.Mock).mockRejectedValue(new Error("API error"));
     const { container } = await mountAndLoad({
-      userPromptCols: ["col_a"],
+      promptCols: [{ col: "col_a", kind: "text" }],
       outputCol: "ai_inference",
     });
     container.querySelector<HTMLButtonElement>("#run-btn")!.click();
@@ -187,7 +191,10 @@ describe("ConfigureAIRunPanel — back", () => {
 describe("ConfigureAIRunPanel — refresh", () => {
   it("refresh-btn refetches headers preserving current selections", async () => {
     (services.getSheetHeaders as jest.Mock).mockResolvedValue(["col_a", "col_b"]);
-    const { container } = await mountAndLoad({ userPromptCols: ["col_a"], outputCol: "col_b" });
+    const { container } = await mountAndLoad({
+      promptCols: [{ col: "col_a", kind: "text" }],
+      outputCol: "col_b",
+    });
     expect(services.getSheetHeaders).toHaveBeenCalledTimes(1);
     container.querySelector<HTMLButtonElement>("#refresh-btn")!.click();
     await Promise.resolve();
@@ -222,7 +229,7 @@ describe("ConfigureAIRunPanel — tools TagList", () => {
   it("includes selected tool IDs in runBatchAI call", async () => {
     (services.runBatchAI as jest.Mock).mockResolvedValue(undefined);
     const { container } = await mountAndLoad({
-      userPromptCols: ["col_a"],
+      promptCols: [{ col: "col_a", kind: "text" }],
       outputCol: "ai_inference",
     });
     container.querySelector<HTMLButtonElement>('[data-value="google_search"]')!.click();
@@ -244,7 +251,7 @@ describe("includeGrounding checkbox", () => {
   it("assembleRunConfig includes includeGrounding: true when checkbox is checked", async () => {
     (services.runBatchAI as jest.Mock).mockResolvedValue(undefined);
     const { container } = await mountAndLoad({
-      userPromptCols: ["col_a"],
+      promptCols: [{ col: "col_a", kind: "text" }],
       outputCol: "ai_inference",
     });
     const cb = container.querySelector<HTMLInputElement>("#include-grounding-cb")!;
@@ -258,7 +265,7 @@ describe("includeGrounding checkbox", () => {
   it("assembleRunConfig omits includeGrounding when checkbox is unchecked", async () => {
     (services.runBatchAI as jest.Mock).mockResolvedValue(undefined);
     const { container } = await mountAndLoad({
-      userPromptCols: ["col_a"],
+      promptCols: [{ col: "col_a", kind: "text" }],
       outputCol: "ai_inference",
     });
     container.querySelector<HTMLInputElement>("#include-grounding-cb")!.checked = false;
@@ -288,11 +295,10 @@ describe("includeGrounding checkbox", () => {
 
   it("restores includeGrounding from savedState", async () => {
     const { container } = await mountAndLoad(undefined, {
-      userPromptCols: ["col_a"],
-      driveFileCols: [],
+      promptCols: [{ col: "col_a", kind: "text" as const }],
       systemPromptCol: "",
       outputCol: "ai_inference",
-      tools: ["google_search"], // ← add this line
+      tools: ["google_search"] as import("../../src/shared/types").ToolId[],
       includeGrounding: true,
     });
     const cb = container.querySelector<HTMLInputElement>("#include-grounding-cb")!;
@@ -314,11 +320,10 @@ describe("includeGrounding checkbox", () => {
 
   it("shows the grounding group on mount when tools are pre-selected in savedState", async () => {
     const { container } = await mountAndLoad(undefined, {
-      userPromptCols: ["col_a"],
-      driveFileCols: [],
+      promptCols: [{ col: "col_a", kind: "text" as const }],
       systemPromptCol: "",
       outputCol: "ai_inference",
-      tools: ["google_search"],
+      tools: ["google_search"] as import("../../src/shared/types").ToolId[],
       includeGrounding: false,
     });
     const group = container.querySelector<HTMLElement>("#include-grounding-group");
@@ -344,7 +349,8 @@ describe("ConfigureAIRunPanel — unmount", () => {
       .click();
     const state = panel.unmount();
     expect(state).not.toBeUndefined();
-    expect((state as { userPromptCols: string[] }).userPromptCols).toContain("col_a");
+    const typedState = state as { promptCols: Array<{ col: string; kind: string }> };
+    expect(typedState.promptCols.map((p) => p.col)).toContain("col_a");
     expect((state as { tools: string[] }).tools).toEqual([]); // no tools selected
   });
 

--- a/__tests__/panels/recipe.test.ts
+++ b/__tests__/panels/recipe.test.ts
@@ -196,11 +196,14 @@ describe("Cook flow", () => {
     await flush();
     container.querySelector<HTMLButtonElement>("#cook-btn")!.click();
     expect(nav.navigate).toHaveBeenCalledWith("configure-ai-run", {
-      driveFileCols: ["Drive Link"],
+      promptCols: [
+        { col: "User", kind: "text" },
+        { col: "Drive Link", kind: "file" },
+      ],
       systemPromptCol: "Sys",
-      userPromptCols: ["User"],
       outputCol: "Out",
       rowRange: { start: 2, end: 5 },
+      tools: undefined,
     });
   });
 });
@@ -242,7 +245,7 @@ describe("unmount / saved state", () => {
   it("mounts with savedState prepComplete: true — Cook is enabled", () => {
     const savedState = {
       prepComplete: true,
-      preppedRunConfig: { outputCol: "Out", userPromptCols: ["User"] },
+      preppedRunConfig: { outputCol: "Out", promptCols: [{ col: "User", kind: "text" as const }] },
     };
     const { container } = mount(
       { outputCol: { colTitle: { value: "Out", locked: true } } },

--- a/__tests__/services.test.ts
+++ b/__tests__/services.test.ts
@@ -68,7 +68,7 @@ describe("getSheetHeaders", () => {
 describe("runBatchAI", () => {
   it("calls google.script.run.runBatchAI with config and resolves", async () => {
     const handlers = captureHandlers();
-    const config = { userPromptCols: ["col_a"], outputCol: "out" };
+    const config = { promptCols: [{ col: "col_a", kind: "text" }], outputCol: "out" };
     const promise = services.runBatchAI(config as import("../src/shared/types").RunConfig);
     handlers.resolve(undefined);
     await expect(promise).resolves.toBeUndefined();
@@ -78,7 +78,7 @@ describe("runBatchAI", () => {
   it("rejects on failure", async () => {
     const handlers = captureHandlers();
     const promise = services.runBatchAI({
-      userPromptCols: [],
+      promptCols: [],
       outputCol: "out",
     });
     handlers.reject(new Error("api error"));

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -1,5 +1,5 @@
 import type { NavigationContext, Panel } from "../types";
-import type { RunConfig, ToolId } from "../../shared/types";
+import type { RunConfig, ToolId, PromptColumnSpec } from "../../shared/types";
 import { TagList } from "../components/tag-list";
 import { SingleTagList } from "../components/single-tag-list";
 import { RowRange } from "../components/row-range";
@@ -39,8 +39,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
 
     const preset: Partial<RunConfig> = savedState
       ? {
-          userPromptCols: savedState.userPromptCols,
-          driveFileCols: savedState.driveFileCols.length ? savedState.driveFileCols : undefined,
+          promptCols: savedState.promptCols,
           systemPromptCol: savedState.systemPromptCol || undefined,
           outputCol: savedState.outputCol || undefined,
           rowRange: savedState.rowRange,
@@ -88,15 +87,19 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
           return;
         }
 
+        const presetTextCols =
+          preset.promptCols?.filter((p) => p.kind === "text").map((p) => p.col) ?? [];
+        const presetFileCols =
+          preset.promptCols?.filter((p) => p.kind === "file").map((p) => p.col) ?? [];
         this.userPromptList = new TagList(
           container.querySelector("#user-prompt-cols")!,
           headers,
-          preset.userPromptCols ?? [],
+          presetTextCols,
         );
         this.driveFileList = new TagList(
           container.querySelector("#drive-file-cols")!,
           headers,
-          preset.driveFileCols ?? [],
+          presetFileCols,
         );
         this.systemPromptList = new SingleTagList(
           container.querySelector("#system-prompt-col")!,
@@ -143,8 +146,10 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
   unmount(): SavedState | undefined {
     if (!this.userPromptList) return undefined;
     return {
-      userPromptCols: this.userPromptList.getValue(),
-      driveFileCols: this.driveFileList?.getValue() ?? [],
+      promptCols: [
+        ...this.userPromptList.getValue().map((col) => ({ col, kind: "text" as const })),
+        ...(this.driveFileList?.getValue() ?? []).map((col) => ({ col, kind: "file" as const })),
+      ],
       systemPromptCol: this.systemPromptList?.getValue() ?? "",
       outputCol: this.outputColList?.getValue() ?? "",
       rowRange: this.rowRangeComp?.getValue(),
@@ -168,9 +173,13 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
   }
 
   private currentPreset(): Partial<RunConfig> {
+    const textCols = this.userPromptList?.getValue() ?? [];
+    const fileCols = this.driveFileList?.getValue() ?? [];
     return {
-      userPromptCols: this.userPromptList?.getValue(),
-      driveFileCols: this.driveFileList?.getValue(),
+      promptCols: [
+        ...textCols.map((col) => ({ col, kind: "text" as const })),
+        ...fileCols.map((col) => ({ col, kind: "file" as const })),
+      ],
       systemPromptCol: this.systemPromptList?.getValue() || undefined,
       outputCol: this.outputColList?.getValue() || undefined,
       rowRange: this.rowRangeComp?.getValue(),
@@ -193,31 +202,28 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
   }
 
   private assembleRunConfig(): RunConfig | null {
-    const userPromptCols = this.userPromptList?.getValue() ?? [];
-    if (userPromptCols.length === 0) {
+    const textCols = this.userPromptList?.getValue() ?? [];
+    if (textCols.length === 0) {
       globalThis.alert("Please select at least one User prompt column.");
       return null;
     }
-
-    const driveFileCols = this.driveFileList?.getValue() ?? [];
+    const fileCols = this.driveFileList?.getValue() ?? [];
+    const promptCols: PromptColumnSpec[] = [
+      ...textCols.map((col) => ({ col, kind: "text" as const })),
+      ...fileCols.map((col) => ({ col, kind: "file" as const })),
+    ];
     const systemPromptCol = this.systemPromptList?.getValue() || undefined;
     const outputCol = this.outputColList?.getValue() ?? "";
-
     if (!outputCol) {
       globalThis.alert("Please select an output column.");
       return null;
     }
-
     const rowRange = this.rowRangeComp?.getValue();
-
     const tools = (this.toolsList?.getValue() ?? []) as ToolId[];
-
     const includeGrounding = this.includeGroundingCb?.checked ?? false;
     const applyMarkdown = this.applyMarkdownCb?.checked ?? false;
-
     return {
-      userPromptCols,
-      driveFileCols: driveFileCols.length > 0 ? driveFileCols : undefined,
+      promptCols,
       systemPromptCol,
       outputCol,
       rowRange,

--- a/src/client/panels/recipe.ts
+++ b/src/client/panels/recipe.ts
@@ -1,6 +1,11 @@
 import type { NavigationContext, Panel, RecipeDefinition } from "../types";
 import type { RecipeParams } from "../types";
-import type { PrepRecipeParams, PrepRecipeResult, RunConfig } from "../../shared/types";
+import type {
+  PrepRecipeParams,
+  PrepRecipeResult,
+  RunConfig,
+  PromptColumnSpec,
+} from "../../shared/types";
 import { LockableField } from "../components/lockable-field";
 import { RecipePrepCook } from "../components/recipe-prep-cook";
 import { prepRecipe } from "../services";
@@ -194,12 +199,18 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
   }
 
   private buildRunConfig(result: PrepRecipeResult): Partial<RunConfig> {
+    const promptCols: PromptColumnSpec[] = [
+      ...(result.colNames.userPrompts ?? []).map((col) => ({ col, kind: "text" as const })),
+      ...(result.colNames.driveLink
+        ? [{ col: result.colNames.driveLink, kind: "file" as const }]
+        : []),
+    ];
     return {
-      driveFileCols: result.colNames.driveLink ? [result.colNames.driveLink] : undefined,
+      promptCols,
       systemPromptCol: result.colNames.systemPrompt,
-      userPromptCols: result.colNames.userPrompts ?? [],
       outputCol: result.colNames.outputCol ?? "",
       rowRange: result.rowRange,
+      tools: result.tools,
     };
   }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -256,31 +256,23 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
     return;
   }
 
-  // Validate user prompt columns (required)
-  const userPromptIdxs = resolveColumns(headers, config.userPromptCols);
-  const missingUserPrompt = config.userPromptCols.filter((_, i) => userPromptIdxs[i] === -1);
-  if (missingUserPrompt.length > 0) {
+  // Validate prompt columns (required — at least one)
+  const promptIdxs = resolveColumns(
+    headers,
+    config.promptCols.map((pc) => pc.col),
+  );
+  const missingPromptCols = config.promptCols
+    .filter((_, i) => promptIdxs[i] === -1)
+    .map((pc) => pc.col);
+  if (config.promptCols.length === 0 || missingPromptCols.length > 0) {
     ui.alert(
       "Error: Missing Columns",
-      `Could not find columns: ${missingUserPrompt.join(", ")}`,
+      missingPromptCols.length > 0
+        ? `Could not find columns: ${missingPromptCols.join(", ")}`
+        : "Please select at least one prompt column.",
       ui.ButtonSet.OK,
     );
     return;
-  }
-
-  // Validate drive file columns (if selected)
-  let driveFileIdxs: number[] = [];
-  if (config.driveFileCols && config.driveFileCols.length > 0) {
-    driveFileIdxs = resolveColumns(headers, config.driveFileCols);
-    const missingDrive = config.driveFileCols.filter((_, i) => driveFileIdxs[i] === -1);
-    if (missingDrive.length > 0) {
-      ui.alert(
-        "Error: Missing Columns",
-        `Could not find columns: ${missingDrive.join(", ")}`,
-        ui.ButtonSet.OK,
-      );
-      return;
-    }
   }
 
   // Validate system prompt column (if selected)
@@ -350,10 +342,10 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
       });
     }
 
-    const promptInputs: PromptInput[] = [
-      ...userPromptIdxs.map((idx) => ({ kind: "text" as const, value: row[idx] })),
-      ...driveFileIdxs.map((idx) => ({ kind: "file" as const, value: row[idx] })),
-    ];
+    const promptInputs: PromptInput[] = config.promptCols.map((pc, i) => ({
+      kind: pc.kind,
+      value: row[promptIdxs[i]],
+    }));
     const systemPrompt = systemPromptIdx >= 0 ? row[systemPromptIdx] : undefined;
 
     const result = runInference(promptInputs, systemPrompt, config.tools);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -32,8 +32,7 @@ export interface PromptColumnSpec {
 // ── Configuration ───────────────────────────────────────────────
 
 export interface RunConfig {
-  userPromptCols: string[];
-  driveFileCols?: string[];
+  promptCols: PromptColumnSpec[];
   systemPromptCol?: string;
   outputCol: string;
   rowRange?: { start: number; end: number };


### PR DESCRIPTION
## Summary

- Replaces `RunConfig.userPromptCols: string[]` + `driveFileCols?: string[]` with a single ordered `promptCols: PromptColumnSpec[]`, threading `kind` through the entire run data flow
- Fixes the text-first ordering bug in `runBatchAI` — parts are now built in the order declared by `promptCols`
- Updates `recipe.ts:buildRunConfig` to assemble `promptCols` from `PrepRecipeResult.colNames` using client-side kind semantics; also fixes a latent bug where `tools` was not echoed through
- `configure-ai-run.ts` splits/merges `promptCols` ↔ its two internal TagList pickers; UI unchanged
- `PrepRecipeParams`/`PrepRecipeResult` intentionally untouched — `kind` is client-side knowledge, not a prep concern

## Test plan

- [ ] All 332 tests pass (`npm test`)
- [ ] Typecheck clean (`npm run typecheck`)
- [ ] Lint clean (`npm run lint`)
- [ ] Coverage thresholds met (`npm run test:coverage`)
- [ ] Manually verify Run AI works end-to-end with both text and file columns
- [ ] Manually verify Document Summarization recipe still preps and cooks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)