### PR TITLE
refactor: replace named-field PrepRecipeParams/RecipeParams with agnostic ColumnDef[] system

### DIFF
--- a/__tests__/panels/recipe.test.ts
+++ b/__tests__/panels/recipe.test.ts
@@ -33,7 +33,7 @@ function mount(params: RecipeParams, savedState?: unknown) {
     params,
   };
   panel.mount(container, nav, definition, savedState as never);
-  return { container, nav, panel, definition };
+  return { container, nav, panel };
 }
 
 async function flush() {
@@ -171,6 +171,21 @@ describe("Prep flow", () => {
           strategy: { kind: "fill-value", value: "Summarize.\n\nLooking for:\n\na signature" },
         },
       ],
+    });
+  });
+
+  it("does not append prefix when appendField input is empty", async () => {
+    mockPrepRecipe.mockResolvedValue(mockResult);
+    const colWithAppend: ColumnDef = {
+      ...fullColumns[2],
+      appendFields: [{ id: "search", label: "What?", prefix: "\n\nLooking for:\n\n" }],
+    };
+    const { container } = mount({ columns: [colWithAppend] });
+    // leave #col-0-append-search empty
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    expect(mockPrepRecipe).toHaveBeenCalledWith({
+      cols: [{ colTitle: "User Prompt", strategy: { kind: "fill-value", value: "Summarize." } }],
     });
   });
 

--- a/__tests__/panels/recipe.test.ts
+++ b/__tests__/panels/recipe.test.ts
@@ -8,8 +8,7 @@ jest.mock("../../src/client/services", () => ({
 import { RecipePanel } from "../../src/client/panels/recipe";
 import * as services from "../../src/client/services";
 import type { PrepRecipeResult } from "../../src/shared/types";
-import type { RecipeParams } from "../../src/client/types";
-import type { NavigationContext, RecipeDefinition } from "../../src/client/types";
+import type { ColumnDef, RecipeDefinition, RecipeParams, NavigationContext } from "../../src/client/types";
 
 const mockPrepRecipe = services.prepRecipe as jest.Mock;
 
@@ -34,7 +33,7 @@ function mount(params: RecipeParams, savedState?: unknown) {
     params,
   };
   panel.mount(container, nav, definition, savedState as never);
-  return { container, nav, panel };
+  return { container, nav, panel, definition };
 }
 
 async function flush() {
@@ -42,65 +41,93 @@ async function flush() {
   await Promise.resolve();
 }
 
+// helper: a minimal column set covering all roles
+const fullColumns: ColumnDef[] = [
+  {
+    label: "Drive Folder",
+    role: "driveLink",
+    strategyKind: "list-drive-folder",
+    colTitle: { value: "Drive Link", locked: true },
+    url: { value: "", locked: false, placeholder: "Paste folder URL" },
+    required: true,
+  },
+  {
+    label: "System Prompt",
+    role: "systemPrompt",
+    strategyKind: "fill-value",
+    colTitle: { value: "System Prompt", locked: true },
+    prompt: { value: "You are helpful.", locked: true },
+  },
+  {
+    label: "User Prompt",
+    role: "userPrompt",
+    strategyKind: "fill-value",
+    colTitle: { value: "User Prompt", locked: true },
+    prompt: { value: "Summarize.", locked: true },
+  },
+  {
+    label: "Output Column",
+    role: "output",
+    strategyKind: "create-empty",
+    colTitle: { value: "AI_Out", locked: true },
+  },
+];
+
+const mockResult: PrepRecipeResult = {
+  rowRange: { start: 2, end: 11 },
+};
+
 // ── rendering ───────────────────────────────────────────────────
 
 describe("rendering", () => {
-  it("renders drive folder input when driveFolder param present", () => {
-    const { container } = mount({ driveFolder: { colTitle: "Drive Link" } });
-    expect(container.querySelector("#drive-folder-input")).not.toBeNull();
+  it("renders a url input for list-drive-folder columns", () => {
+    const { container } = mount({ columns: [fullColumns[0]] });
+    expect(container.querySelector("#col-0-url-input")).not.toBeNull();
   });
 
-  it("does not render drive folder input when driveFolder absent", () => {
-    const { container } = mount({});
-    expect(container.querySelector("#drive-folder-input")).toBeNull();
+  it("does not render url input for fill-value columns", () => {
+    const { container } = mount({ columns: [fullColumns[2]] });
+    expect(container.querySelector("#col-0-url-input")).toBeNull();
   });
 
-  it("renders system prompt fields when systemPrompt param present", () => {
-    const { container } = mount({
-      systemPrompt: {
-        colTitle: { value: "System Prompt", locked: true },
-        prompt: { value: "You are helpful.", locked: true },
-      },
-    });
-    expect(container.querySelector("#system-prompt-title-container")).not.toBeNull();
-    expect(container.querySelector("#system-prompt-value-container")).not.toBeNull();
+  it("renders a prompt container for fill-value columns", () => {
+    const { container } = mount({ columns: [fullColumns[1]] });
+    expect(container.querySelector("#col-0-prompt-container")).not.toBeNull();
   });
 
-  it("renders one user prompt section per userPrompts entry", () => {
-    const { container } = mount({
-      userPrompts: [
-        {
-          colTitle: { value: "User Prompt", locked: true },
-          prompt: { value: "Summarize.", locked: true },
-        },
-        {
-          colTitle: { value: "User Prompt 2", locked: true },
-          prompt: { value: "Also this.", locked: true },
-        },
-      ],
-    });
-    expect(container.querySelector("#user-prompt-title-0-container")).not.toBeNull();
-    expect(container.querySelector("#user-prompt-title-1-container")).not.toBeNull();
+  it("does not render prompt container for create-empty columns", () => {
+    const { container } = mount({ columns: [fullColumns[3]] });
+    expect(container.querySelector("#col-0-prompt-container")).toBeNull();
+  });
+
+  it("renders one section per ColumnDef", () => {
+    const { container } = mount({ columns: fullColumns });
+    expect(container.querySelectorAll(".recipe-section-card")).toHaveLength(fullColumns.length);
+  });
+
+  it("renders append field inputs when appendFields present", () => {
+    const colWithAppend: ColumnDef = {
+      ...fullColumns[2],
+      appendFields: [{ id: "search", label: "What are you looking for?" }],
+    };
+    const { container } = mount({ columns: [colWithAppend] });
+    expect(container.querySelector("#col-0-append-search")).not.toBeNull();
   });
 });
 
 // ── LockableField defaults ────────────────────────────────────────
 
 describe("LockableField defaults", () => {
-  it("initialises fields with locked: true values from params", () => {
-    const { container } = mount({
-      outputCol: { colTitle: { value: "AI_Summarization", locked: true } },
-    });
-    const input = container.querySelector<HTMLInputElement>("#output-col-title-container input")!;
-    expect(input.value).toBe("AI_Summarization");
+  it("initialises locked colTitle field as disabled", () => {
+    const { container } = mount({ columns: [fullColumns[3]] });
+    const input = container.querySelector<HTMLInputElement>("#col-0-title-container input")!;
+    expect(input.value).toBe("AI_Out");
     expect(input.disabled).toBe(true);
   });
 
-  it("initialises fields with locked: false as unlocked", () => {
-    const { container } = mount({
-      outputCol: { colTitle: { value: "AI_Output", locked: false } },
-    });
-    const input = container.querySelector<HTMLInputElement>("#output-col-title-container input")!;
+  it("initialises unlocked url field as enabled", () => {
+    const { container } = mount({ columns: [fullColumns[0]] });
+    const input = container.querySelector<HTMLInputElement>("#col-0-url-input")!;
     expect(input.disabled).toBe(false);
   });
 });
@@ -108,59 +135,52 @@ describe("LockableField defaults", () => {
 // ── prep flow ──────────────────────────────────────────────────
 
 describe("Prep flow", () => {
-  beforeEach(() => {
-    mockPrepRecipe.mockClear();
-  });
-  const fullParams: RecipeParams = {
-    driveFolder: { colTitle: "Drive Link", helperText: "Check access" },
-    systemPrompt: {
-      colTitle: { value: "System Prompt", locked: true },
-      prompt: { value: "You are helpful.", locked: true },
-    },
-    userPrompts: [
-      {
-        colTitle: { value: "User Prompt", locked: true },
-        prompt: { value: "Summarize.", locked: true },
-      },
-    ],
-    outputCol: { colTitle: { value: "AI_Out", locked: true } },
-  };
+  beforeEach(() => mockPrepRecipe.mockClear());
 
-  const mockResult: PrepRecipeResult = {
-    rowRange: { start: 2, end: 11 },
-    colNames: {
-      driveLink: "Drive Link",
-      systemPrompt: "System Prompt",
-      userPrompts: ["User Prompt"],
-      outputCol: "AI_Out",
-    },
-  };
-
-  it("calls services.prepRecipe with resolved form values", async () => {
+  it("calls services.prepRecipe with PrepColSpec[] built from resolved field values", async () => {
     mockPrepRecipe.mockResolvedValue(mockResult);
-    const { container } = mount(fullParams);
-    container.querySelector<HTMLInputElement>("#drive-folder-input")!.value =
+    const { container } = mount({ columns: fullColumns });
+    container.querySelector<HTMLInputElement>("#col-0-url-input")!.value =
       "https://drive.google.com/drive/folders/abc123";
     container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
     await flush();
-    expect(mockPrepRecipe).toHaveBeenCalledWith(
-      expect.objectContaining({
-        driveFolder: expect.objectContaining({ colTitle: "Drive Link" }),
-        systemPrompt: { colTitle: "System Prompt", value: "You are helpful." },
-        userPrompts: [{ colTitle: "User Prompt", value: "Summarize." }],
-        outputCol: { colTitle: "AI_Out" },
-      }),
-    );
+    expect(mockPrepRecipe).toHaveBeenCalledWith({
+      cols: [
+        { colTitle: "Drive Link", strategy: { kind: "list-drive-folder", url: "https://drive.google.com/drive/folders/abc123" } },
+        { colTitle: "System Prompt", strategy: { kind: "fill-value", value: "You are helpful." } },
+        { colTitle: "User Prompt", strategy: { kind: "fill-value", value: "Summarize." } },
+        { colTitle: "AI_Out", strategy: { kind: "create-empty" } },
+      ],
+    });
   });
 
-  it("shows alert and does not proceed if drive folder is empty", async () => {
+  it("composes appendFields into the fill-value prompt string", async () => {
+    mockPrepRecipe.mockResolvedValue(mockResult);
+    const colWithAppend: ColumnDef = {
+      ...fullColumns[2],
+      appendFields: [{ id: "search", label: "What?", prefix: "\n\nLooking for:\n\n" }],
+    };
+    const { container } = mount({ columns: [colWithAppend] });
+    container.querySelector<HTMLInputElement>("#col-0-append-search")!.value = "a signature";
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    expect(mockPrepRecipe).toHaveBeenCalledWith({
+      cols: [
+        {
+          colTitle: "User Prompt",
+          strategy: { kind: "fill-value", value: "Summarize.\n\nLooking for:\n\na signature" },
+        },
+      ],
+    });
+  });
+
+  it("shows alert and does not call prepRecipe when url input is empty for list-drive-folder", async () => {
     const alertMock = jest.fn();
     globalThis.alert = alertMock;
-    const { container } = mount(fullParams);
+    const { container } = mount({ columns: [fullColumns[0]] });
     container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
     await flush();
     expect(alertMock).toHaveBeenCalledTimes(1);
-    expect(alertMock).toHaveBeenCalledWith(expect.stringContaining("folder"));
     expect(mockPrepRecipe).not.toHaveBeenCalled();
   });
 });
@@ -168,89 +188,70 @@ describe("Prep flow", () => {
 // ── Cook flow ──────────────────────────────────────────────────
 
 describe("Cook flow", () => {
-  it("navigates to configure-ai-run with preppedRunConfig assembled from PrepRecipeResult", async () => {
-    const result: PrepRecipeResult = {
-      rowRange: { start: 2, end: 5 },
-      colNames: {
-        driveLink: "Drive Link",
-        systemPrompt: "Sys",
-        userPrompts: ["User"],
-        outputCol: "Out",
-      },
-    };
-    mockPrepRecipe.mockResolvedValue(result);
-    const { container, nav } = mount({
-      driveFolder: { colTitle: "Drive Link" },
-      systemPrompt: {
-        colTitle: { value: "Sys", locked: true },
-        prompt: { value: "p", locked: true },
-      },
-      userPrompts: [
-        { colTitle: { value: "User", locked: true }, prompt: { value: "q", locked: true } },
-      ],
-      outputCol: { colTitle: { value: "Out", locked: true } },
-    });
-    container.querySelector<HTMLInputElement>("#drive-folder-input")!.value =
+  it("navigates to configure-ai-run with RunConfig assembled from ColumnDef roles + rowRange", async () => {
+    mockPrepRecipe.mockResolvedValue({ rowRange: { start: 2, end: 5 } });
+    const { container, nav } = mount({ columns: fullColumns });
+    container.querySelector<HTMLInputElement>("#col-0-url-input")!.value =
       "https://drive.google.com/abc";
     container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
     await flush();
     container.querySelector<HTMLButtonElement>("#cook-btn")!.click();
     expect(nav.navigate).toHaveBeenCalledWith("configure-ai-run", {
       promptCols: [
-        { col: "User", kind: "text" },
         { col: "Drive Link", kind: "file" },
+        { col: "User Prompt", kind: "text" },
       ],
-      systemPromptCol: "Sys",
-      outputCol: "Out",
+      systemPromptCol: "System Prompt",
+      outputCol: "AI_Out",
       rowRange: { start: 2, end: 5 },
-      tools: undefined,
     });
+  });
+
+  it("spreads RecipeSettings into RunConfig", async () => {
+    mockPrepRecipe.mockResolvedValue({ rowRange: { start: 2, end: 3 } });
+    const outputOnly: ColumnDef = fullColumns[3];
+    const { container, nav } = mount({
+      columns: [outputOnly],
+      settings: { tools: ["google_search"], applyMarkdown: true },
+    });
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    container.querySelector<HTMLButtonElement>("#cook-btn")!.click();
+    expect(nav.navigate).toHaveBeenCalledWith("configure-ai-run",
+      expect.objectContaining({ tools: ["google_search"], applyMarkdown: true }),
+    );
   });
 });
 
 // ── saved state ────────────────────────────────────────────────
 
 describe("unmount / saved state", () => {
-  it("unmount returns form values and prepComplete: false when not prepped", () => {
-    const { container, panel } = mount({
-      driveFolder: { colTitle: "Drive Link" },
-      outputCol: { colTitle: { value: "AI_Out", locked: true } },
-    });
-    container.querySelector<HTMLInputElement>("#drive-folder-input")!.value = "my-folder";
+  it("unmount returns colValues array and prepComplete: false when not prepped", () => {
+    const { container, panel } = mount({ columns: [fullColumns[0]] });
+    container.querySelector<HTMLInputElement>("#col-0-url-input")!.value = "my-folder-url";
     const state = panel.unmount();
     expect(state).toMatchObject({
-      driveFolderValue: "my-folder",
+      colValues: [expect.objectContaining({ url: "my-folder-url" })],
       prepComplete: false,
     });
   });
 
-  it("mounts with savedState — restores form values", () => {
+  it("restores url value from savedState", () => {
     const savedState = {
-      driveFolderValue: "restored-folder",
-      outputColTitle: "MyOutput",
+      colValues: [{ url: "restored-url" }],
       prepComplete: false,
     };
-    const { container } = mount(
-      {
-        driveFolder: { colTitle: "Drive Link" },
-        outputCol: { colTitle: { value: "AI_Out", locked: true } },
-      },
-      savedState,
-    );
-    expect(container.querySelector<HTMLInputElement>("#drive-folder-input")!.value).toBe(
-      "restored-folder",
-    );
+    const { container } = mount({ columns: [fullColumns[0]] }, savedState);
+    expect(container.querySelector<HTMLInputElement>("#col-0-url-input")!.value).toBe("restored-url");
   });
 
   it("mounts with savedState prepComplete: true — Cook is enabled", () => {
     const savedState = {
+      colValues: [{}],
       prepComplete: true,
-      preppedRunConfig: { outputCol: "Out", promptCols: [{ col: "User", kind: "text" as const }] },
+      preppedRunConfig: { outputCol: "Out", promptCols: [] },
     };
-    const { container } = mount(
-      { outputCol: { colTitle: { value: "Out", locked: true } } },
-      savedState,
-    );
+    const { container } = mount({ columns: [fullColumns[3]] }, savedState);
     expect(container.querySelector<HTMLButtonElement>("#cook-btn")!.disabled).toBe(false);
   });
 });

--- a/__tests__/services.test.ts
+++ b/__tests__/services.test.ts
@@ -107,12 +107,13 @@ describe("prepRecipe", () => {
   it("calls google.script.run.prepRecipe with params and resolves with result", async () => {
     const handlers = captureHandlers();
     const params: import("../src/shared/types").PrepRecipeParams = {
-      driveFolder: { url: "https://drive.google.com/folder/abc", colTitle: "Drive Link" },
-      outputCol: { colTitle: "AI_Summarization" },
+      cols: [
+        { colTitle: "Drive Link", strategy: { kind: "list-drive-folder", url: "https://drive.google.com/folder/abc" } },
+        { colTitle: "AI_Summarization", strategy: { kind: "create-empty" } },
+      ],
     };
     const result: import("../src/shared/types").PrepRecipeResult = {
       rowRange: { start: 2, end: 5 },
-      colNames: { driveLink: "Drive Link", outputCol: "AI_Summarization" },
     };
     const promise = services.prepRecipe(params);
     handlers.resolve(result);
@@ -122,7 +123,7 @@ describe("prepRecipe", () => {
 
   it("rejects on failure", async () => {
     const handlers = captureHandlers();
-    const promise = services.prepRecipe({});
+    const promise = services.prepRecipe({ cols: [] });
     handlers.reject(new Error("prep error"));
     await expect(promise).rejects.toThrow("prep error");
   });

--- a/docs/plans/2026-03-26-recipe-prep-redesign-plan.md
+++ b/docs/plans/2026-03-26-recipe-prep-redesign-plan.md
@@ -1,0 +1,930 @@
+# Recipe Prep Redesign Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the named-field `PrepRecipeParams`/`RecipeParams` shape with an agnostic `ColumnDef[]` system that separates population strategy (server), semantic role (client), and UI configuration (client).
+
+**Architecture:** Three-phase refactor — (1) shared types + server, (2) client types + recipe migration, (3) RecipePanel rewrite. Each phase is independently committable. See `docs/plans/2026-03-26-recipe-prep-redesign.md` for full design rationale.
+
+**Tech Stack:** TypeScript, Jest/ts-jest, jsdom (client tests), Google Apps Script globals mocked via `globalThis`
+
+---
+
+## Phase 1: Shared Types + Server
+
+### Task 1: Replace PrepRecipeParams and PrepRecipeResult in shared/types.ts
+
+**Files:**
+- Modify: `src/shared/types.ts`
+
+**Step 1: Replace the recipe RPC types**
+
+In `src/shared/types.ts`, replace the entire `// ── Recipes ─────────────────────────────────────────────────────` section:
+
+```typescript
+// ── Recipes ─────────────────────────────────────────────────────
+
+export type ColStrategy =
+  | { kind: "list-drive-folder"; url: string }
+  | { kind: "fill-value"; value: string }
+  | { kind: "create-empty" };
+
+export interface PrepColSpec {
+  colTitle: string;
+  strategy: ColStrategy;
+}
+
+export interface PrepRecipeParams {
+  cols: PrepColSpec[];
+}
+
+export interface PrepRecipeResult {
+  rowRange: { start: number; end: number };
+}
+```
+
+Remove: the old `PrepRecipeParams` (with `driveFolder?`, `systemPrompt?`, `userPrompts?`, `outputCol?`, `tools?`) and the old `PrepRecipeResult` (with `rowRange`, `colNames`, `tools?`).
+
+**Step 2: Run typecheck to see what breaks**
+
+```bash
+npm run typecheck
+```
+
+Expected: type errors in `src/server/index.ts`, `src/client/panels/recipe.ts`, `__tests__/panels/recipe.test.ts`. These are addressed in subsequent tasks.
+
+**Step 3: Commit**
+
+```bash
+git add src/shared/types.ts
+git commit -m "refactor: replace named-field PrepRecipeParams/Result with agnostic ColStrategy shapes"
+```
+
+---
+
+### Task 2: Rewrite server prepRecipe()
+
+**Files:**
+- Modify: `src/server/index.ts`
+
+**Step 1: Replace the prepRecipe function body**
+
+Find `export function prepRecipe(params: PrepRecipeParams): PrepRecipeResult {` in `src/server/index.ts` and replace the entire function:
+
+```typescript
+export function prepRecipe(params: PrepRecipeParams): PrepRecipeResult {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+  let numRows = 1;
+
+  // Pass 1: scan Drive folders, cache results, determine numRows
+  const folderCache = new Map<string, string[]>();
+  for (const col of params.cols) {
+    if (col.strategy.kind === "list-drive-folder") {
+      const url = col.strategy.url;
+      if (!folderCache.has(url)) {
+        const folder = DriveApp.getFolderById(extractId(url));
+        const files: { url: string }[] = [];
+        getAllFilesRecursive(folder, files);
+        folderCache.set(url, files.map((f) => f.url));
+      }
+      numRows = Math.max(numRows, folderCache.get(url)!.length || 1);
+    }
+  }
+
+  // Pass 2: write all columns
+  for (const col of params.cols) {
+    const colIdx = findOrCreateColumn(sheet, col.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
+    switch (col.strategy.kind) {
+      case "list-drive-folder": {
+        const urls = folderCache.get(col.strategy.url) ?? [];
+        writeColumn(sheet, colIdx, urls, SpreadsheetApp.WrapStrategy.CLIP);
+        break;
+      }
+      case "fill-value":
+        writeColumn(
+          sheet,
+          colIdx,
+          Array(numRows).fill(col.strategy.value) as string[],
+          SpreadsheetApp.WrapStrategy.CLIP,
+        );
+        break;
+      case "create-empty":
+        break;
+    }
+  }
+
+  SpreadsheetApp.flush();
+  return { rowRange: { start: 2, end: 2 + numRows - 1 } };
+}
+```
+
+**Step 2: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: `src/server/index.ts` passes. Remaining errors are in client files (addressed next).
+
+**Step 3: Run tests**
+
+```bash
+npm test
+```
+
+Expected: `__tests__/panels/recipe.test.ts` fails (shape mismatch). All other suites pass.
+
+**Step 4: Commit**
+
+```bash
+git add src/server/index.ts
+git commit -m "refactor: rewrite prepRecipe() to iterate PrepColSpec[] with two-pass folder scan"
+```
+
+---
+
+## Phase 2: Client Types + Recipe Migration
+
+### Task 3: Add new client types to client/types.ts
+
+**Files:**
+- Modify: `src/client/types.ts`
+
+**Step 1: Add new types and replace RecipeParams**
+
+Add to imports at the top of `src/client/types.ts`:
+```typescript
+import type { ToolId } from "../shared/types";
+```
+
+Replace the existing `RecipeParams` interface and add the new types. The full additions/replacements:
+
+```typescript
+export type ColStrategyKind = "list-drive-folder" | "fill-value" | "create-empty";
+export type ColRole = "userPrompt" | "systemPrompt" | "driveLink" | "output";
+
+export interface AppendField {
+  id: string;
+  label: string;
+  placeholder?: string;
+  /** Text injected before the reporter's value, e.g. "\n\nYou are looking for:\n\n" */
+  prefix?: string;
+}
+
+export interface RecipeSettings {
+  tools?: ToolId[];
+  applyMarkdown?: boolean;
+  includeGrounding?: boolean;
+}
+
+export interface ColumnDef {
+  /** UI section heading shown in the recipe panel */
+  label: string;
+  /** How this column maps into RunConfig after prep */
+  role: ColRole;
+  /** What PrepColSpec.strategy type to generate during prep */
+  strategyKind: ColStrategyKind;
+  /** Lockable column header field */
+  colTitle: RecipeFieldConfig;
+  /** Lockable prompt text — present for fill-value columns */
+  prompt?: RecipeFieldConfig;
+  /** Lockable URL input — present for drive columns */
+  url?: RecipeFieldConfig;
+  /** Extra reporter inputs composed into the prompt before prep */
+  appendFields?: AppendField[];
+  helperText?: string;
+  /** Show * in section heading */
+  required?: boolean;
+}
+
+export interface RecipeParams {
+  columns: ColumnDef[];
+  settings?: RecipeSettings;
+}
+```
+
+Remove the old `RecipeParams` interface (with `driveFolder?`, `systemPrompt?`, `userPrompts?`, `outputCol?`).
+
+`RecipeDefinition` is unchanged — `params?: RecipeParams` already references the updated type.
+
+**Step 2: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: errors in `src/client/recipes.ts` and `src/client/panels/recipe.ts` (they use old RecipeParams shape). Addressed in subsequent tasks.
+
+**Step 3: Commit**
+
+```bash
+git add src/client/types.ts
+git commit -m "refactor: replace named-field RecipeParams with ColumnDef[] + RecipeSettings"
+```
+
+---
+
+### Task 4: Migrate document-summarization recipe
+
+**Files:**
+- Modify: `src/client/recipes.ts`
+
+**Step 1: Rewrite the document-summarization recipe entry**
+
+Replace the entire `document-summarization` entry in `RECIPES` with:
+
+```typescript
+{
+  id: "document-summarization",
+  name: "Document Summarization",
+  icon: "📄",
+  description: "Summarize each file in a Google Drive folder",
+  panelId: "recipe",
+  params: {
+    columns: [
+      {
+        label: "Drive Folder",
+        role: "driveLink",
+        strategyKind: "list-drive-folder",
+        colTitle: { value: "Drive Link", locked: true },
+        url: { value: "", locked: false, placeholder: "Paste Google Drive folder URL" },
+        helperText: "Make sure you have access to this folder",
+        required: true,
+      },
+      {
+        label: "System Prompt",
+        role: "systemPrompt",
+        strategyKind: "fill-value",
+        colTitle: { value: "System Prompt", locked: true },
+        prompt: {
+          value:
+            "You are an expert document analyst. Produce clear, structured summaries " +
+            "focusing on key themes, main arguments, important data points, and actionable conclusions.",
+          locked: true,
+        },
+      },
+      {
+        label: "User Prompt",
+        role: "userPrompt",
+        strategyKind: "fill-value",
+        colTitle: { value: "User Prompt", locked: true },
+        prompt: {
+          value:
+            "Please summarize the attached document. Include the main topics, key findings, " +
+            "and important conclusions. The document file will be attached as inline data.",
+          locked: true,
+        },
+      },
+      {
+        label: "Output Column",
+        role: "output",
+        strategyKind: "create-empty",
+        colTitle: { value: "AI_Summarization", locked: true },
+      },
+    ],
+  } satisfies RecipeParams,
+},
+```
+
+Update the import at the top if needed — `RecipeParams` is still exported from `"./types"`.
+
+**Step 2: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: `src/client/recipes.ts` passes. Remaining errors in `src/client/panels/recipe.ts`.
+
+**Step 3: Commit**
+
+```bash
+git add src/client/recipes.ts
+git commit -m "refactor: migrate document-summarization recipe to ColumnDef[] shape"
+```
+
+---
+
+## Phase 3: RecipePanel Rewrite
+
+This is the largest task. The panel's template, field mounting, prep params, run config assembly, and saved state all change together. Write the tests first, then implement.
+
+### Task 5: Rewrite RecipePanel tests
+
+**Files:**
+- Modify: `__tests__/panels/recipe.test.ts`
+
+**Step 1: Replace the test file**
+
+The new tests use `ColumnDef[]` shape and new DOM IDs (`#col-{i}-title-container`, `#col-{i}-prompt-container`, `#col-{i}-url-input`). Replace the full file:
+
+```typescript
+/**
+ * @jest-environment jsdom
+ */
+jest.mock("../../src/client/services", () => ({
+  prepRecipe: jest.fn(),
+}));
+
+import { RecipePanel } from "../../src/client/panels/recipe";
+import * as services from "../../src/client/services";
+import type { PrepRecipeResult } from "../../src/shared/types";
+import type { ColumnDef, RecipeDefinition, RecipeParams, NavigationContext } from "../../src/client/types";
+
+const mockPrepRecipe = services.prepRecipe as jest.Mock;
+
+function makeNav(): jest.Mocked<NavigationContext> {
+  return {
+    navigate: jest.fn(),
+    back: jest.fn(),
+    canGoBack: jest.fn().mockReturnValue(true),
+  };
+}
+
+function mount(params: RecipeParams, savedState?: unknown) {
+  const container = document.createElement("div");
+  const nav = makeNav();
+  const panel = new RecipePanel();
+  const definition: RecipeDefinition = {
+    id: "test",
+    name: "Test Recipe",
+    icon: "🧪",
+    description: "Test",
+    panelId: "recipe",
+    params,
+  };
+  panel.mount(container, nav, definition, savedState as never);
+  return { container, nav, panel, definition };
+}
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+// helper: a minimal column set covering all roles
+const fullColumns: ColumnDef[] = [
+  {
+    label: "Drive Folder",
+    role: "driveLink",
+    strategyKind: "list-drive-folder",
+    colTitle: { value: "Drive Link", locked: true },
+    url: { value: "", locked: false, placeholder: "Paste folder URL" },
+    required: true,
+  },
+  {
+    label: "System Prompt",
+    role: "systemPrompt",
+    strategyKind: "fill-value",
+    colTitle: { value: "System Prompt", locked: true },
+    prompt: { value: "You are helpful.", locked: true },
+  },
+  {
+    label: "User Prompt",
+    role: "userPrompt",
+    strategyKind: "fill-value",
+    colTitle: { value: "User Prompt", locked: true },
+    prompt: { value: "Summarize.", locked: true },
+  },
+  {
+    label: "Output Column",
+    role: "output",
+    strategyKind: "create-empty",
+    colTitle: { value: "AI_Out", locked: true },
+  },
+];
+
+const mockResult: PrepRecipeResult = {
+  rowRange: { start: 2, end: 11 },
+};
+
+// ── rendering ───────────────────────────────────────────────────
+
+describe("rendering", () => {
+  it("renders a url input for list-drive-folder columns", () => {
+    const { container } = mount({ columns: [fullColumns[0]] });
+    expect(container.querySelector("#col-0-url-input")).not.toBeNull();
+  });
+
+  it("does not render url input for fill-value columns", () => {
+    const { container } = mount({ columns: [fullColumns[2]] });
+    expect(container.querySelector("#col-0-url-input")).toBeNull();
+  });
+
+  it("renders a prompt container for fill-value columns", () => {
+    const { container } = mount({ columns: [fullColumns[1]] });
+    expect(container.querySelector("#col-0-prompt-container")).not.toBeNull();
+  });
+
+  it("does not render prompt container for create-empty columns", () => {
+    const { container } = mount({ columns: [fullColumns[3]] });
+    expect(container.querySelector("#col-0-prompt-container")).toBeNull();
+  });
+
+  it("renders one section per ColumnDef", () => {
+    const { container } = mount({ columns: fullColumns });
+    expect(container.querySelectorAll(".recipe-section-card")).toHaveLength(fullColumns.length);
+  });
+
+  it("renders append field inputs when appendFields present", () => {
+    const colWithAppend: ColumnDef = {
+      ...fullColumns[2],
+      appendFields: [{ id: "search", label: "What are you looking for?" }],
+    };
+    const { container } = mount({ columns: [colWithAppend] });
+    expect(container.querySelector("#col-0-append-search")).not.toBeNull();
+  });
+});
+
+// ── LockableField defaults ────────────────────────────────────────
+
+describe("LockableField defaults", () => {
+  it("initialises locked colTitle field as disabled", () => {
+    const { container } = mount({ columns: [fullColumns[3]] });
+    const input = container.querySelector<HTMLInputElement>("#col-0-title-container input")!;
+    expect(input.value).toBe("AI_Out");
+    expect(input.disabled).toBe(true);
+  });
+
+  it("initialises unlocked url field as enabled", () => {
+    const { container } = mount({ columns: [fullColumns[0]] });
+    const input = container.querySelector<HTMLInputElement>("#col-0-url-input")!;
+    expect(input.disabled).toBe(false);
+  });
+});
+
+// ── prep flow ──────────────────────────────────────────────────
+
+describe("Prep flow", () => {
+  beforeEach(() => mockPrepRecipe.mockClear());
+
+  it("calls services.prepRecipe with PrepColSpec[] built from resolved field values", async () => {
+    mockPrepRecipe.mockResolvedValue(mockResult);
+    const { container } = mount({ columns: fullColumns });
+    container.querySelector<HTMLInputElement>("#col-0-url-input")!.value =
+      "https://drive.google.com/drive/folders/abc123";
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    expect(mockPrepRecipe).toHaveBeenCalledWith({
+      cols: [
+        { colTitle: "Drive Link", strategy: { kind: "list-drive-folder", url: "https://drive.google.com/drive/folders/abc123" } },
+        { colTitle: "System Prompt", strategy: { kind: "fill-value", value: "You are helpful." } },
+        { colTitle: "User Prompt", strategy: { kind: "fill-value", value: "Summarize." } },
+        { colTitle: "AI_Out", strategy: { kind: "create-empty" } },
+      ],
+    });
+  });
+
+  it("composes appendFields into the fill-value prompt string", async () => {
+    mockPrepRecipe.mockResolvedValue(mockResult);
+    const colWithAppend: ColumnDef = {
+      ...fullColumns[2],
+      appendFields: [{ id: "search", label: "What?", prefix: "\n\nLooking for:\n\n" }],
+    };
+    const { container } = mount({ columns: [colWithAppend] });
+    container.querySelector<HTMLInputElement>("#col-0-append-search")!.value = "a signature";
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    expect(mockPrepRecipe).toHaveBeenCalledWith({
+      cols: [
+        {
+          colTitle: "User Prompt",
+          strategy: { kind: "fill-value", value: "Summarize.\n\nLooking for:\n\na signature" },
+        },
+      ],
+    });
+  });
+
+  it("shows alert and does not call prepRecipe when url input is empty for list-drive-folder", async () => {
+    const alertMock = jest.fn();
+    globalThis.alert = alertMock;
+    const { container } = mount({ columns: [fullColumns[0]] });
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    expect(alertMock).toHaveBeenCalledTimes(1);
+    expect(mockPrepRecipe).not.toHaveBeenCalled();
+  });
+});
+
+// ── Cook flow ──────────────────────────────────────────────────
+
+describe("Cook flow", () => {
+  it("navigates to configure-ai-run with RunConfig assembled from ColumnDef roles + rowRange", async () => {
+    mockPrepRecipe.mockResolvedValue({ rowRange: { start: 2, end: 5 } });
+    const { container, nav } = mount({ columns: fullColumns });
+    container.querySelector<HTMLInputElement>("#col-0-url-input")!.value =
+      "https://drive.google.com/abc";
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    container.querySelector<HTMLButtonElement>("#cook-btn")!.click();
+    expect(nav.navigate).toHaveBeenCalledWith("configure-ai-run", {
+      promptCols: [
+        { col: "Drive Link", kind: "file" },
+        { col: "User Prompt", kind: "text" },
+      ],
+      systemPromptCol: "System Prompt",
+      outputCol: "AI_Out",
+      rowRange: { start: 2, end: 5 },
+    });
+  });
+
+  it("spreads RecipeSettings into RunConfig", async () => {
+    mockPrepRecipe.mockResolvedValue({ rowRange: { start: 2, end: 3 } });
+    const outputOnly: ColumnDef = fullColumns[3];
+    const { container, nav } = mount({
+      columns: [outputOnly],
+      settings: { tools: ["google_search"], applyMarkdown: true },
+    });
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    container.querySelector<HTMLButtonElement>("#cook-btn")!.click();
+    expect(nav.navigate).toHaveBeenCalledWith("configure-ai-run",
+      expect.objectContaining({ tools: ["google_search"], applyMarkdown: true }),
+    );
+  });
+});
+
+// ── saved state ────────────────────────────────────────────────
+
+describe("unmount / saved state", () => {
+  it("unmount returns colValues array and prepComplete: false when not prepped", () => {
+    const { container, panel } = mount({ columns: [fullColumns[0]] });
+    container.querySelector<HTMLInputElement>("#col-0-url-input")!.value = "my-folder-url";
+    const state = panel.unmount();
+    expect(state).toMatchObject({
+      colValues: [expect.objectContaining({ url: "my-folder-url" })],
+      prepComplete: false,
+    });
+  });
+
+  it("restores url value from savedState", () => {
+    const savedState = {
+      colValues: [{ url: "restored-url" }],
+      prepComplete: false,
+    };
+    const { container } = mount({ columns: [fullColumns[0]] }, savedState);
+    expect(container.querySelector<HTMLInputElement>("#col-0-url-input")!.value).toBe("restored-url");
+  });
+
+  it("mounts with savedState prepComplete: true — Cook is enabled", () => {
+    const savedState = {
+      colValues: [{}],
+      prepComplete: true,
+      preppedRunConfig: { outputCol: "Out", promptCols: [] },
+    };
+    const { container } = mount({ columns: [fullColumns[3]] }, savedState);
+    expect(container.querySelector<HTMLButtonElement>("#cook-btn")!.disabled).toBe(false);
+  });
+});
+```
+
+**Step 2: Run the new tests to verify they all fail**
+
+```bash
+npx jest __tests__/panels/recipe.test.ts
+```
+
+Expected: multiple failures — DOM IDs not found, shape mismatches. This confirms the tests are exercising the right new behavior.
+
+---
+
+### Task 6: Rewrite RecipePanel
+
+**Files:**
+- Modify: `src/client/panels/recipe.ts`
+
+**Step 1: Replace the full file**
+
+The panel's private fields, SavedState, template, mountFields, buildPrepParams, buildRunConfig, and unmount all change. Replace the full file content:
+
+```typescript
+import type { NavigationContext, Panel, RecipeDefinition, ColumnDef } from "../types";
+import type { ColStrategy, PrepColSpec, PrepRecipeParams, PrepRecipeResult, RunConfig, PromptColumnSpec } from "../../shared/types";
+import { LockableField } from "../components/lockable-field";
+import { RecipePrepCook } from "../components/recipe-prep-cook";
+import { prepRecipe } from "../services";
+
+type ColFieldRefs = {
+  colTitle?: LockableField;
+  prompt?: LockableField;
+  urlInput?: HTMLInputElement;
+  appendInputs?: Record<string, HTMLInputElement>;
+};
+
+type ColSavedValues = {
+  colTitle?: string;
+  prompt?: string;
+  url?: string;
+  appendValues?: Record<string, string>;
+};
+
+type SavedState = {
+  colValues: ColSavedValues[];
+  prepComplete: boolean;
+  preppedRunConfig?: Partial<RunConfig>;
+};
+
+export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
+  private nav: NavigationContext | null = null;
+  private definition: RecipeDefinition | null = null;
+  private prepCook: RecipePrepCook | null = null;
+  private preppedRunConfig: Partial<RunConfig> | null = null;
+  private fields: ColFieldRefs[] = [];
+
+  mount(
+    container: HTMLElement,
+    nav: NavigationContext,
+    definition?: RecipeDefinition,
+    savedState?: SavedState,
+  ): void {
+    this.nav = nav;
+    this.definition = definition ?? null;
+    this.fields = [];
+    this.preppedRunConfig = savedState?.preppedRunConfig ?? null;
+
+    container.innerHTML = this.template(definition);
+    container.querySelector("#back-btn")?.addEventListener("click", () => nav.back());
+
+    this.mountFields(container, definition?.params?.columns ?? [], savedState);
+    this.mountPrepCook(container, savedState?.prepComplete ?? false);
+  }
+
+  unmount(): SavedState {
+    const colValues: ColSavedValues[] = this.fields.map((f) => ({
+      colTitle: f.colTitle?.getValue(),
+      prompt: f.prompt?.getValue(),
+      url: f.urlInput?.value,
+      appendValues: f.appendInputs
+        ? Object.fromEntries(
+            Object.entries(f.appendInputs).map(([id, el]) => [id, el.value]),
+          )
+        : undefined,
+    }));
+    return {
+      colValues,
+      prepComplete: this.prepCook?.isPrepComplete() ?? false,
+      preppedRunConfig: this.preppedRunConfig ?? undefined,
+    };
+  }
+
+  private mountFields(
+    container: HTMLElement,
+    columns: ColumnDef[],
+    savedState?: SavedState,
+  ): void {
+    const reset = (): void => this.prepCook?.reset();
+
+    columns.forEach((col, i) => {
+      const saved = savedState?.colValues?.[i];
+      const refs: ColFieldRefs = {};
+
+      refs.colTitle = new LockableField(
+        container.querySelector(`#col-${i}-title-container`)!,
+        {
+          label: "Column",
+          defaultValue: saved?.colTitle ?? col.colTitle.value,
+          locked: col.colTitle.locked,
+          onUnlock: reset,
+        },
+      );
+
+      if (col.prompt !== undefined) {
+        refs.prompt = new LockableField(
+          container.querySelector(`#col-${i}-prompt-container`)!,
+          {
+            label: "Prompt",
+            defaultValue: saved?.prompt ?? col.prompt.value,
+            locked: col.prompt.locked,
+            multiline: true,
+            onUnlock: reset,
+          },
+        );
+      }
+
+      if (col.url !== undefined) {
+        const urlEl = container.querySelector<HTMLInputElement>(`#col-${i}-url-input`);
+        if (urlEl) {
+          if (saved?.url) urlEl.value = saved.url;
+          urlEl.addEventListener("input", reset);
+          refs.urlInput = urlEl;
+        }
+      }
+
+      if (col.appendFields?.length) {
+        refs.appendInputs = {};
+        for (const af of col.appendFields) {
+          const el = container.querySelector<HTMLInputElement>(`#col-${i}-append-${af.id}`);
+          if (el) {
+            if (saved?.appendValues?.[af.id]) el.value = saved.appendValues[af.id];
+            refs.appendInputs[af.id] = el;
+          }
+        }
+      }
+
+      this.fields[i] = refs;
+    });
+  }
+
+  private mountPrepCook(container: HTMLElement, prepComplete: boolean): void {
+    this.prepCook = new RecipePrepCook(container.querySelector("#prep-cook-container")!, {
+      onPrep: async (): Promise<void> => {
+        const params = this.buildPrepParams();
+        if (!params) throw null;
+        const result = await prepRecipe(params);
+        this.preppedRunConfig = this.buildRunConfig(result);
+      },
+      onCook: (): void => {
+        if (this.preppedRunConfig) {
+          this.nav?.navigate("configure-ai-run", this.preppedRunConfig);
+        }
+      },
+      prepComplete,
+    });
+  }
+
+  private buildPrepParams(): PrepRecipeParams | null {
+    const columns = this.definition?.params?.columns ?? [];
+    const cols: PrepColSpec[] = [];
+
+    for (let i = 0; i < columns.length; i++) {
+      const col = columns[i];
+      const colTitle = this.fields[i]?.colTitle?.getValue() ?? col.colTitle.value;
+
+      let strategy: ColStrategy;
+      switch (col.strategyKind) {
+        case "list-drive-folder": {
+          const url = this.fields[i]?.urlInput?.value.trim() ?? "";
+          if (!url) {
+            globalThis.alert(`Please enter a URL for "${col.label}".`);
+            return null;
+          }
+          strategy = { kind: "list-drive-folder", url };
+          break;
+        }
+        case "fill-value": {
+          const base = this.fields[i]?.prompt?.getValue() ?? col.prompt?.value ?? "";
+          const appended = (col.appendFields ?? [])
+            .map((af) => {
+              const v = this.fields[i]?.appendInputs?.[af.id]?.value.trim() ?? "";
+              return v ? (af.prefix ?? "") + v : "";
+            })
+            .join("");
+          strategy = { kind: "fill-value", value: base + appended };
+          break;
+        }
+        case "create-empty":
+          strategy = { kind: "create-empty" };
+          break;
+      }
+
+      cols.push({ colTitle, strategy });
+    }
+
+    return { cols };
+  }
+
+  private buildRunConfig(result: PrepRecipeResult): Partial<RunConfig> {
+    const columns = this.definition?.params?.columns ?? [];
+    const settings = this.definition?.params?.settings ?? {};
+    const promptCols: PromptColumnSpec[] = [];
+    let systemPromptCol: string | undefined;
+    let outputCol = "";
+
+    for (let i = 0; i < columns.length; i++) {
+      const col = columns[i];
+      const resolvedTitle = this.fields[i]?.colTitle?.getValue() ?? col.colTitle.value;
+
+      switch (col.role) {
+        case "userPrompt":
+          promptCols.push({ col: resolvedTitle, kind: "text" });
+          break;
+        case "driveLink":
+          promptCols.push({ col: resolvedTitle, kind: "file" });
+          break;
+        case "systemPrompt":
+          systemPromptCol = resolvedTitle;
+          break;
+        case "output":
+          outputCol = resolvedTitle;
+          break;
+      }
+    }
+
+    return { promptCols, systemPromptCol, outputCol, rowRange: result.rowRange, ...settings };
+  }
+
+  private template(definition: RecipeDefinition | undefined | null): string {
+    const columns = definition?.params?.columns ?? [];
+    const title = definition ? `${definition.icon} ${definition.name}` : "Recipe";
+
+    const columnSections = columns
+      .map((col, i) => {
+        const requiredMark = col.required ? ` <span class="required">*</span>` : "";
+        const helperHtml = col.helperText ? `<p class="field-helper">${col.helperText}</p>` : "";
+
+        const urlInputHtml =
+          col.url !== undefined
+            ? `<input id="col-${i}-url-input" type="text" class="text-input"
+                placeholder="${col.url.placeholder ?? "Paste Google Drive URL"}" />`
+            : "";
+
+        const promptContainerHtml =
+          col.prompt !== undefined ? `<div id="col-${i}-prompt-container"></div>` : "";
+
+        const appendFieldsHtml = (col.appendFields ?? [])
+          .map(
+            (af) =>
+              `<div class="append-field">
+                <label class="field-label">${af.label}</label>
+                <input id="col-${i}-append-${af.id}" type="text" class="text-input"
+                  placeholder="${af.placeholder ?? ""}" />
+              </div>`,
+          )
+          .join("");
+
+        return `
+          <div class="recipe-section-card">
+            <div class="recipe-section-card-title">${col.label}${requiredMark}</div>
+            ${helperHtml}
+            <div id="col-${i}-title-container"></div>
+            ${urlInputHtml}
+            ${promptContainerHtml}
+            ${appendFieldsHtml}
+          </div>`;
+      })
+      .join("");
+
+    return `
+      <div class="panel-header">
+        <button id="back-btn" class="back-btn">← Back</button>
+        <span class="panel-title">${title}</span>
+      </div>
+      ${columnSections}
+      <div id="prep-cook-container"></div>
+    `;
+  }
+}
+```
+
+**Step 2: Run the recipe panel tests**
+
+```bash
+npx jest __tests__/panels/recipe.test.ts
+```
+
+Expected: all tests pass.
+
+**Step 3: Run the full test suite**
+
+```bash
+npm test
+```
+
+Expected: all 332+ tests pass. Fix any unexpected failures before proceeding.
+
+**Step 4: Run typecheck and lint**
+
+```bash
+npm run typecheck && npm run lint
+```
+
+Expected: no errors.
+
+**Step 5: Commit**
+
+```bash
+git add src/client/panels/recipe.ts __tests__/panels/recipe.test.ts
+git commit -m "refactor: rewrite RecipePanel for ColumnDef[] — agnostic column specs, role-based RunConfig assembly"
+```
+
+---
+
+## Final Verification
+
+**Step 1: Full test suite with coverage**
+
+```bash
+npm run test:coverage
+```
+
+Expected: all tests pass, all per-file thresholds met.
+
+**Step 2: Typecheck both configs**
+
+```bash
+npm run typecheck
+```
+
+Expected: clean.
+
+**Step 3: Lint**
+
+```bash
+npm run lint
+```
+
+Expected: clean.
+
+**Step 4: Final commit if anything was cleaned up**
+
+If clean, no commit needed. The branch is ready for PR to `develop`.

--- a/docs/plans/2026-03-26-recipe-prep-redesign.md
+++ b/docs/plans/2026-03-26-recipe-prep-redesign.md
@@ -1,0 +1,400 @@
+# Recipe Prep Redesign: Agnostic Column Specs
+
+**Date:** 2026-03-26
+**Status:** Design complete, implementation plan ready
+
+---
+
+## Motivation
+
+The existing `PrepRecipeParams` conflates three separate concerns in one named-field shape:
+- **Population strategy** — how the server fills a column (scan a folder, fill a value, create empty)
+- **Semantic role** — what the column means in a RunConfig (file input, text prompt, system prompt, output)
+- **UI configuration** — what fields to render and what their defaults/locks are
+
+This made the "single source of truth" invariant (`preppedRunConfig` assembled from `PrepRecipeResult` alone) load-bearing. But that invariant was solving the wrong problem: users **should** be able to modify column titles, prompt values, and settings between prep and cook. Once that's accepted, `PrepRecipeResult` no longer needs to echo anything back — the client already has everything except the row count.
+
+A secondary issue: `PrepRecipeResult` echoed `tools` and `colNames` back from the server despite the server doing no processing on them. These were only there to preserve the invariant.
+
+---
+
+## Design
+
+### Core Insight
+
+Split the three concerns across the right owners:
+
+| Concern | Owner | Lives in |
+|---|---|---|
+| Population strategy | Server | `PrepColSpec.strategy` (sent in `PrepRecipeParams`) |
+| Semantic role | Client | `ColumnDef.role` (recipe definition, never sent to server) |
+| UI configuration | Client | `ColumnDef.colTitle / prompt / url / appendFields` |
+
+`PrepRecipeResult` shrinks to just `{ rowRange }` — the only thing the client genuinely couldn't know before prep ran.
+
+---
+
+### Shared Types (`src/shared/types.ts`)
+
+```typescript
+export type ColStrategy =
+  | { kind: "list-drive-folder"; url: string }  // scan folder, one row per file
+  | { kind: "fill-value"; value: string }        // fill N rows with the same value
+  | { kind: "create-empty" };                    // create column header only
+
+export interface PrepColSpec {
+  colTitle: string;
+  strategy: ColStrategy;
+}
+
+export interface PrepRecipeParams {
+  cols: PrepColSpec[];
+}
+
+export interface PrepRecipeResult {
+  rowRange: { start: number; end: number };
+}
+```
+
+`tools`, `colNames`, and the `settings` echo are all removed. The old named-field `PrepRecipeParams` and `PrepRecipeResult` are replaced entirely.
+
+---
+
+### Client Types (`src/client/types.ts`)
+
+```typescript
+export type ColStrategyKind = "list-drive-folder" | "fill-value" | "create-empty";
+export type ColRole = "userPrompt" | "systemPrompt" | "driveLink" | "output";
+
+export interface AppendField {
+  id: string;
+  label: string;
+  placeholder?: string;
+  /** Injected before the reporter's value when composing the final prompt string. */
+  prefix?: string;
+}
+
+export interface RecipeSettings {
+  tools?: ToolId[];
+  applyMarkdown?: boolean;
+  includeGrounding?: boolean;
+}
+
+export interface ColumnDef {
+  label: string;                  // UI section heading ("Drive Folder", "System Prompt", …)
+  role: ColRole;                  // how this column maps into RunConfig
+  strategyKind: ColStrategyKind;  // what PrepColSpec.strategy type to generate
+  colTitle: RecipeFieldConfig;    // lockable column header field
+  prompt?: RecipeFieldConfig;     // lockable prompt text (for fill-value columns)
+  url?: RecipeFieldConfig;        // lockable URL input (for drive columns)
+  appendFields?: AppendField[];   // extra reporter inputs appended to prompt before prep
+  helperText?: string;
+  required?: boolean;             // shows * in section heading
+}
+
+export interface RecipeParams {
+  columns: ColumnDef[];
+  settings?: RecipeSettings;
+}
+```
+
+`RecipeDefinition` is unchanged structurally — `params?: RecipeParams` already references the updated type.
+
+---
+
+### Server `prepRecipe()` (`src/server/index.ts`)
+
+Two-pass approach to avoid double folder scans:
+
+```typescript
+export function prepRecipe(params: PrepRecipeParams): PrepRecipeResult {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+  let numRows = 1;
+
+  // Pass 1: scan folders, build URL cache, determine numRows
+  const folderCache = new Map<string, string[]>();
+  for (const col of params.cols) {
+    if (col.strategy.kind === "list-drive-folder") {
+      const url = col.strategy.url;
+      if (!folderCache.has(url)) {
+        const folder = DriveApp.getFolderById(extractId(url));
+        const files: { url: string }[] = [];
+        getAllFilesRecursive(folder, files);
+        folderCache.set(url, files.map((f) => f.url));
+      }
+      numRows = Math.max(numRows, folderCache.get(url)!.length || 1);
+    }
+  }
+
+  // Pass 2: write all columns
+  for (const col of params.cols) {
+    const colIdx = findOrCreateColumn(sheet, col.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
+    switch (col.strategy.kind) {
+      case "list-drive-folder": {
+        const urls = folderCache.get(col.strategy.url) ?? [];
+        writeColumn(sheet, colIdx, urls, SpreadsheetApp.WrapStrategy.CLIP);
+        break;
+      }
+      case "fill-value":
+        writeColumn(
+          sheet, colIdx,
+          Array(numRows).fill(col.strategy.value) as string[],
+          SpreadsheetApp.WrapStrategy.CLIP,
+        );
+        break;
+      case "create-empty":
+        break; // findOrCreateColumn already created the header
+    }
+  }
+
+  SpreadsheetApp.flush();
+  return { rowRange: { start: 2, end: 2 + numRows - 1 } };
+}
+```
+
+---
+
+### Client `buildPrepParams()` (`src/client/panels/recipe.ts`)
+
+Iterates `ColumnDef[]`, resolves UI field values, constructs `PrepColSpec[]`. `appendFields` are composed into the prompt string before the server sees anything:
+
+```typescript
+private buildPrepParams(): PrepRecipeParams | null {
+  const columns = this.definition!.params!.columns;
+  const cols: PrepColSpec[] = [];
+
+  for (let i = 0; i < columns.length; i++) {
+    const col = columns[i];
+    const colTitle = this.fields[i].colTitle?.getValue() ?? col.colTitle.value;
+
+    let strategy: ColStrategy;
+    switch (col.strategyKind) {
+      case "list-drive-folder": {
+        const url = this.fields[i].url?.value.trim() ?? "";
+        if (!url) {
+          globalThis.alert(`Please enter a URL for "${col.label}".`);
+          return null;
+        }
+        strategy = { kind: "list-drive-folder", url };
+        break;
+      }
+      case "fill-value": {
+        const base = this.fields[i].prompt?.getValue() ?? col.prompt?.value ?? "";
+        const appended = (col.appendFields ?? [])
+          .map((af) => {
+            const v = this.fields[i].appendInputs?.[af.id]?.value.trim() ?? "";
+            return v ? (af.prefix ?? "") + v : "";
+          })
+          .join("");
+        strategy = { kind: "fill-value", value: base + appended };
+        break;
+      }
+      case "create-empty":
+        strategy = { kind: "create-empty" };
+        break;
+    }
+
+    cols.push({ colTitle, strategy });
+  }
+
+  return { cols };
+}
+```
+
+---
+
+### Client `buildRunConfig()` (`src/client/panels/recipe.ts`)
+
+Reads `ColumnDef.role` for RunConfig mapping. `tools` and other settings come from `definition.params.settings`, not from the server result:
+
+```typescript
+private buildRunConfig(result: PrepRecipeResult): Partial<RunConfig> {
+  const columns = this.definition!.params!.columns ?? [];
+  const settings = this.definition!.params!.settings ?? {};
+  const promptCols: PromptColumnSpec[] = [];
+  let systemPromptCol: string | undefined;
+  let outputCol = "";
+
+  for (let i = 0; i < columns.length; i++) {
+    const col = columns[i];
+    const resolvedTitle = this.fields[i].colTitle?.getValue() ?? col.colTitle.value;
+
+    switch (col.role) {
+      case "userPrompt":
+        promptCols.push({ col: resolvedTitle, kind: "text" });
+        break;
+      case "driveLink":
+        promptCols.push({ col: resolvedTitle, kind: "file" });
+        break;
+      case "systemPrompt":
+        systemPromptCol = resolvedTitle;
+        break;
+      case "output":
+        outputCol = resolvedTitle;
+        break;
+    }
+  }
+
+  return {
+    promptCols,
+    systemPromptCol,
+    outputCol,
+    rowRange: result.rowRange,
+    ...settings,
+  };
+}
+```
+
+---
+
+### Saved State
+
+Named fields are replaced with a column-indexed array:
+
+```typescript
+type ColSavedValues = {
+  colTitle?: string;
+  prompt?: string;
+  url?: string;
+  appendValues?: Record<string, string>;
+};
+
+type SavedState = {
+  colValues: ColSavedValues[];
+  prepComplete: boolean;
+  preppedRunConfig?: Partial<RunConfig>;
+};
+```
+
+---
+
+### `appendFields` flow
+
+`appendFields` live in `ColumnDef` (recipe definition). They are rendered by `RecipePanel` as plain `<input>` elements. When `buildPrepParams()` runs, it reads these inputs and composes them into the `fill-value` strategy's `value` — the server receives the composed string and never knows `appendFields` exist.
+
+---
+
+### Recipe Definition Example: Document Summarization
+
+```typescript
+{
+  id: "document-summarization",
+  name: "Document Summarization",
+  icon: "📄",
+  description: "Summarize each file in a Google Drive folder",
+  panelId: "recipe",
+  params: {
+    columns: [
+      {
+        label: "Drive Folder",
+        role: "driveLink",
+        strategyKind: "list-drive-folder",
+        colTitle: { value: "Drive Link", locked: true },
+        url: { value: "", locked: false, placeholder: "Paste Google Drive folder URL" },
+        helperText: "Make sure you have access to this folder",
+        required: true,
+      },
+      {
+        label: "System Prompt",
+        role: "systemPrompt",
+        strategyKind: "fill-value",
+        colTitle: { value: "System Prompt", locked: true },
+        prompt: {
+          value:
+            "You are an expert document analyst. Produce clear, structured summaries " +
+            "focusing on key themes, main arguments, important data points, and actionable conclusions.",
+          locked: true,
+        },
+      },
+      {
+        label: "User Prompt",
+        role: "userPrompt",
+        strategyKind: "fill-value",
+        colTitle: { value: "User Prompt", locked: true },
+        prompt: {
+          value:
+            "Please summarize the attached document. Include the main topics, key findings, " +
+            "and important conclusions. The document file will be attached as inline data.",
+          locked: true,
+        },
+      },
+      {
+        label: "Output Column",
+        role: "output",
+        strategyKind: "create-empty",
+        colTitle: { value: "AI_Summarization", locked: true },
+      },
+    ],
+  } satisfies RecipeParams,
+},
+```
+
+---
+
+## What This Enables
+
+### Find a Thing in a Thing recipe
+
+```typescript
+columns: [
+  {
+    label: "Documents Folder",
+    role: "driveLink",
+    strategyKind: "list-drive-folder",
+    colTitle: { value: "Drive Link", locked: true },
+    url: { value: "", locked: false },
+    required: true,
+  },
+  {
+    label: "Reference File",
+    role: "driveLink",
+    strategyKind: "fill-value",      // same URL in every row
+    colTitle: { value: "Reference File", locked: true },
+    url: { value: "", locked: false, placeholder: "Paste reference file URL" },
+  },
+  {
+    label: "System Prompt",
+    role: "systemPrompt",
+    strategyKind: "fill-value",
+    colTitle: { value: "System Prompt", locked: true },
+    prompt: { value: "You are a document analyst...", locked: true },
+  },
+  {
+    label: "User Prompt",
+    role: "userPrompt",
+    strategyKind: "fill-value",
+    colTitle: { value: "User Prompt", locked: true },
+    prompt: { value: "Does this document contain the following item?", locked: true },
+    appendFields: [
+      {
+        id: "search-description",
+        label: "What are you looking for?",
+        placeholder: "e.g. a signature, an exhibit sticker, a person's name",
+        prefix: "\n\nYou are specifically looking for:\n\n",
+      },
+    ],
+  },
+  {
+    label: "Output Column",
+    role: "output",
+    strategyKind: "create-empty",
+    colTitle: { value: "AI_FindResult", locked: true },
+  },
+],
+settings: { tools: ["google_search"] },
+```
+
+Note: `fill-value` for a `driveLink` role correctly maps to `{ kind: "file" }` in `promptCols`. The distinction between "folder scan" and "constant file link" is a strategy concern only — both become file parts in the Gemini request.
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `src/shared/types.ts` | Replace `PrepRecipeParams`/`PrepRecipeResult` with new agnostic shapes; add `ColStrategy`, `PrepColSpec` |
+| `src/client/types.ts` | Replace `RecipeParams` named fields with `ColumnDef[]`; add `ColStrategyKind`, `ColRole`, `AppendField`, `RecipeSettings` |
+| `src/client/recipes.ts` | Migrate document-summarization to new `ColumnDef` shape |
+| `src/client/panels/recipe.ts` | Rewrite `template()`, `mountFields()`, `buildPrepParams()`, `buildRunConfig()`, `unmount()` |
+| `src/server/index.ts` | Rewrite `prepRecipe()` to iterate `PrepColSpec[]` with two-pass folder scan |
+| `__tests__/panels/recipe.test.ts` | Rewrite tests for new `ColumnDef` shape and DOM structure |

--- a/src/client/google.d.ts
+++ b/src/client/google.d.ts
@@ -1,6 +1,7 @@
 import type {
   RunConfig,
   PrepRecipeParams,
+  PrepRecipeResult,
   ImportDriveLinksConfig,
   ExtractTextConfig,
 } from "../shared/types";
@@ -14,7 +15,7 @@ declare global {
     runBatchAI(config: RunConfig, jobId?: string): void;
     importDriveLinks(config: ImportDriveLinksConfig, jobId?: string): void;
     extractText(config: ExtractTextConfig, jobId?: string): void;
-    prepRecipe(params: PrepRecipeParams): void;
+    prepRecipe(params: PrepRecipeParams): PrepRecipeResult;
     getJobProgress(jobId: string): void;
   }
 

--- a/src/client/panels/recipe.ts
+++ b/src/client/panels/recipe.ts
@@ -1,5 +1,12 @@
 import type { NavigationContext, Panel, RecipeDefinition, ColumnDef } from "../types";
-import type { ColStrategy, PrepColSpec, PrepRecipeParams, PrepRecipeResult, RunConfig, PromptColumnSpec } from "../../shared/types";
+import type {
+  ColStrategy,
+  PrepColSpec,
+  PrepRecipeParams,
+  PrepRecipeResult,
+  RunConfig,
+  PromptColumnSpec,
+} from "../../shared/types";
 import { LockableField } from "../components/lockable-field";
 import { RecipePrepCook } from "../components/recipe-prep-cook";
 import { prepRecipe } from "../services";
@@ -55,9 +62,7 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
       prompt: f.prompt?.getValue(),
       url: f.urlInput?.value,
       appendValues: f.appendInputs
-        ? Object.fromEntries(
-            Object.entries(f.appendInputs).map(([id, el]) => [id, el.value]),
-          )
+        ? Object.fromEntries(Object.entries(f.appendInputs).map(([id, el]) => [id, el.value]))
         : undefined,
     }));
     return {
@@ -67,38 +72,28 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
     };
   }
 
-  private mountFields(
-    container: HTMLElement,
-    columns: ColumnDef[],
-    savedState?: SavedState,
-  ): void {
+  private mountFields(container: HTMLElement, columns: ColumnDef[], savedState?: SavedState): void {
     const reset = (): void => this.prepCook?.reset();
 
     columns.forEach((col, i) => {
       const saved = savedState?.colValues?.[i];
       const refs: ColFieldRefs = {};
 
-      refs.colTitle = new LockableField(
-        container.querySelector(`#col-${i}-title-container`)!,
-        {
-          label: "Column",
-          defaultValue: saved?.colTitle ?? col.colTitle.value,
-          locked: col.colTitle.locked,
-          onUnlock: reset,
-        },
-      );
+      refs.colTitle = new LockableField(container.querySelector(`#col-${i}-title-container`)!, {
+        label: "Column",
+        defaultValue: saved?.colTitle ?? col.colTitle.value,
+        locked: col.colTitle.locked,
+        onUnlock: reset,
+      });
 
       if (col.prompt !== undefined) {
-        refs.prompt = new LockableField(
-          container.querySelector(`#col-${i}-prompt-container`)!,
-          {
-            label: "Prompt",
-            defaultValue: saved?.prompt ?? col.prompt.value,
-            locked: col.prompt.locked,
-            multiline: true,
-            onUnlock: reset,
-          },
-        );
+        refs.prompt = new LockableField(container.querySelector(`#col-${i}-prompt-container`)!, {
+          label: "Prompt",
+          defaultValue: saved?.prompt ?? col.prompt.value,
+          locked: col.prompt.locked,
+          multiline: true,
+          onUnlock: reset,
+        });
       }
 
       if (col.url !== undefined) {

--- a/src/client/panels/recipe.ts
+++ b/src/client/panels/recipe.ts
@@ -1,22 +1,25 @@
-import type { NavigationContext, Panel, RecipeDefinition } from "../types";
-import type { RecipeParams } from "../types";
-import type {
-  PrepRecipeParams,
-  PrepRecipeResult,
-  RunConfig,
-  PromptColumnSpec,
-} from "../../shared/types";
+import type { NavigationContext, Panel, RecipeDefinition, ColumnDef } from "../types";
+import type { ColStrategy, PrepColSpec, PrepRecipeParams, PrepRecipeResult, RunConfig, PromptColumnSpec } from "../../shared/types";
 import { LockableField } from "../components/lockable-field";
 import { RecipePrepCook } from "../components/recipe-prep-cook";
 import { prepRecipe } from "../services";
 
+type ColFieldRefs = {
+  colTitle?: LockableField;
+  prompt?: LockableField;
+  urlInput?: HTMLInputElement;
+  appendInputs?: Record<string, HTMLInputElement>;
+};
+
+type ColSavedValues = {
+  colTitle?: string;
+  prompt?: string;
+  url?: string;
+  appendValues?: Record<string, string>;
+};
+
 type SavedState = {
-  driveFolderValue?: string;
-  systemPromptTitle?: string;
-  systemPromptValue?: string;
-  userPromptTitles?: string[];
-  userPromptValues?: string[];
-  outputColTitle?: string;
+  colValues: ColSavedValues[];
   prepComplete: boolean;
   preppedRunConfig?: Partial<RunConfig>;
 };
@@ -24,18 +27,9 @@ type SavedState = {
 export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
   private nav: NavigationContext | null = null;
   private definition: RecipeDefinition | null = null;
-  private params: RecipeParams | null = null;
   private prepCook: RecipePrepCook | null = null;
   private preppedRunConfig: Partial<RunConfig> | null = null;
-  private driveFolderInput: HTMLInputElement | null = null;
-
-  private fields: {
-    systemPromptTitle?: LockableField;
-    systemPromptValue?: LockableField;
-    userPromptTitles: LockableField[];
-    userPromptValues: LockableField[];
-    outputColTitle?: LockableField;
-  } = { userPromptTitles: [], userPromptValues: [] };
+  private fields: ColFieldRefs[] = [];
 
   mount(
     container: HTMLElement,
@@ -45,111 +39,97 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
   ): void {
     this.nav = nav;
     this.definition = definition ?? null;
-    this.params = definition?.params ?? {};
-    this.fields = { userPromptTitles: [], userPromptValues: [] };
+    this.fields = [];
     this.preppedRunConfig = savedState?.preppedRunConfig ?? null;
 
-    container.innerHTML = this.template(this.definition);
-
+    container.innerHTML = this.template(definition);
     container.querySelector("#back-btn")?.addEventListener("click", () => nav.back());
 
-    this.mountFields(container, this.params, savedState);
-    this.mountPrepCook(container, savedState?.prepComplete ?? false, container);
+    this.mountFields(container, definition?.params?.columns ?? [], savedState);
+    this.mountPrepCook(container, savedState?.prepComplete ?? false);
   }
 
   unmount(): SavedState {
+    const colValues: ColSavedValues[] = this.fields.map((f) => ({
+      colTitle: f.colTitle?.getValue(),
+      prompt: f.prompt?.getValue(),
+      url: f.urlInput?.value,
+      appendValues: f.appendInputs
+        ? Object.fromEntries(
+            Object.entries(f.appendInputs).map(([id, el]) => [id, el.value]),
+          )
+        : undefined,
+    }));
     return {
-      driveFolderValue: this.driveFolderInput?.value,
-      systemPromptTitle: this.fields.systemPromptTitle?.getValue(),
-      systemPromptValue: this.fields.systemPromptValue?.getValue(),
-      userPromptTitles: this.fields.userPromptTitles.map((f) => f.getValue()),
-      userPromptValues: this.fields.userPromptValues.map((f) => f.getValue()),
-      outputColTitle: this.fields.outputColTitle?.getValue(),
+      colValues,
       prepComplete: this.prepCook?.isPrepComplete() ?? false,
       preppedRunConfig: this.preppedRunConfig ?? undefined,
     };
   }
 
-  private mountFields(container: HTMLElement, params: RecipeParams, savedState?: SavedState): void {
+  private mountFields(
+    container: HTMLElement,
+    columns: ColumnDef[],
+    savedState?: SavedState,
+  ): void {
     const reset = (): void => this.prepCook?.reset();
 
-    if (params.driveFolder) {
-      this.driveFolderInput = container.querySelector<HTMLInputElement>("#drive-folder-input");
-      if (savedState?.driveFolderValue && this.driveFolderInput) {
-        this.driveFolderInput.value = savedState.driveFolderValue;
-      }
-      this.driveFolderInput?.addEventListener("input", reset);
-    }
+    columns.forEach((col, i) => {
+      const saved = savedState?.colValues?.[i];
+      const refs: ColFieldRefs = {};
 
-    if (params.systemPrompt) {
-      this.fields.systemPromptTitle = new LockableField(
-        container.querySelector("#system-prompt-title-container")!,
+      refs.colTitle = new LockableField(
+        container.querySelector(`#col-${i}-title-container`)!,
         {
           label: "Column",
-          defaultValue: savedState?.systemPromptTitle ?? params.systemPrompt.colTitle.value,
-          locked: params.systemPrompt.colTitle.locked,
+          defaultValue: saved?.colTitle ?? col.colTitle.value,
+          locked: col.colTitle.locked,
           onUnlock: reset,
         },
       );
-      this.fields.systemPromptValue = new LockableField(
-        container.querySelector("#system-prompt-value-container")!,
-        {
-          label: "Prompt",
-          defaultValue: savedState?.systemPromptValue ?? params.systemPrompt.prompt.value,
-          locked: params.systemPrompt.prompt.locked,
-          multiline: true,
-          onUnlock: reset,
-        },
-      );
-    }
 
-    if (params.userPrompts) {
-      params.userPrompts.forEach((up, i) => {
-        this.fields.userPromptTitles[i] = new LockableField(
-          container.querySelector(`#user-prompt-title-${i}-container`)!,
-          {
-            label: "Column",
-            defaultValue: savedState?.userPromptTitles?.[i] ?? up.colTitle.value,
-            locked: up.colTitle.locked,
-            onUnlock: reset,
-          },
-        );
-        this.fields.userPromptValues[i] = new LockableField(
-          container.querySelector(`#user-prompt-value-${i}-container`)!,
+      if (col.prompt !== undefined) {
+        refs.prompt = new LockableField(
+          container.querySelector(`#col-${i}-prompt-container`)!,
           {
             label: "Prompt",
-            defaultValue: savedState?.userPromptValues?.[i] ?? up.prompt.value,
-            locked: up.prompt.locked,
+            defaultValue: saved?.prompt ?? col.prompt.value,
+            locked: col.prompt.locked,
             multiline: true,
             onUnlock: reset,
           },
         );
-      });
-    }
+      }
 
-    if (params.outputCol) {
-      this.fields.outputColTitle = new LockableField(
-        container.querySelector("#output-col-title-container")!,
-        {
-          label: "Column",
-          defaultValue: savedState?.outputColTitle ?? params.outputCol.colTitle.value,
-          locked: params.outputCol.colTitle.locked,
-          onUnlock: reset,
-        },
-      );
-    }
+      if (col.url !== undefined) {
+        const urlEl = container.querySelector<HTMLInputElement>(`#col-${i}-url-input`);
+        if (urlEl) {
+          if (saved?.url) urlEl.value = saved.url;
+          urlEl.addEventListener("input", reset);
+          refs.urlInput = urlEl;
+        }
+      }
+
+      if (col.appendFields?.length) {
+        refs.appendInputs = {};
+        for (const af of col.appendFields) {
+          const el = container.querySelector<HTMLInputElement>(`#col-${i}-append-${af.id}`);
+          if (el) {
+            if (saved?.appendValues?.[af.id]) el.value = saved.appendValues[af.id];
+            refs.appendInputs[af.id] = el;
+          }
+        }
+      }
+
+      this.fields[i] = refs;
+    });
   }
 
-  private mountPrepCook(
-    container: HTMLElement,
-    prepComplete: boolean,
-    _panelContainer: HTMLElement,
-  ): void {
+  private mountPrepCook(container: HTMLElement, prepComplete: boolean): void {
     this.prepCook = new RecipePrepCook(container.querySelector("#prep-cook-container")!, {
       onPrep: async (): Promise<void> => {
         const params = this.buildPrepParams();
-        if (!params) throw null; // validation alert already shown; bail silently
-
+        if (!params) throw null;
         const result = await prepRecipe(params);
         this.preppedRunConfig = this.buildRunConfig(result);
       },
@@ -163,107 +143,123 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
   }
 
   private buildPrepParams(): PrepRecipeParams | null {
-    const params = this.params!;
-    const result: PrepRecipeParams = {};
+    const columns = this.definition?.params?.columns ?? [];
+    const cols: PrepColSpec[] = [];
 
-    if (params.driveFolder) {
-      const url = this.driveFolderInput?.value.trim() ?? "";
-      if (!url) {
-        globalThis.alert("Please enter a Google Drive folder link.");
-        return null;
+    for (let i = 0; i < columns.length; i++) {
+      const col = columns[i];
+      const colTitle = this.fields[i]?.colTitle?.getValue() ?? col.colTitle.value;
+
+      let strategy: ColStrategy;
+      switch (col.strategyKind) {
+        case "list-drive-folder": {
+          const url = this.fields[i]?.urlInput?.value.trim() ?? "";
+          if (!url) {
+            globalThis.alert(`Please enter a URL for "${col.label}".`);
+            return null;
+          }
+          strategy = { kind: "list-drive-folder", url };
+          break;
+        }
+        case "fill-value": {
+          const base = this.fields[i]?.prompt?.getValue() ?? col.prompt?.value ?? "";
+          const appended = (col.appendFields ?? [])
+            .map((af) => {
+              const v = this.fields[i]?.appendInputs?.[af.id]?.value.trim() ?? "";
+              return v ? (af.prefix ?? "") + v : "";
+            })
+            .join("");
+          strategy = { kind: "fill-value", value: base + appended };
+          break;
+        }
+        case "create-empty":
+          strategy = { kind: "create-empty" };
+          break;
       }
-      result.driveFolder = { url, colTitle: params.driveFolder.colTitle };
+
+      cols.push({ colTitle, strategy });
     }
 
-    if (params.systemPrompt) {
-      result.systemPrompt = {
-        colTitle: this.fields.systemPromptTitle?.getValue() ?? params.systemPrompt.colTitle.value,
-        value: this.fields.systemPromptValue?.getValue() ?? params.systemPrompt.prompt.value,
-      };
-    }
-
-    if (params.userPrompts) {
-      result.userPrompts = params.userPrompts.map((up, i) => ({
-        colTitle: this.fields.userPromptTitles[i]?.getValue() ?? up.colTitle.value,
-        value: this.fields.userPromptValues[i]?.getValue() ?? up.prompt.value,
-      }));
-    }
-
-    if (params.outputCol) {
-      result.outputCol = {
-        colTitle: this.fields.outputColTitle?.getValue() ?? params.outputCol.colTitle.value,
-      };
-    }
-
-    return result;
+    return { cols };
   }
 
   private buildRunConfig(result: PrepRecipeResult): Partial<RunConfig> {
-    const promptCols: PromptColumnSpec[] = [
-      ...(result.colNames.userPrompts ?? []).map((col) => ({ col, kind: "text" as const })),
-      ...(result.colNames.driveLink
-        ? [{ col: result.colNames.driveLink, kind: "file" as const }]
-        : []),
-    ];
-    return {
-      promptCols,
-      systemPromptCol: result.colNames.systemPrompt,
-      outputCol: result.colNames.outputCol ?? "",
-      rowRange: result.rowRange,
-      tools: result.tools,
-    };
+    const columns = this.definition?.params?.columns ?? [];
+    const settings = this.definition?.params?.settings ?? {};
+    const promptCols: PromptColumnSpec[] = [];
+    let systemPromptCol: string | undefined;
+    let outputCol = "";
+
+    for (let i = 0; i < columns.length; i++) {
+      const col = columns[i];
+      const resolvedTitle = this.fields[i]?.colTitle?.getValue() ?? col.colTitle.value;
+
+      switch (col.role) {
+        case "userPrompt":
+          promptCols.push({ col: resolvedTitle, kind: "text" });
+          break;
+        case "driveLink":
+          promptCols.push({ col: resolvedTitle, kind: "file" });
+          break;
+        case "systemPrompt":
+          systemPromptCol = resolvedTitle;
+          break;
+        case "output":
+          outputCol = resolvedTitle;
+          break;
+      }
+    }
+
+    return { promptCols, systemPromptCol, outputCol, rowRange: result.rowRange, ...settings };
   }
 
-  private template(definition: RecipeDefinition | null): string {
-    const params = definition?.params ?? {};
+  private template(definition: RecipeDefinition | undefined | null): string {
+    const columns = definition?.params?.columns ?? [];
     const title = definition ? `${definition.icon} ${definition.name}` : "Recipe";
-    const numUserPrompts = params.userPrompts?.length ?? 0;
+
+    const columnSections = columns
+      .map((col, i) => {
+        const requiredMark = col.required ? ` <span class="required">*</span>` : "";
+        const helperHtml = col.helperText ? `<p class="field-helper">${col.helperText}</p>` : "";
+
+        const urlInputHtml =
+          col.url !== undefined
+            ? `<input id="col-${i}-url-input" type="text" class="text-input"
+                placeholder="${col.url.placeholder ?? "Paste Google Drive URL"}" />`
+            : "";
+
+        const promptContainerHtml =
+          col.prompt !== undefined ? `<div id="col-${i}-prompt-container"></div>` : "";
+
+        const appendFieldsHtml = (col.appendFields ?? [])
+          .map(
+            (af) =>
+              `<div class="append-field">
+                <label class="field-label">${af.label}</label>
+                <input id="col-${i}-append-${af.id}" type="text" class="text-input"
+                  placeholder="${af.placeholder ?? ""}" />
+              </div>`,
+          )
+          .join("");
+
+        return `
+          <div class="recipe-section-card">
+            <div class="recipe-section-card-title">${col.label}${requiredMark}</div>
+            ${helperHtml}
+            <div id="col-${i}-title-container"></div>
+            ${urlInputHtml}
+            ${promptContainerHtml}
+            ${appendFieldsHtml}
+          </div>`;
+      })
+      .join("");
 
     return `
       <div class="panel-header">
         <button id="back-btn" class="back-btn">← Back</button>
         <span class="panel-title">${title}</span>
       </div>
-      ${
-        params.driveFolder
-          ? `
-      <div class="recipe-section-card">
-        <div class="recipe-section-card-title">Drive Folder <span class="required">*</span></div>
-        ${params.driveFolder.helperText ? `<p class="field-helper">${params.driveFolder.helperText}</p>` : ""}
-        <input id="drive-folder-input" type="text" class="text-input"
-          placeholder="Paste Google Drive folder URL or ID" />
-      </div>`
-          : ""
-      }
-      ${
-        params.systemPrompt
-          ? `
-      <div class="recipe-section-card">
-        <div class="recipe-section-card-title">System Prompt</div>
-        <div id="system-prompt-title-container"></div>
-        <div id="system-prompt-value-container"></div>
-      </div>`
-          : ""
-      }
-      ${(params.userPrompts ?? [])
-        .map(
-          (_, i) => `
-      <div class="recipe-section-card">
-        <div class="recipe-section-card-title">User Prompt${numUserPrompts > 1 ? ` ${i + 1}` : ""}</div>
-        <div id="user-prompt-title-${i}-container"></div>
-        <div id="user-prompt-value-${i}-container"></div>
-      </div>`,
-        )
-        .join("")}
-      ${
-        params.outputCol
-          ? `
-      <div class="recipe-section-card">
-        <div class="recipe-section-card-title">Output Column</div>
-        <div id="output-col-title-container"></div>
-      </div>`
-          : ""
-      }
+      ${columnSections}
       <div id="prep-cook-container"></div>
     `;
   }

--- a/src/client/recipes.ts
+++ b/src/client/recipes.ts
@@ -9,21 +9,32 @@ export const RECIPES: RecipeDefinition[] = [
     description: "Summarize each file in a Google Drive folder",
     panelId: "recipe",
     params: {
-      driveFolder: {
-        colTitle: "Drive Link",
-        helperText: "Make sure you have access to this folder",
-      },
-      systemPrompt: {
-        colTitle: { value: "System Prompt", locked: true },
-        prompt: {
-          value:
-            "You are an expert document analyst. Produce clear, structured summaries " +
-            "focusing on key themes, main arguments, important data points, and actionable conclusions.",
-          locked: true,
-        },
-      },
-      userPrompts: [
+      columns: [
         {
+          label: "Drive Folder",
+          role: "driveLink",
+          strategyKind: "list-drive-folder",
+          colTitle: { value: "Drive Link", locked: true },
+          url: { value: "", locked: false, placeholder: "Paste Google Drive folder URL" },
+          helperText: "Make sure you have access to this folder",
+          required: true,
+        },
+        {
+          label: "System Prompt",
+          role: "systemPrompt",
+          strategyKind: "fill-value",
+          colTitle: { value: "System Prompt", locked: true },
+          prompt: {
+            value:
+              "You are an expert document analyst. Produce clear, structured summaries " +
+              "focusing on key themes, main arguments, important data points, and actionable conclusions.",
+            locked: true,
+          },
+        },
+        {
+          label: "User Prompt",
+          role: "userPrompt",
+          strategyKind: "fill-value",
           colTitle: { value: "User Prompt", locked: true },
           prompt: {
             value:
@@ -32,10 +43,13 @@ export const RECIPES: RecipeDefinition[] = [
             locked: true,
           },
         },
+        {
+          label: "Output Column",
+          role: "output",
+          strategyKind: "create-empty",
+          colTitle: { value: "AI_Summarization", locked: true },
+        },
       ],
-      outputCol: {
-        colTitle: { value: "AI_Summarization", locked: true },
-      },
     } satisfies RecipeParams,
   },
 ];

--- a/src/client/recipes.ts
+++ b/src/client/recipes.ts
@@ -1,5 +1,4 @@
-import type { RecipeDefinition } from "./types";
-import type { RecipeParams } from "./types";
+import type { RecipeDefinition, RecipeParams } from "./types";
 
 export const RECIPES: RecipeDefinition[] = [
   {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -17,6 +17,8 @@ export interface Job {
   completedAt?: number;
 }
 
+import type { ToolId } from "../shared/types";
+
 // ── Recipe UI types ─────────────────────────────────────────────
 // These are client-only — they define sidebar form structure, not RPC payloads.
 
@@ -26,22 +28,46 @@ export interface RecipeFieldConfig {
   placeholder?: string;
 }
 
+export type ColStrategyKind = "list-drive-folder" | "fill-value" | "create-empty";
+export type ColRole = "userPrompt" | "systemPrompt" | "driveLink" | "output";
+
+export interface AppendField {
+  id: string;
+  label: string;
+  placeholder?: string;
+  /** Text injected before the reporter's value, e.g. "\n\nYou are looking for:\n\n" */
+  prefix?: string;
+}
+
+export interface RecipeSettings {
+  tools?: ToolId[];
+  applyMarkdown?: boolean;
+  includeGrounding?: boolean;
+}
+
+export interface ColumnDef {
+  /** UI section heading shown in the recipe panel */
+  label: string;
+  /** How this column maps into RunConfig after prep */
+  role: ColRole;
+  /** What PrepColSpec.strategy type to generate during prep */
+  strategyKind: ColStrategyKind;
+  /** Lockable column header field */
+  colTitle: RecipeFieldConfig;
+  /** Lockable prompt text — present for fill-value columns */
+  prompt?: RecipeFieldConfig;
+  /** Lockable URL input — present for drive columns */
+  url?: RecipeFieldConfig;
+  /** Extra reporter inputs composed into the prompt before prep */
+  appendFields?: AppendField[];
+  helperText?: string;
+  /** Show * in section heading */
+  required?: boolean;
+}
+
 export interface RecipeParams {
-  driveFolder?: {
-    colTitle: string;
-    helperText?: string;
-  };
-  systemPrompt?: {
-    colTitle: RecipeFieldConfig;
-    prompt: RecipeFieldConfig;
-  };
-  userPrompts?: Array<{
-    colTitle: RecipeFieldConfig;
-    prompt: RecipeFieldConfig;
-  }>;
-  outputCol?: {
-    colTitle: RecipeFieldConfig;
-  };
+  columns: ColumnDef[];
+  settings?: RecipeSettings;
 }
 
 /**

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,3 +1,5 @@
+import type { ToolId } from "../shared/types";
+
 // ── Loading / Progress types ─────────────────────────────────────────────────
 
 export type LoadingStatus = "idle" | "loading" | "progress" | "complete" | "error";
@@ -16,8 +18,6 @@ export interface Job {
   startedAt: number;
   completedAt?: number;
 }
-
-import type { ToolId } from "../shared/types";
 
 // ── Recipe UI types ─────────────────────────────────────────────
 // These are client-only — they define sidebar form structure, not RPC payloads.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -397,70 +397,47 @@ export function runTool(functionName: string, jobId?: string): void {
 
 export function prepRecipe(params: PrepRecipeParams): PrepRecipeResult {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
-  const colNames: PrepRecipeResult["colNames"] = {};
   let numRows = 1;
 
-  if (params.driveFolder) {
-    const folderId = extractId(params.driveFolder.url);
-    const folder = DriveApp.getFolderById(folderId);
-    const files: { url: string }[] = [];
-    getAllFilesRecursive(folder, files);
-    numRows = files.length || 1;
-    const col = findOrCreateColumn(
-      sheet,
-      params.driveFolder.colTitle,
-      SpreadsheetApp.WrapStrategy.CLIP,
-    );
-    writeColumn(
-      sheet,
-      col,
-      files.map((f) => f.url),
-      SpreadsheetApp.WrapStrategy.CLIP,
-    );
-    colNames.driveLink = params.driveFolder.colTitle;
-  }
-
-  if (params.systemPrompt) {
-    const col = findOrCreateColumn(
-      sheet,
-      params.systemPrompt.colTitle,
-      SpreadsheetApp.WrapStrategy.CLIP,
-    );
-    writeColumn(
-      sheet,
-      col,
-      Array(numRows).fill(params.systemPrompt.value) as string[],
-      SpreadsheetApp.WrapStrategy.CLIP,
-    );
-    colNames.systemPrompt = params.systemPrompt.colTitle;
-  }
-
-  if (params.userPrompts) {
-    colNames.userPrompts = [];
-    for (const up of params.userPrompts) {
-      const col = findOrCreateColumn(sheet, up.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
-      writeColumn(
-        sheet,
-        col,
-        Array(numRows).fill(up.value) as string[],
-        SpreadsheetApp.WrapStrategy.CLIP,
-      );
-      colNames.userPrompts.push(up.colTitle);
+  // Pass 1: scan Drive folders, cache results, determine numRows
+  const folderCache = new Map<string, string[]>();
+  for (const col of params.cols) {
+    if (col.strategy.kind === "list-drive-folder") {
+      const url = col.strategy.url;
+      if (!folderCache.has(url)) {
+        const folder = DriveApp.getFolderById(extractId(url));
+        const files: { url: string }[] = [];
+        getAllFilesRecursive(folder, files);
+        folderCache.set(url, files.map((f) => f.url));
+      }
+      numRows = Math.max(numRows, folderCache.get(url)!.length || 1);
     }
   }
 
-  if (params.outputCol) {
-    findOrCreateColumn(sheet, params.outputCol.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
-    colNames.outputCol = params.outputCol.colTitle;
+  // Pass 2: write all columns
+  for (const col of params.cols) {
+    const colIdx = findOrCreateColumn(sheet, col.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
+    switch (col.strategy.kind) {
+      case "list-drive-folder": {
+        const urls = folderCache.get(col.strategy.url) ?? [];
+        writeColumn(sheet, colIdx, urls, SpreadsheetApp.WrapStrategy.CLIP);
+        break;
+      }
+      case "fill-value":
+        writeColumn(
+          sheet,
+          colIdx,
+          Array(numRows).fill(col.strategy.value) as string[],
+          SpreadsheetApp.WrapStrategy.CLIP,
+        );
+        break;
+      case "create-empty":
+        break;
+    }
   }
 
   SpreadsheetApp.flush();
-
-  return {
-    rowRange: { start: 2, end: 2 + numRows - 1 },
-    colNames,
-    tools: params.tools,
-  };
+  return { rowRange: { start: 2, end: 2 + numRows - 1 } };
 }
 
 // ==========================================

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -408,7 +408,10 @@ export function prepRecipe(params: PrepRecipeParams): PrepRecipeResult {
         const folder = DriveApp.getFolderById(extractId(url));
         const files: { url: string }[] = [];
         getAllFilesRecursive(folder, files);
-        folderCache.set(url, files.map((f) => f.url));
+        folderCache.set(
+          url,
+          files.map((f) => f.url),
+        );
       }
       numRows = Math.max(numRows, folderCache.get(url)!.length || 1);
     }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -21,8 +21,7 @@ export type ToolId = "google_search" | "url_context" | "code_execution";
 
 /**
  * A reference to a spreadsheet column together with its prompt kind.
- * Crosses the RPC boundary in RunConfig.promptCols (Phase 2) and is
- * echoed through PrepRecipeResult so the client never needs to infer kinds.
+ * Crosses the RPC boundary in RunConfig.promptCols.
  */
 export interface PromptColumnSpec {
   col: string;
@@ -45,8 +44,8 @@ export interface RunConfig {
    * column. When false (default), result.text is written directly via setValue.
    * The grounding column is unaffected by this setting.
    *
-   * Future: recipes could pre-set this via PrepRecipeParams/PrepRecipeResult —
-   * follow the tools echo pattern if needed.
+   * Recipes pre-set this via RecipeSettings (client-only) — it flows into RunConfig
+   * through buildRunConfig() without any server echo.
    */
   applyMarkdown?: boolean;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -53,29 +53,22 @@ export interface RunConfig {
 
 // ── Recipes ─────────────────────────────────────────────────────
 
+export type ColStrategy =
+  | { kind: "list-drive-folder"; url: string }
+  | { kind: "fill-value"; value: string }
+  | { kind: "create-empty" };
+
+export interface PrepColSpec {
+  colTitle: string;
+  strategy: ColStrategy;
+}
+
 export interface PrepRecipeParams {
-  driveFolder?: { url: string; colTitle: string };
-  systemPrompt?: { colTitle: string; value: string };
-  userPrompts?: Array<{ colTitle: string; value: string }>;
-  outputCol?: { colTitle: string };
-  /**
-   * Tool IDs to pass through to PrepRecipeResult.
-   * The server does not process these during prep — they are echoed back
-   * to preserve the single-source-of-truth invariant for preppedRunConfig.
-   */
-  tools?: ToolId[];
+  cols: PrepColSpec[];
 }
 
 export interface PrepRecipeResult {
   rowRange: { start: number; end: number };
-  colNames: {
-    driveLink?: string;
-    systemPrompt?: string;
-    userPrompts?: string[];
-    outputCol?: string;
-  };
-  /** Echoed from PrepRecipeParams — no server-side processing. */
-  tools?: ToolId[];
 }
 
 // ── Import Drive Links ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replaces named-field `PrepRecipeParams`/`PrepRecipeResult` with an agnostic `ColStrategy` discriminated union + `PrepColSpec[]` — the server now iterates a flat list of column instructions rather than switching on named optional fields
- Replaces named-field `RecipeParams` (`driveFolder`, `systemPrompt`, `userPrompts`, `outputCol`) with `columns: ColumnDef[]` — each column carries its UI config, population strategy kind, and RunConfig role in one shape
- Adds `RecipeSettings` for non-column recipe configuration (tools, applyMarkdown, includeGrounding) that flows directly into `RunConfig` without any server echo
- `PrepRecipeResult` shrinks to `{ rowRange }` only — role mapping, tools, and column names are all owned by the client, enabling post-prep editing of column titles and prompt values before AI execution
- Migrates `document-summarization` recipe to new shape; establishes foundation for "Find a Thing in a Thing" recipe

## Test Plan
- [x] `npm test` — 337 tests passing
- [x] `npm run test:coverage` — all per-file thresholds met
- [x] `npm run typecheck` — no errors
- [x] `npm run lint` — no errors

## Design

See `docs/plans/2026-03-26-recipe-prep-redesign.md` for full architecture rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)