### PR TITLE
feat: Run AI Inference panel UX redesign

### DIFF
--- a/__tests__/components/prompt-col-list.test.ts
+++ b/__tests__/components/prompt-col-list.test.ts
@@ -1,0 +1,238 @@
+/**
+ * @jest-environment jsdom
+ */
+import { PromptColList } from "../../src/client/components/prompt-col-list";
+import type { PromptColumnSpec } from "../../src/shared/types";
+
+const HEADERS = ["col_a", "col_b", "col_c"];
+
+function makeContainer(): HTMLElement {
+  document.body.innerHTML = '<div id="app"></div>';
+  return document.getElementById("app")!;
+}
+
+/** Clicks the column TokenInput add btn in the Nth row, then selects value from dropdown. */
+function selectColInRow(container: HTMLElement, rowIndex: number, value: string): void {
+  const rows = container.querySelectorAll(".pcol-row");
+  const row = rows[rowIndex] as HTMLElement;
+  row.querySelector<HTMLElement>(".token-add-btn")!.click();
+  row.querySelector<HTMLElement>(`.token-option[data-value="${value}"]`)!.click();
+}
+
+/** Returns the selected column value chip in the Nth row, or "" if none. */
+function getColInRow(container: HTMLElement, rowIndex: number): string {
+  const rows = container.querySelectorAll(".pcol-row");
+  const row = rows[rowIndex] as HTMLElement;
+  return row.querySelector<HTMLElement>(".token-chip[data-value]")?.getAttribute("data-value") ?? "";
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("PromptColList — construction", () => {
+  it("renders no rows and an add button when constructed with no initialValue", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS);
+    expect(container.querySelectorAll(".pcol-row").length).toBe(0);
+    expect(container.querySelector(".pcol-add-btn")).not.toBeNull();
+    list.destroy();
+  });
+
+  it("renders one row per entry in initialValue", () => {
+    const container = makeContainer();
+    const initial: PromptColumnSpec[] = [
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "file" },
+    ];
+    const list = new PromptColList(container, HEADERS, initial);
+    expect(container.querySelectorAll(".pcol-row").length).toBe(2);
+    list.destroy();
+  });
+
+  it("pre-selects the column chip for each initialValue entry", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [{ col: "col_a", kind: "text" }]);
+    expect(getColInRow(container, 0)).toBe("col_a");
+    list.destroy();
+  });
+
+  it("pre-selects the correct kind pill for each initialValue entry", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "file" },
+    ]);
+    const rows = container.querySelectorAll(".pcol-row");
+    const textPillRow0 = rows[0].querySelector<HTMLElement>(".pcol-kind-pills .tag:first-child");
+    const filePillRow1 = rows[1].querySelector<HTMLElement>(".pcol-kind-pills .tag:last-child");
+    expect(textPillRow0?.classList.contains("selected")).toBe(true);
+    expect(filePillRow1?.classList.contains("selected")).toBe(true);
+    list.destroy();
+  });
+});
+
+describe("PromptColList — getValue()", () => {
+  it("returns [] when there are no rows", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS);
+    expect(list.getValue()).toEqual([]);
+    list.destroy();
+  });
+
+  it("returns [] when rows have no column selected", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS);
+    container.querySelector<HTMLElement>(".pcol-add-btn")!.click();
+    expect(list.getValue()).toEqual([]);
+    list.destroy();
+  });
+
+  it("returns spec for a row with a selected column", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS);
+    container.querySelector<HTMLElement>(".pcol-add-btn")!.click();
+    selectColInRow(container, 0, "col_a");
+    expect(list.getValue()).toEqual([{ col: "col_a", kind: "text" }]);
+    list.destroy();
+  });
+
+  it("returns rows in display order", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "file" },
+    ]);
+    expect(list.getValue()).toEqual([
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "file" },
+    ]);
+    list.destroy();
+  });
+
+  it("skips rows with no column selected when mixed with filled rows", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [{ col: "col_a", kind: "text" }]);
+    container.querySelector<HTMLElement>(".pcol-add-btn")!.click(); // empty row
+    expect(list.getValue()).toEqual([{ col: "col_a", kind: "text" }]);
+    list.destroy();
+  });
+});
+
+describe("PromptColList — add row", () => {
+  it("clicking add button appends a new empty row", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS);
+    container.querySelector<HTMLElement>(".pcol-add-btn")!.click();
+    expect(container.querySelectorAll(".pcol-row").length).toBe(1);
+    expect(getColInRow(container, 0)).toBe("");
+    list.destroy();
+  });
+
+  it("new row defaults to text kind", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS);
+    container.querySelector<HTMLElement>(".pcol-add-btn")!.click();
+    const rows = container.querySelectorAll(".pcol-row");
+    const textPill = rows[0].querySelector<HTMLElement>(".pcol-kind-pills .tag:first-child");
+    expect(textPill?.classList.contains("selected")).toBe(true);
+    list.destroy();
+  });
+});
+
+describe("PromptColList — remove row", () => {
+  it("clicking remove on a row removes it from the DOM and getValue()", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "file" },
+    ]);
+    container.querySelector<HTMLElement>(".pcol-btn-remove")!.click();
+    expect(container.querySelectorAll(".pcol-row").length).toBe(1);
+    expect(list.getValue()).toEqual([{ col: "col_b", kind: "file" }]);
+    list.destroy();
+  });
+});
+
+describe("PromptColList — kind toggle", () => {
+  it("clicking File pill changes kind to file in getValue()", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [{ col: "col_a", kind: "text" }]);
+    const row = container.querySelector<HTMLElement>(".pcol-row")!;
+    row.querySelector<HTMLElement>(".pcol-kind-pills .tag:last-child")!.click(); // File
+    expect(list.getValue()).toEqual([{ col: "col_a", kind: "file" }]);
+    list.destroy();
+  });
+
+  it("clicking Text pill after File restores text kind", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [{ col: "col_a", kind: "file" }]);
+    const row = container.querySelector<HTMLElement>(".pcol-row")!;
+    row.querySelector<HTMLElement>(".pcol-kind-pills .tag:first-child")!.click(); // Text
+    expect(list.getValue()).toEqual([{ col: "col_a", kind: "text" }]);
+    list.destroy();
+  });
+});
+
+describe("PromptColList — reorder", () => {
+  it("up button disabled on first row", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "text" },
+    ]);
+    const firstUpBtn = container.querySelector<HTMLButtonElement>(".pcol-btn-up");
+    expect(firstUpBtn?.disabled).toBe(true);
+    list.destroy();
+  });
+
+  it("down button disabled on last row", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "text" },
+    ]);
+    const downBtns = container.querySelectorAll<HTMLButtonElement>(".pcol-btn-down");
+    expect(downBtns[downBtns.length - 1].disabled).toBe(true);
+    list.destroy();
+  });
+
+  it("clicking up on second row moves it to first position in getValue()", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "file" },
+    ]);
+    const upBtns = container.querySelectorAll<HTMLButtonElement>(".pcol-btn-up");
+    upBtns[1].click(); // up on second row
+    expect(list.getValue()).toEqual([
+      { col: "col_b", kind: "file" },
+      { col: "col_a", kind: "text" },
+    ]);
+    list.destroy();
+  });
+
+  it("clicking down on first row moves it to second position in getValue()", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "file" },
+    ]);
+    container.querySelector<HTMLButtonElement>(".pcol-btn-down")!.click(); // down on first row
+    expect(list.getValue()).toEqual([
+      { col: "col_b", kind: "file" },
+      { col: "col_a", kind: "text" },
+    ]);
+    list.destroy();
+  });
+});
+
+describe("PromptColList — destroy()", () => {
+  it("removes all DOM elements from the container", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [{ col: "col_a", kind: "text" }]);
+    list.destroy();
+    expect(container.querySelector(".pcol-list")).toBeNull();
+    expect(container.querySelector(".pcol-add-btn")).toBeNull();
+  });
+});

--- a/__tests__/components/token-input.test.ts
+++ b/__tests__/components/token-input.test.ts
@@ -1,0 +1,340 @@
+/**
+ * @jest-environment jsdom
+ */
+import { TokenInput } from "../../src/client/components/token-input";
+
+function makeContainer(): HTMLElement {
+  document.body.innerHTML = '<div id="c"></div>';
+  return document.getElementById("c")!;
+}
+
+const ITEMS = ["col_a", "col_b", "col_c"];
+
+function openDropdown(c: HTMLElement): void {
+  c.querySelector<HTMLElement>(".token-add-btn")!.click();
+}
+
+function selectOption(c: HTMLElement, value: string): void {
+  c.querySelector<HTMLElement>(`.token-option[data-value="${value}"]`)!.click();
+}
+
+// ─── Initial render ──────────────────────────────────────────────────────────
+
+describe("TokenInput — initial render", () => {
+  it("renders a .token-field container", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    expect(c.querySelector(".token-field")).not.toBeNull();
+  });
+
+  it("shows no chips when nothing is pre-selected", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    expect(c.querySelectorAll(".token-chip")).toHaveLength(0);
+  });
+
+  it("shows one chip per pre-selected item", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { selected: ["col_a", "col_c"] });
+    expect(c.querySelectorAll(".token-chip")).toHaveLength(2);
+  });
+
+  it("dropdown is hidden initially", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    expect(c.querySelector<HTMLElement>(".token-dropdown")!.style.display).toBe("none");
+  });
+});
+
+// ─── Dropdown open / close ────────────────────────────────────────────────────
+
+describe("TokenInput — dropdown open/close", () => {
+  it("clicking the field opens the dropdown", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    expect(c.querySelector<HTMLElement>(".token-dropdown")!.style.display).not.toBe("none");
+  });
+
+  it("dropdown shows only unselected items", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { selected: ["col_a"] });
+    openDropdown(c);
+    const options = c.querySelectorAll(".token-option");
+    expect(options).toHaveLength(2);
+    const values = Array.from(options).map((o) => o.getAttribute("data-value"));
+    expect(values).not.toContain("col_a");
+  });
+
+  it("pressing Escape closes the dropdown", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    c.querySelector<HTMLInputElement>(".token-search")!.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    expect(c.querySelector<HTMLElement>(".token-dropdown")!.style.display).toBe("none");
+  });
+
+  it("clicking outside the field closes the dropdown", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    document.body.click();
+    expect(c.querySelector<HTMLElement>(".token-dropdown")!.style.display).toBe("none");
+  });
+});
+
+// ─── Filtering ────────────────────────────────────────────────────────────────
+
+describe("TokenInput — filtering", () => {
+  it("typing filters visible dropdown options", () => {
+    const c = makeContainer();
+    new TokenInput(c, ["alpha", "beta", "algebra"], {});
+    openDropdown(c);
+    const input = c.querySelector<HTMLInputElement>(".token-search")!;
+    input.value = "alp";
+    input.dispatchEvent(new Event("input"));
+    const visible = Array.from(c.querySelectorAll<HTMLElement>(".token-option")).filter(
+      (o) => o.style.display !== "none",
+    );
+    expect(visible).toHaveLength(1);
+    expect(visible[0].getAttribute("data-value")).toBe("alpha");
+  });
+
+  it("shows a no-match message when filter has no results", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    const input = c.querySelector<HTMLInputElement>(".token-search")!;
+    input.value = "zzz";
+    input.dispatchEvent(new Event("input"));
+    expect(c.querySelector(".token-no-match")).not.toBeNull();
+  });
+
+  it("clearing the filter restores all unselected options", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    const input = c.querySelector<HTMLInputElement>(".token-search")!;
+    input.value = "col_a";
+    input.dispatchEvent(new Event("input"));
+    input.value = "";
+    input.dispatchEvent(new Event("input"));
+    const visible = Array.from(c.querySelectorAll<HTMLElement>(".token-option")).filter(
+      (o) => o.style.display !== "none",
+    );
+    expect(visible).toHaveLength(3);
+  });
+});
+
+// ─── Selection — multi (default) ──────────────────────────────────────────────
+
+describe("TokenInput — selection (multi)", () => {
+  it("clicking a dropdown option adds a chip", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    selectOption(c, "col_b");
+    expect(c.querySelectorAll(".token-chip")).toHaveLength(1);
+  });
+
+  it("selecting an option removes it from the dropdown", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    selectOption(c, "col_b");
+    const values = Array.from(c.querySelectorAll(".token-option")).map((o) =>
+      o.getAttribute("data-value"),
+    );
+    expect(values).not.toContain("col_b");
+  });
+
+  it("dropdown closes after selecting in multi mode", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    selectOption(c, "col_b");
+    expect(c.querySelector<HTMLElement>(".token-dropdown")!.style.display).toBe("none");
+  });
+
+  it("getValue() returns all selected values", () => {
+    const c = makeContainer();
+    const ti = new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    selectOption(c, "col_a");
+    selectOption(c, "col_c");
+    expect(ti.getValue()).toEqual(["col_a", "col_c"]);
+  });
+
+  it("getValue() returns empty array when nothing is selected", () => {
+    const c = makeContainer();
+    const ti = new TokenInput(c, ITEMS, {});
+    expect(ti.getValue()).toEqual([]);
+  });
+
+  it("getValue() includes pre-selected items", () => {
+    const c = makeContainer();
+    const ti = new TokenInput(c, ITEMS, { selected: ["col_b"] });
+    expect(ti.getValue()).toEqual(["col_b"]);
+  });
+});
+
+// ─── Chip removal ─────────────────────────────────────────────────────────────
+
+describe("TokenInput — chip removal", () => {
+  it("clicking × on a chip removes it", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { selected: ["col_a"] });
+    c.querySelector<HTMLButtonElement>(".token-chip-remove")!.click();
+    expect(c.querySelectorAll(".token-chip")).toHaveLength(0);
+  });
+
+  it("removing a chip makes the item available in the dropdown again", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { selected: ["col_a"] });
+    c.querySelector<HTMLButtonElement>(".token-chip-remove")!.click();
+    openDropdown(c);
+    const values = Array.from(c.querySelectorAll(".token-option")).map((o) =>
+      o.getAttribute("data-value"),
+    );
+    expect(values).toContain("col_a");
+  });
+
+  it("getValue() excludes removed chips", () => {
+    const c = makeContainer();
+    const ti = new TokenInput(c, ITEMS, { selected: ["col_a", "col_b"] });
+    c.querySelector<HTMLButtonElement>('[data-value="col_a"] .token-chip-remove')!.click();
+    expect(ti.getValue()).toEqual(["col_b"]);
+  });
+});
+
+// ─── Single-select mode ───────────────────────────────────────────────────────
+
+describe("TokenInput — single-select mode", () => {
+  it("selecting an option closes the dropdown", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { multi: false });
+    openDropdown(c);
+    selectOption(c, "col_a");
+    expect(c.querySelector<HTMLElement>(".token-dropdown")!.style.display).toBe("none");
+  });
+
+  it("selecting a second option replaces the first chip", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { multi: false });
+    openDropdown(c);
+    selectOption(c, "col_a");
+    openDropdown(c);
+    selectOption(c, "col_b");
+    expect(c.querySelectorAll(".token-chip")).toHaveLength(1);
+    expect(c.querySelector<HTMLElement>(".token-chip")!.getAttribute("data-value")).toBe("col_b");
+  });
+
+  it("getValue() returns array with single selected value", () => {
+    const c = makeContainer();
+    const ti = new TokenInput(c, ITEMS, { multi: false });
+    openDropdown(c);
+    selectOption(c, "col_b");
+    expect(ti.getValue()).toEqual(["col_b"]);
+  });
+});
+
+// ─── includeNew (output column) ───────────────────────────────────────────────
+
+describe("TokenInput — includeNew", () => {
+  it("dropdown shows a '+ New column' option when includeNew is true", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { multi: false, includeNew: true });
+    openDropdown(c);
+    expect(c.querySelector('[data-value="__new__"]')).not.toBeNull();
+  });
+
+  it("selecting '+ New column' adds an editable text chip", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { multi: false, includeNew: true });
+    openDropdown(c);
+    selectOption(c, "__new__");
+    expect(c.querySelector<HTMLInputElement>(".token-chip-input")).not.toBeNull();
+  });
+
+  it("getValue() returns the editable chip text when '+ New column' is selected", () => {
+    const c = makeContainer();
+    const ti = new TokenInput(c, ITEMS, { multi: false, includeNew: true });
+    openDropdown(c);
+    selectOption(c, "__new__");
+    c.querySelector<HTMLInputElement>(".token-chip-input")!.value = "my_col";
+    expect(ti.getValue()).toEqual(["my_col"]);
+  });
+
+  it("pre-selects '+ New column' and fills chip input when selected value is not a known item", () => {
+    const c = makeContainer();
+    const ti = new TokenInput(c, ITEMS, {
+      multi: false,
+      includeNew: true,
+      selected: ["custom_val"],
+    });
+    expect(c.querySelector<HTMLInputElement>(".token-chip-input")).not.toBeNull();
+    expect(ti.getValue()).toEqual(["custom_val"]);
+  });
+
+  it("removing the '+ New column' chip makes '+ Add' reappear", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { multi: false, includeNew: true });
+    openDropdown(c);
+    selectOption(c, "__new__");
+    c.querySelector<HTMLButtonElement>('[data-value="__new__"].token-chip-remove')!.click();
+    expect(c.querySelector<HTMLElement>(".token-add-btn")!.style.display).not.toBe("none");
+  });
+
+  it("getValue() returns the regular selection after replacing a new-column chip", () => {
+    const c = makeContainer();
+    const ti = new TokenInput(c, ITEMS, { multi: false, includeNew: true });
+    openDropdown(c);
+    selectOption(c, "__new__"); // select + New column
+    openDropdown(c);
+    selectOption(c, "col_b"); // replace with a regular column
+    expect(ti.getValue()).toEqual(["col_b"]);
+  });
+});
+
+// ─── Add/change button ────────────────────────────────────────────────────────
+
+describe("TokenInput — add button visibility", () => {
+  it("shows '+ Add' button initially", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    expect(c.querySelector<HTMLElement>(".token-add-btn")!.style.display).not.toBe("none");
+  });
+
+  it("multi-select always shows '+ Add' after selection", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, {});
+    openDropdown(c);
+    selectOption(c, "col_a");
+    expect(c.querySelector<HTMLElement>(".token-add-btn")!.style.display).not.toBe("none");
+  });
+
+  it("single-select hides '+ Add' button after selection", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { multi: false });
+    openDropdown(c);
+    selectOption(c, "col_a");
+    expect(c.querySelector<HTMLElement>(".token-add-btn")!.style.display).toBe("none");
+  });
+
+  it("single-select shows '+ Add' again after chip is removed", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { multi: false });
+    openDropdown(c);
+    selectOption(c, "col_a");
+    c.querySelector<HTMLButtonElement>(".token-chip-remove")!.click();
+    expect(c.querySelector<HTMLElement>(".token-add-btn")!.style.display).not.toBe("none");
+  });
+
+  it("single-select hides '+ Add' when pre-selected", () => {
+    const c = makeContainer();
+    new TokenInput(c, ITEMS, { multi: false, selected: ["col_a"] });
+    expect(c.querySelector<HTMLElement>(".token-add-btn")!.style.display).toBe("none");
+  });
+});

--- a/__tests__/configure-ai-run.test.ts
+++ b/__tests__/configure-ai-run.test.ts
@@ -1,0 +1,36 @@
+import { computeChunks } from "../src/client/panels/configure-ai-run";
+
+describe("computeChunks", () => {
+  it("returns a single chunk when row count equals chunk size", () => {
+    expect(computeChunks({ start: 2, end: 51 }, 50)).toEqual([{ start: 2, end: 51 }]);
+  });
+
+  it("returns a single chunk when row count is less than chunk size", () => {
+    expect(computeChunks({ start: 2, end: 11 }, 50)).toEqual([{ start: 2, end: 11 }]);
+  });
+
+  it("returns multiple full chunks", () => {
+    expect(computeChunks({ start: 2, end: 101 }, 50)).toEqual([
+      { start: 2, end: 51 },
+      { start: 52, end: 101 },
+    ]);
+  });
+
+  it("trims the last chunk to the actual end row", () => {
+    expect(computeChunks({ start: 2, end: 75 }, 50)).toEqual([
+      { start: 2, end: 51 },
+      { start: 52, end: 75 },
+    ]);
+  });
+
+  it("handles a start row other than 2", () => {
+    expect(computeChunks({ start: 10, end: 69 }, 50)).toEqual([
+      { start: 10, end: 59 },
+      { start: 60, end: 69 },
+    ]);
+  });
+
+  it("returns a single chunk for exactly one row", () => {
+    expect(computeChunks({ start: 5, end: 5 }, 50)).toEqual([{ start: 5, end: 5 }]);
+  });
+});

--- a/__tests__/job-store.test.ts
+++ b/__tests__/job-store.test.ts
@@ -28,9 +28,7 @@ describe("JobStore", () => {
     store.dispatch("job-1", "Test Job", promise);
 
     expect(listener).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ id: "job-1", label: "Test Job" }),
-      ]),
+      expect.arrayContaining([expect.objectContaining({ id: "job-1", label: "Test Job" })]),
     );
   });
 
@@ -65,7 +63,10 @@ describe("JobStore", () => {
 
     await store.dispatch("job-4", "Test Job", rejected).catch(() => {});
 
-    const lastCall = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{ id: string; state: { status: string; message?: string } }>;
+    const lastCall = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{
+      id: string;
+      state: { status: string; message?: string };
+    }>;
     const job = lastCall.find((j) => j.id === "job-4");
     expect(job?.state.status).toBe("error");
     expect(job?.state.message).toBe("boom");
@@ -78,7 +79,9 @@ describe("JobStore", () => {
     await store.dispatch("job-5", "Test", Promise.resolve());
 
     const completedCalls = listener.mock.calls;
-    const lastCall = completedCalls[completedCalls.length - 1][0] as Array<{ completedAt?: number }>;
+    const lastCall = completedCalls[completedCalls.length - 1][0] as Array<{
+      completedAt?: number;
+    }>;
     expect(lastCall[0].completedAt).toBeDefined();
   });
 
@@ -110,7 +113,9 @@ describe("JobStore", () => {
 
     jest.advanceTimersByTime(5000);
 
-    const lastCall = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{ id: string }>;
+    const lastCall = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{
+      id: string;
+    }>;
     expect(lastCall.find((j) => j.id === "job-auto-remove")).toBeUndefined();
   });
 
@@ -124,5 +129,101 @@ describe("JobStore", () => {
     await Promise.resolve();
 
     expect(mockGetJobProgress).not.toHaveBeenCalled();
+  });
+
+  describe("cancel()", () => {
+    it("transitions a loading job to cancelling", () => {
+      const listener = jest.fn();
+      store.subscribe(listener);
+
+      store.dispatch("job-c1", "Test", new Promise(() => {}));
+      store.cancel("job-c1");
+
+      const lastJobs = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{
+        id: string;
+        state: { status: string };
+      }>;
+      const job = lastJobs.find((j) => j.id === "job-c1");
+      expect(job?.state.status).toBe("cancelling");
+    });
+
+    it("transitions a progress job to cancelling", () => {
+      const listener = jest.fn();
+      store.subscribe(listener);
+
+      store.dispatch("job-c2", "Test", new Promise(() => {}));
+      store.setProgress("job-c2", "Row 3 of 10");
+      store.cancel("job-c2");
+
+      const lastJobs = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{
+        id: string;
+        state: { status: string };
+      }>;
+      const job = lastJobs.find((j) => j.id === "job-c2");
+      expect(job?.state.status).toBe("cancelling");
+    });
+
+    it("is a no-op for unknown job id", () => {
+      expect(() => store.cancel("nonexistent")).not.toThrow();
+    });
+
+    it("is a no-op if job is already complete", async () => {
+      const listener = jest.fn();
+      store.subscribe(listener);
+
+      await store.dispatch("job-c3", "Test", Promise.resolve());
+      listener.mockClear();
+
+      store.cancel("job-c3");
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("isCancelled()", () => {
+    it("returns false before cancel is called", () => {
+      store.dispatch("job-ic1", "Test", new Promise(() => {}));
+      expect(store.isCancelled("job-ic1")).toBe(false);
+    });
+
+    it("returns true after cancel is called", () => {
+      store.dispatch("job-ic2", "Test", new Promise(() => {}));
+      store.cancel("job-ic2");
+      expect(store.isCancelled("job-ic2")).toBe(true);
+    });
+
+    it("returns false for unknown job id", () => {
+      expect(store.isCancelled("nonexistent")).toBe(false);
+    });
+
+    it("returns false after the job completes (flag cleaned up)", async () => {
+      store.dispatch("job-ic3", "Test", new Promise(() => {}));
+      store.cancel("job-ic3");
+      expect(store.isCancelled("job-ic3")).toBe(true);
+
+      await store.dispatch("job-ic4", "Cleanup test", Promise.resolve());
+      expect(store.isCancelled("job-ic4")).toBe(false);
+    });
+  });
+
+  describe("setProgress()", () => {
+    it("updates the job state message", () => {
+      const listener = jest.fn();
+      store.subscribe(listener);
+
+      store.dispatch("job-sp1", "Test", new Promise(() => {}));
+      store.setProgress("job-sp1", "Chunk 2 of 6");
+
+      const lastJobs = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{
+        id: string;
+        state: { status: string; message?: string };
+      }>;
+      const job = lastJobs.find((j) => j.id === "job-sp1");
+      expect(job?.state.status).toBe("progress");
+      expect(job?.state.message).toBe("Chunk 2 of 6");
+    });
+
+    it("is a no-op for unknown job id", () => {
+      expect(() => store.setProgress("nonexistent", "msg")).not.toThrow();
+    });
   });
 });

--- a/__tests__/job-store.test.ts
+++ b/__tests__/job-store.test.ts
@@ -235,11 +235,21 @@ describe("JobStore", () => {
     });
 
     it("returns false after the job completes (flag cleaned up)", async () => {
-      store.dispatch("job-ic3", "Test", new Promise(() => {}));
-      store.cancel("job-ic3");
-      expect(store.isCancelled("job-ic3")).toBe(true);
+      await store.dispatch("job-ic3", "Test", Promise.resolve());
+      store.cancel("job-ic3"); // no-op since already complete, but flag should still be absent
+      expect(store.isCancelled("job-ic3")).toBe(false);
+    });
 
-      await store.dispatch("job-ic4", "Cleanup test", Promise.resolve());
+    it("clears the cancel flag when a cancelled job finishes", async () => {
+      let resolve!: () => void;
+      const promise = new Promise<void>((r) => {
+        resolve = r;
+      });
+      store.dispatch("job-ic4", "Test", promise);
+      store.cancel("job-ic4");
+      expect(store.isCancelled("job-ic4")).toBe(true);
+      resolve();
+      await promise;
       expect(store.isCancelled("job-ic4")).toBe(false);
     });
   });
@@ -263,6 +273,18 @@ describe("JobStore", () => {
 
     it("is a no-op for unknown job id", () => {
       expect(() => store.setProgress("nonexistent", "msg")).not.toThrow();
+    });
+
+    it("is a no-op when job is cancelling", () => {
+      const listener = jest.fn();
+      store.subscribe(listener);
+
+      store.dispatch("job-sp2", "Test", new Promise(() => {}));
+      store.cancel("job-sp2");
+      listener.mockClear();
+
+      store.setProgress("job-sp2", "should be ignored");
+      expect(listener).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/job-store.test.ts
+++ b/__tests__/job-store.test.ts
@@ -28,9 +28,7 @@ describe("JobStore", () => {
     store.dispatch("job-1", "Test Job", promise);
 
     expect(listener).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ id: "job-1", label: "Test Job" }),
-      ]),
+      expect.arrayContaining([expect.objectContaining({ id: "job-1", label: "Test Job" })]),
     );
   });
 
@@ -65,7 +63,10 @@ describe("JobStore", () => {
 
     await store.dispatch("job-4", "Test Job", rejected).catch(() => {});
 
-    const lastCall = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{ id: string; state: { status: string; message?: string } }>;
+    const lastCall = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{
+      id: string;
+      state: { status: string; message?: string };
+    }>;
     const job = lastCall.find((j) => j.id === "job-4");
     expect(job?.state.status).toBe("error");
     expect(job?.state.message).toBe("boom");
@@ -78,8 +79,49 @@ describe("JobStore", () => {
     await store.dispatch("job-5", "Test", Promise.resolve());
 
     const completedCalls = listener.mock.calls;
-    const lastCall = completedCalls[completedCalls.length - 1][0] as Array<{ completedAt?: number }>;
+    const lastCall = completedCalls[completedCalls.length - 1][0] as Array<{
+      completedAt?: number;
+    }>;
     expect(lastCall[0].completedAt).toBeDefined();
+  });
+
+  it("does not overwrite cancelling state when poll returns progress", async () => {
+    mockGetJobProgress.mockResolvedValue({ message: "Row 3 of 10", current: 3, total: 10 });
+    const listener = jest.fn();
+    store.subscribe(listener);
+
+    store.dispatch("job-poll-cancel", "Test", new Promise(() => {}));
+    store.cancel("job-poll-cancel");
+
+    jest.advanceTimersByTime(2000);
+    await Promise.resolve();
+
+    const lastJobs = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{
+      id: string;
+      state: { status: string };
+    }>;
+    const job = lastJobs.find((j) => j.id === "job-poll-cancel");
+    expect(job?.state.status).toBe("cancelling");
+  });
+
+  it("surfaces server message prefixed with 'Stopping —' when cancelling and poll has progress", async () => {
+    mockGetJobProgress.mockResolvedValue({ message: "Row 3 of 10", current: 3, total: 10 });
+    const listener = jest.fn();
+    store.subscribe(listener);
+
+    store.dispatch("job-poll-cancel-msg", "Test", new Promise(() => {}));
+    store.cancel("job-poll-cancel-msg");
+
+    jest.advanceTimersByTime(2000);
+    await Promise.resolve();
+
+    const lastJobs = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{
+      id: string;
+      state: { status: string; message?: string };
+    }>;
+    const job = lastJobs.find((j) => j.id === "job-poll-cancel-msg");
+    expect(job?.state.status).toBe("cancelling");
+    expect(job?.state.message).toBe("Stopping — row 3 of 10");
   });
 
   it("polls getJobProgress on interval while job is running", async () => {
@@ -110,7 +152,9 @@ describe("JobStore", () => {
 
     jest.advanceTimersByTime(5000);
 
-    const lastCall = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{ id: string }>;
+    const lastCall = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{
+      id: string;
+    }>;
     expect(lastCall.find((j) => j.id === "job-auto-remove")).toBeUndefined();
   });
 
@@ -124,5 +168,101 @@ describe("JobStore", () => {
     await Promise.resolve();
 
     expect(mockGetJobProgress).not.toHaveBeenCalled();
+  });
+
+  describe("cancel()", () => {
+    it("transitions a loading job to cancelling", () => {
+      const listener = jest.fn();
+      store.subscribe(listener);
+
+      store.dispatch("job-c1", "Test", new Promise(() => {}));
+      store.cancel("job-c1");
+
+      const lastJobs = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{
+        id: string;
+        state: { status: string };
+      }>;
+      const job = lastJobs.find((j) => j.id === "job-c1");
+      expect(job?.state.status).toBe("cancelling");
+    });
+
+    it("transitions a progress job to cancelling", () => {
+      const listener = jest.fn();
+      store.subscribe(listener);
+
+      store.dispatch("job-c2", "Test", new Promise(() => {}));
+      store.setProgress("job-c2", "Row 3 of 10");
+      store.cancel("job-c2");
+
+      const lastJobs = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{
+        id: string;
+        state: { status: string };
+      }>;
+      const job = lastJobs.find((j) => j.id === "job-c2");
+      expect(job?.state.status).toBe("cancelling");
+    });
+
+    it("is a no-op for unknown job id", () => {
+      expect(() => store.cancel("nonexistent")).not.toThrow();
+    });
+
+    it("is a no-op if job is already complete", async () => {
+      const listener = jest.fn();
+      store.subscribe(listener);
+
+      await store.dispatch("job-c3", "Test", Promise.resolve());
+      listener.mockClear();
+
+      store.cancel("job-c3");
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("isCancelled()", () => {
+    it("returns false before cancel is called", () => {
+      store.dispatch("job-ic1", "Test", new Promise(() => {}));
+      expect(store.isCancelled("job-ic1")).toBe(false);
+    });
+
+    it("returns true after cancel is called", () => {
+      store.dispatch("job-ic2", "Test", new Promise(() => {}));
+      store.cancel("job-ic2");
+      expect(store.isCancelled("job-ic2")).toBe(true);
+    });
+
+    it("returns false for unknown job id", () => {
+      expect(store.isCancelled("nonexistent")).toBe(false);
+    });
+
+    it("returns false after the job completes (flag cleaned up)", async () => {
+      store.dispatch("job-ic3", "Test", new Promise(() => {}));
+      store.cancel("job-ic3");
+      expect(store.isCancelled("job-ic3")).toBe(true);
+
+      await store.dispatch("job-ic4", "Cleanup test", Promise.resolve());
+      expect(store.isCancelled("job-ic4")).toBe(false);
+    });
+  });
+
+  describe("setProgress()", () => {
+    it("updates the job state message", () => {
+      const listener = jest.fn();
+      store.subscribe(listener);
+
+      store.dispatch("job-sp1", "Test", new Promise(() => {}));
+      store.setProgress("job-sp1", "Chunk 2 of 6");
+
+      const lastJobs = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{
+        id: string;
+        state: { status: string; message?: string };
+      }>;
+      const job = lastJobs.find((j) => j.id === "job-sp1");
+      expect(job?.state.status).toBe("progress");
+      expect(job?.state.message).toBe("Chunk 2 of 6");
+    });
+
+    it("is a no-op for unknown job id", () => {
+      expect(() => store.setProgress("nonexistent", "msg")).not.toThrow();
+    });
   });
 });

--- a/__tests__/panels/configure-ai-run.test.ts
+++ b/__tests__/panels/configure-ai-run.test.ts
@@ -46,17 +46,37 @@ async function mountAndLoad(
   return { container, panel };
 }
 
-/** Selects a column in a TokenInput field by opening its dropdown and clicking the option. */
+/** Clicks "+ Add column" and selects value in the newly appended PromptColList row. */
+function addPromptCol(
+  container: HTMLElement,
+  value: string,
+  kind: "text" | "file" = "text",
+): void {
+  container.querySelector<HTMLElement>(".pcol-add-btn")!.click();
+  const rows = container.querySelectorAll(".pcol-row");
+  const row = rows[rows.length - 1] as HTMLElement;
+  row.querySelector<HTMLElement>(".token-add-btn")!.click();
+  row.querySelector<HTMLElement>(`.token-option[data-value="${value}"]`)!.click();
+  if (kind === "file") {
+    const pills = row.querySelectorAll<HTMLElement>(".pcol-kind-pills .tag");
+    pills[1].click();
+  }
+}
+
+/** Returns column chip values from all filled rows in the PromptColList. */
+function getPromptColValues(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll(".pcol-row"))
+    .map(
+      (row) =>
+        row.querySelector<HTMLElement>(".token-chip[data-value]")?.getAttribute("data-value") ?? "",
+    )
+    .filter(Boolean);
+}
+
+/** Selects a column in a non-PromptColList TokenInput field (e.g. system-prompt-col, output-col). */
 function selectColumn(container: HTMLElement, fieldId: string, value: string): void {
   container.querySelector<HTMLElement>(`#${fieldId} .token-add-btn`)!.click();
   container.querySelector<HTMLElement>(`#${fieldId} .token-option[data-value="${value}"]`)!.click();
-}
-
-/** Returns data-value attributes of current chips in a TokenInput field. */
-function getChipValues(container: HTMLElement, fieldId: string): string[] {
-  return Array.from(
-    container.querySelectorAll<HTMLElement>(`#${fieldId} .token-chip[data-value]`),
-  ).map((el) => el.getAttribute("data-value") ?? "");
 }
 
 beforeEach(() => {
@@ -97,7 +117,7 @@ describe("ConfigureAIRunPanel — mount", () => {
 
   it("pre-selects params on mount", async () => {
     const { container } = await mountAndLoad({ promptCols: [{ col: "col_a", kind: "text" }] });
-    expect(getChipValues(container, "user-prompt-cols")).toContain("col_a");
+    expect(getPromptColValues(container)).toContain("col_a");
   });
 
   it("restores savedState over params", async () => {
@@ -110,7 +130,7 @@ describe("ConfigureAIRunPanel — mount", () => {
       { promptCols: [{ col: "col_a", kind: "text" }] },
       savedState,
     );
-    expect(getChipValues(container, "user-prompt-cols")).toContain("col_b");
+    expect(getPromptColValues(container)).toContain("col_b");
   });
 });
 
@@ -124,7 +144,7 @@ describe("ConfigureAIRunPanel — Run AI", () => {
 
   it("alerts when no output column selected", async () => {
     const { container } = await mountAndLoad();
-    selectColumn(container, "user-prompt-cols", "col_a");
+    addPromptCol(container, "col_a");
     container.querySelector<HTMLButtonElement>("#run-btn")!.click();
     expect(globalThis.alert).toHaveBeenCalledWith("Please select an output column.");
   });
@@ -232,7 +252,7 @@ describe("ConfigureAIRunPanel — refresh", () => {
     await Promise.resolve();
     expect(services.getSheetHeaders).toHaveBeenCalledTimes(2);
     // selections preserved after refresh
-    expect(getChipValues(container, "user-prompt-cols")).toContain("col_a");
+    expect(getPromptColValues(container)).toContain("col_a");
   });
 });
 
@@ -309,7 +329,7 @@ describe("includeGrounding checkbox", () => {
   it("unmount saves includeGrounding state", async () => {
     const { container, panel } = await mountAndLoad();
     container.querySelector<HTMLInputElement>("#include-grounding-cb")!.checked = true;
-    selectColumn(container, "user-prompt-cols", "col_a");
+    addPromptCol(container, "col_a");
     const saved = panel.unmount();
     expect(saved?.includeGrounding).toBe(true);
   });
@@ -372,7 +392,7 @@ describe("includeGrounding checkbox", () => {
 describe("ConfigureAIRunPanel — unmount", () => {
   it("unmount() returns current form state as SavedState", async () => {
     const { container, panel } = await mountAndLoad();
-    selectColumn(container, "user-prompt-cols", "col_a");
+    addPromptCol(container, "col_a");
     selectColumn(container, "output-col", "ai_inference");
     const state = panel.unmount();
     expect(state).not.toBeUndefined();

--- a/__tests__/panels/configure-ai-run.test.ts
+++ b/__tests__/panels/configure-ai-run.test.ts
@@ -46,6 +46,19 @@ async function mountAndLoad(
   return { container, panel };
 }
 
+/** Selects a column in a TokenInput field by opening its dropdown and clicking the option. */
+function selectColumn(container: HTMLElement, fieldId: string, value: string): void {
+  container.querySelector<HTMLElement>(`#${fieldId} .token-add-btn`)!.click();
+  container.querySelector<HTMLElement>(`#${fieldId} .token-option[data-value="${value}"]`)!.click();
+}
+
+/** Returns data-value attributes of current chips in a TokenInput field. */
+function getChipValues(container: HTMLElement, fieldId: string): string[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(`#${fieldId} .token-chip[data-value]`),
+  ).map((el) => el.getAttribute("data-value") ?? "");
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   globalThis.alert = jest.fn();
@@ -84,9 +97,7 @@ describe("ConfigureAIRunPanel — mount", () => {
 
   it("pre-selects params on mount", async () => {
     const { container } = await mountAndLoad({ promptCols: [{ col: "col_a", kind: "text" }] });
-    const selected = container.querySelectorAll("#user-prompt-cols .tag.selected");
-    expect(selected).toHaveLength(1);
-    expect(selected[0].getAttribute("data-value")).toBe("col_a");
+    expect(getChipValues(container, "user-prompt-cols")).toContain("col_a");
   });
 
   it("restores savedState over params", async () => {
@@ -99,8 +110,7 @@ describe("ConfigureAIRunPanel — mount", () => {
       { promptCols: [{ col: "col_a", kind: "text" }] },
       savedState,
     );
-    const selected = container.querySelectorAll("#user-prompt-cols .tag.selected");
-    expect(selected[0].getAttribute("data-value")).toBe("col_b");
+    expect(getChipValues(container, "user-prompt-cols")).toContain("col_b");
   });
 });
 
@@ -114,7 +124,7 @@ describe("ConfigureAIRunPanel — Run AI", () => {
 
   it("alerts when no output column selected", async () => {
     const { container } = await mountAndLoad();
-    container.querySelector<HTMLButtonElement>('[data-value="col_a"]')!.click();
+    selectColumn(container, "user-prompt-cols", "col_a");
     container.querySelector<HTMLButtonElement>("#run-btn")!.click();
     expect(globalThis.alert).toHaveBeenCalledWith("Please select an output column.");
   });
@@ -155,7 +165,7 @@ describe("ConfigureAIRunPanel — Run AI", () => {
     );
   });
 
-  it("stays on panel after run is dispatched and refetches headers", async () => {
+  it("stays on panel after run is dispatched without reloading headers", async () => {
     (services.runBatchAI as jest.Mock).mockResolvedValue(undefined);
     const { container } = await mountAndLoad({
       promptCols: [{ col: "col_a", kind: "text" }],
@@ -164,7 +174,7 @@ describe("ConfigureAIRunPanel — Run AI", () => {
     container.querySelector<HTMLButtonElement>("#run-btn")!.click();
     await Promise.resolve();
     expect(mockNav.back).not.toHaveBeenCalled();
-    expect(services.getSheetHeaders).toHaveBeenCalledTimes(2); // initial load + refresh
+    expect(services.getSheetHeaders).toHaveBeenCalledTimes(1); // initial load only, no reload
   });
 
   it("alerts on failure via jobStore catch handler", async () => {
@@ -222,8 +232,7 @@ describe("ConfigureAIRunPanel — refresh", () => {
     await Promise.resolve();
     expect(services.getSheetHeaders).toHaveBeenCalledTimes(2);
     // selections preserved after refresh
-    const tags = container.querySelectorAll("#user-prompt-cols .tag.selected");
-    expect(tags.length).toBeGreaterThan(0);
+    expect(getChipValues(container, "user-prompt-cols")).toContain("col_a");
   });
 });
 
@@ -300,19 +309,17 @@ describe("includeGrounding checkbox", () => {
   it("unmount saves includeGrounding state", async () => {
     const { container, panel } = await mountAndLoad();
     container.querySelector<HTMLInputElement>("#include-grounding-cb")!.checked = true;
-    // Select at least one user-prompt column so unmount() returns a value (not undefined)
-    container.querySelectorAll<HTMLElement>("#user-prompt-cols .tag")[0]?.click();
+    selectColumn(container, "user-prompt-cols", "col_a");
     const saved = panel.unmount();
     expect(saved?.includeGrounding).toBe(true);
   });
 
   it("updates grounding column label when output column selection changes", async () => {
-    const { container } = await mountAndLoad(); // no pre-selected output column
-    const tag = container.querySelector<HTMLButtonElement>("#output-col .tag");
-    if (!tag) return; // guard against no tags in jsdom
-    tag.click();
+    const { container } = await mountAndLoad();
+    selectColumn(container, "output-col", "col_a");
+    await Promise.resolve(); // flush MutationObserver microtask
     const label = container.querySelector<HTMLElement>("#grounding-col-name");
-    expect(label?.textContent).toBe(`${tag.textContent}_grounding`);
+    expect(label?.textContent).toBe("col_a_grounding");
   });
 
   it("restores includeGrounding from savedState", async () => {
@@ -365,10 +372,8 @@ describe("includeGrounding checkbox", () => {
 describe("ConfigureAIRunPanel — unmount", () => {
   it("unmount() returns current form state as SavedState", async () => {
     const { container, panel } = await mountAndLoad();
-    container.querySelector<HTMLButtonElement>('[data-value="col_a"]')!.click(); // user-prompt
-    container
-      .querySelectorAll<HTMLButtonElement>("#output-col .tag")[1]! // ai_inference
-      .click();
+    selectColumn(container, "user-prompt-cols", "col_a");
+    selectColumn(container, "output-col", "ai_inference");
     const state = panel.unmount();
     expect(state).not.toBeUndefined();
     const typedState = state as { promptCols: Array<{ col: string; kind: string }> };

--- a/__tests__/panels/extract-text.test.ts
+++ b/__tests__/panels/extract-text.test.ts
@@ -30,6 +30,11 @@ function mountPanel(savedState?: unknown): HTMLElement {
   return container;
 }
 
+function selectColumn(container: HTMLElement, fieldId: string, value: string): void {
+  container.querySelector<HTMLElement>(`#${fieldId} .token-add-btn`)!.click();
+  container.querySelector<HTMLElement>(`#${fieldId} .token-option[data-value="${value}"]`)!.click();
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   (jobStoreModule.jobStore.dispatch as jest.Mock).mockResolvedValue(undefined);
@@ -72,7 +77,7 @@ describe("ExtractTextPanel", () => {
     const c = mountPanel();
     await Promise.resolve();
     // select source column but not output
-    c.querySelector<HTMLElement>("#source-col .tag")?.click();
+    selectColumn(c, "source-col", "source_drive");
     c.querySelector<HTMLButtonElement>("#extract-btn")!.click();
     expect(globalThis.alert).toHaveBeenCalledWith(expect.stringContaining("output column"));
   });
@@ -84,9 +89,8 @@ describe("ExtractTextPanel", () => {
     const c = mountPanel();
     await Promise.resolve();
 
-    // select first tag in each list independently
-    c.querySelector<HTMLElement>("#source-col .tag")?.click();
-    c.querySelector<HTMLElement>("#output-col .tag")?.click();
+    selectColumn(c, "source-col", "source_drive");
+    selectColumn(c, "output-col", "extracted_text");
 
     c.querySelector<HTMLButtonElement>("#extract-btn")!.click();
     expect(jobStoreModule.jobStore.dispatch).toHaveBeenCalledWith(
@@ -102,8 +106,8 @@ describe("ExtractTextPanel", () => {
     const c = mountPanel();
     await Promise.resolve();
 
-    c.querySelector<HTMLElement>("#source-col .tag")?.click();
-    c.querySelector<HTMLElement>("#output-col .tag")?.click();
+    selectColumn(c, "source-col", "source_drive");
+    selectColumn(c, "output-col", "extracted_text");
     // leave RowRange in default "Use sheet selection" mode
     c.querySelector<HTMLButtonElement>("#extract-btn")!.click();
 
@@ -119,8 +123,8 @@ describe("ExtractTextPanel", () => {
     const c = mountPanel();
     await Promise.resolve();
 
-    c.querySelector<HTMLElement>("#source-col .tag")?.click();
-    c.querySelector<HTMLElement>("#output-col .tag")?.click();
+    selectColumn(c, "source-col", "source_drive");
+    selectColumn(c, "output-col", "extracted_text");
 
     // switch to "Specify range" and fill in values
     const rangeRadio = c.querySelector<HTMLInputElement>("input[value='range']")!;
@@ -183,8 +187,8 @@ describe("ExtractTextPanel", () => {
     const c = mountPanel();
     await Promise.resolve();
 
-    c.querySelector<HTMLElement>("#source-col .tag")?.click();
-    c.querySelector<HTMLElement>("#output-col .tag")?.click();
+    selectColumn(c, "source-col", "source_drive");
+    selectColumn(c, "output-col", "extracted_text");
     c.querySelector<HTMLButtonElement>("#extract-btn")!.click();
     await new Promise((r) => setTimeout(r, 0));
     expect(globalThis.alert).toHaveBeenCalledWith("Error: job failed");

--- a/__tests__/panels/import-drive-links.test.ts
+++ b/__tests__/panels/import-drive-links.test.ts
@@ -30,6 +30,11 @@ function mountPanel(savedState?: unknown): HTMLElement {
   return container;
 }
 
+function selectColumn(container: HTMLElement, fieldId: string, value: string): void {
+  container.querySelector<HTMLElement>(`#${fieldId} .token-add-btn`)!.click();
+  container.querySelector<HTMLElement>(`#${fieldId} .token-option[data-value="${value}"]`)!.click();
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   (jobStoreModule.jobStore.dispatch as jest.Mock).mockResolvedValue(undefined);
@@ -75,8 +80,7 @@ describe("ImportDriveLinksPanel", () => {
 
     c.querySelector<HTMLInputElement>("#folder-url-input")!.value =
       "https://drive.google.com/drive/folders/abc123";
-    // select the output column tag
-    c.querySelector<HTMLElement>("#output-col .tag")?.click();
+    selectColumn(c, "output-col", "source_drive");
 
     c.querySelector<HTMLButtonElement>("#import-btn")!.click();
     expect(jobStoreModule.jobStore.dispatch).toHaveBeenCalledWith(
@@ -128,7 +132,7 @@ describe("ImportDriveLinksPanel", () => {
     await Promise.resolve();
     c.querySelector<HTMLInputElement>("#folder-url-input")!.value =
       "https://drive.google.com/drive/folders/abc123";
-    // do NOT click any output column tag — leave it unselected
+    // do NOT select any output column — leave it unselected
     c.querySelector<HTMLButtonElement>("#import-btn")!.click();
     expect(globalThis.alert).toHaveBeenCalledWith(expect.stringContaining("output column"));
   });
@@ -172,7 +176,7 @@ describe("ImportDriveLinksPanel", () => {
     await Promise.resolve();
     c.querySelector<HTMLInputElement>("#folder-url-input")!.value =
       "https://drive.google.com/drive/folders/abc123";
-    c.querySelector<HTMLElement>("#output-col .tag")?.click();
+    selectColumn(c, "output-col", "source_drive");
     c.querySelector<HTMLButtonElement>("#import-btn")!.click();
     await new Promise((r) => setTimeout(r, 0));
     expect(globalThis.alert).toHaveBeenCalledWith("Error: job failed");

--- a/__tests__/panels/recipe.test.ts
+++ b/__tests__/panels/recipe.test.ts
@@ -8,8 +8,7 @@ jest.mock("../../src/client/services", () => ({
 import { RecipePanel } from "../../src/client/panels/recipe";
 import * as services from "../../src/client/services";
 import type { PrepRecipeResult } from "../../src/shared/types";
-import type { RecipeParams } from "../../src/client/types";
-import type { NavigationContext, RecipeDefinition } from "../../src/client/types";
+import type { ColumnDef, RecipeDefinition, RecipeParams, NavigationContext } from "../../src/client/types";
 
 const mockPrepRecipe = services.prepRecipe as jest.Mock;
 
@@ -42,65 +41,93 @@ async function flush() {
   await Promise.resolve();
 }
 
+// helper: a minimal column set covering all roles
+const fullColumns: ColumnDef[] = [
+  {
+    label: "Drive Folder",
+    role: "driveLink",
+    strategyKind: "list-drive-folder",
+    colTitle: { value: "Drive Link", locked: true },
+    url: { value: "", locked: false, placeholder: "Paste folder URL" },
+    required: true,
+  },
+  {
+    label: "System Prompt",
+    role: "systemPrompt",
+    strategyKind: "fill-value",
+    colTitle: { value: "System Prompt", locked: true },
+    prompt: { value: "You are helpful.", locked: true },
+  },
+  {
+    label: "User Prompt",
+    role: "userPrompt",
+    strategyKind: "fill-value",
+    colTitle: { value: "User Prompt", locked: true },
+    prompt: { value: "Summarize.", locked: true },
+  },
+  {
+    label: "Output Column",
+    role: "output",
+    strategyKind: "create-empty",
+    colTitle: { value: "AI_Out", locked: true },
+  },
+];
+
+const mockResult: PrepRecipeResult = {
+  rowRange: { start: 2, end: 11 },
+};
+
 // ── rendering ───────────────────────────────────────────────────
 
 describe("rendering", () => {
-  it("renders drive folder input when driveFolder param present", () => {
-    const { container } = mount({ driveFolder: { colTitle: "Drive Link" } });
-    expect(container.querySelector("#drive-folder-input")).not.toBeNull();
+  it("renders a url input for list-drive-folder columns", () => {
+    const { container } = mount({ columns: [fullColumns[0]] });
+    expect(container.querySelector("#col-0-url-input")).not.toBeNull();
   });
 
-  it("does not render drive folder input when driveFolder absent", () => {
-    const { container } = mount({});
-    expect(container.querySelector("#drive-folder-input")).toBeNull();
+  it("does not render url input for fill-value columns", () => {
+    const { container } = mount({ columns: [fullColumns[2]] });
+    expect(container.querySelector("#col-0-url-input")).toBeNull();
   });
 
-  it("renders system prompt fields when systemPrompt param present", () => {
-    const { container } = mount({
-      systemPrompt: {
-        colTitle: { value: "System Prompt", locked: true },
-        prompt: { value: "You are helpful.", locked: true },
-      },
-    });
-    expect(container.querySelector("#system-prompt-title-container")).not.toBeNull();
-    expect(container.querySelector("#system-prompt-value-container")).not.toBeNull();
+  it("renders a prompt container for fill-value columns", () => {
+    const { container } = mount({ columns: [fullColumns[1]] });
+    expect(container.querySelector("#col-0-prompt-container")).not.toBeNull();
   });
 
-  it("renders one user prompt section per userPrompts entry", () => {
-    const { container } = mount({
-      userPrompts: [
-        {
-          colTitle: { value: "User Prompt", locked: true },
-          prompt: { value: "Summarize.", locked: true },
-        },
-        {
-          colTitle: { value: "User Prompt 2", locked: true },
-          prompt: { value: "Also this.", locked: true },
-        },
-      ],
-    });
-    expect(container.querySelector("#user-prompt-title-0-container")).not.toBeNull();
-    expect(container.querySelector("#user-prompt-title-1-container")).not.toBeNull();
+  it("does not render prompt container for create-empty columns", () => {
+    const { container } = mount({ columns: [fullColumns[3]] });
+    expect(container.querySelector("#col-0-prompt-container")).toBeNull();
+  });
+
+  it("renders one section per ColumnDef", () => {
+    const { container } = mount({ columns: fullColumns });
+    expect(container.querySelectorAll(".recipe-section-card")).toHaveLength(fullColumns.length);
+  });
+
+  it("renders append field inputs when appendFields present", () => {
+    const colWithAppend: ColumnDef = {
+      ...fullColumns[2],
+      appendFields: [{ id: "search", label: "What are you looking for?" }],
+    };
+    const { container } = mount({ columns: [colWithAppend] });
+    expect(container.querySelector("#col-0-append-search")).not.toBeNull();
   });
 });
 
 // ── LockableField defaults ────────────────────────────────────────
 
 describe("LockableField defaults", () => {
-  it("initialises fields with locked: true values from params", () => {
-    const { container } = mount({
-      outputCol: { colTitle: { value: "AI_Summarization", locked: true } },
-    });
-    const input = container.querySelector<HTMLInputElement>("#output-col-title-container input")!;
-    expect(input.value).toBe("AI_Summarization");
+  it("initialises locked colTitle field as disabled", () => {
+    const { container } = mount({ columns: [fullColumns[3]] });
+    const input = container.querySelector<HTMLInputElement>("#col-0-title-container input")!;
+    expect(input.value).toBe("AI_Out");
     expect(input.disabled).toBe(true);
   });
 
-  it("initialises fields with locked: false as unlocked", () => {
-    const { container } = mount({
-      outputCol: { colTitle: { value: "AI_Output", locked: false } },
-    });
-    const input = container.querySelector<HTMLInputElement>("#output-col-title-container input")!;
+  it("initialises unlocked url field as enabled", () => {
+    const { container } = mount({ columns: [fullColumns[0]] });
+    const input = container.querySelector<HTMLInputElement>("#col-0-url-input")!;
     expect(input.disabled).toBe(false);
   });
 });
@@ -108,59 +135,67 @@ describe("LockableField defaults", () => {
 // ── prep flow ──────────────────────────────────────────────────
 
 describe("Prep flow", () => {
-  beforeEach(() => {
-    mockPrepRecipe.mockClear();
-  });
-  const fullParams: RecipeParams = {
-    driveFolder: { colTitle: "Drive Link", helperText: "Check access" },
-    systemPrompt: {
-      colTitle: { value: "System Prompt", locked: true },
-      prompt: { value: "You are helpful.", locked: true },
-    },
-    userPrompts: [
-      {
-        colTitle: { value: "User Prompt", locked: true },
-        prompt: { value: "Summarize.", locked: true },
-      },
-    ],
-    outputCol: { colTitle: { value: "AI_Out", locked: true } },
-  };
+  beforeEach(() => mockPrepRecipe.mockClear());
 
-  const mockResult: PrepRecipeResult = {
-    rowRange: { start: 2, end: 11 },
-    colNames: {
-      driveLink: "Drive Link",
-      systemPrompt: "System Prompt",
-      userPrompts: ["User Prompt"],
-      outputCol: "AI_Out",
-    },
-  };
-
-  it("calls services.prepRecipe with resolved form values", async () => {
+  it("calls services.prepRecipe with PrepColSpec[] built from resolved field values", async () => {
     mockPrepRecipe.mockResolvedValue(mockResult);
-    const { container } = mount(fullParams);
-    container.querySelector<HTMLInputElement>("#drive-folder-input")!.value =
+    const { container } = mount({ columns: fullColumns });
+    container.querySelector<HTMLInputElement>("#col-0-url-input")!.value =
       "https://drive.google.com/drive/folders/abc123";
     container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
     await flush();
-    expect(mockPrepRecipe).toHaveBeenCalledWith(
-      expect.objectContaining({
-        driveFolder: expect.objectContaining({ colTitle: "Drive Link" }),
-        systemPrompt: { colTitle: "System Prompt", value: "You are helpful." },
-        userPrompts: [{ colTitle: "User Prompt", value: "Summarize." }],
-        outputCol: { colTitle: "AI_Out" },
-      }),
-    );
+    expect(mockPrepRecipe).toHaveBeenCalledWith({
+      cols: [
+        { colTitle: "Drive Link", strategy: { kind: "list-drive-folder", url: "https://drive.google.com/drive/folders/abc123" } },
+        { colTitle: "System Prompt", strategy: { kind: "fill-value", value: "You are helpful." } },
+        { colTitle: "User Prompt", strategy: { kind: "fill-value", value: "Summarize." } },
+        { colTitle: "AI_Out", strategy: { kind: "create-empty" } },
+      ],
+    });
   });
 
-  it("shows alert and does not proceed if drive folder is empty", async () => {
+  it("composes appendFields into the fill-value prompt string", async () => {
+    mockPrepRecipe.mockResolvedValue(mockResult);
+    const colWithAppend: ColumnDef = {
+      ...fullColumns[2],
+      appendFields: [{ id: "search", label: "What?", prefix: "\n\nLooking for:\n\n" }],
+    };
+    const { container } = mount({ columns: [colWithAppend] });
+    container.querySelector<HTMLInputElement>("#col-0-append-search")!.value = "a signature";
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    expect(mockPrepRecipe).toHaveBeenCalledWith({
+      cols: [
+        {
+          colTitle: "User Prompt",
+          strategy: { kind: "fill-value", value: "Summarize.\n\nLooking for:\n\na signature" },
+        },
+      ],
+    });
+  });
+
+  it("does not append prefix when appendField input is empty", async () => {
+    mockPrepRecipe.mockResolvedValue(mockResult);
+    const colWithAppend: ColumnDef = {
+      ...fullColumns[2],
+      appendFields: [{ id: "search", label: "What?", prefix: "\n\nLooking for:\n\n" }],
+    };
+    const { container } = mount({ columns: [colWithAppend] });
+    // leave #col-0-append-search empty
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    expect(mockPrepRecipe).toHaveBeenCalledWith({
+      cols: [{ colTitle: "User Prompt", strategy: { kind: "fill-value", value: "Summarize." } }],
+    });
+  });
+
+  it("shows alert and does not call prepRecipe when url input is empty for list-drive-folder", async () => {
     const alertMock = jest.fn();
     globalThis.alert = alertMock;
-    const { container } = mount(fullParams);
+    const { container } = mount({ columns: [fullColumns[0]] });
     container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
     await flush();
     expect(alertMock).toHaveBeenCalledTimes(1);
-    expect(alertMock).toHaveBeenCalledWith(expect.stringContaining("folder"));
     expect(mockPrepRecipe).not.toHaveBeenCalled();
   });
 });
@@ -168,89 +203,70 @@ describe("Prep flow", () => {
 // ── Cook flow ──────────────────────────────────────────────────
 
 describe("Cook flow", () => {
-  it("navigates to configure-ai-run with preppedRunConfig assembled from PrepRecipeResult", async () => {
-    const result: PrepRecipeResult = {
-      rowRange: { start: 2, end: 5 },
-      colNames: {
-        driveLink: "Drive Link",
-        systemPrompt: "Sys",
-        userPrompts: ["User"],
-        outputCol: "Out",
-      },
-    };
-    mockPrepRecipe.mockResolvedValue(result);
-    const { container, nav } = mount({
-      driveFolder: { colTitle: "Drive Link" },
-      systemPrompt: {
-        colTitle: { value: "Sys", locked: true },
-        prompt: { value: "p", locked: true },
-      },
-      userPrompts: [
-        { colTitle: { value: "User", locked: true }, prompt: { value: "q", locked: true } },
-      ],
-      outputCol: { colTitle: { value: "Out", locked: true } },
-    });
-    container.querySelector<HTMLInputElement>("#drive-folder-input")!.value =
+  it("navigates to configure-ai-run with RunConfig assembled from ColumnDef roles + rowRange", async () => {
+    mockPrepRecipe.mockResolvedValue({ rowRange: { start: 2, end: 5 } });
+    const { container, nav } = mount({ columns: fullColumns });
+    container.querySelector<HTMLInputElement>("#col-0-url-input")!.value =
       "https://drive.google.com/abc";
     container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
     await flush();
     container.querySelector<HTMLButtonElement>("#cook-btn")!.click();
     expect(nav.navigate).toHaveBeenCalledWith("configure-ai-run", {
       promptCols: [
-        { col: "User", kind: "text" },
         { col: "Drive Link", kind: "file" },
+        { col: "User Prompt", kind: "text" },
       ],
-      systemPromptCol: "Sys",
-      outputCol: "Out",
+      systemPromptCol: "System Prompt",
+      outputCol: "AI_Out",
       rowRange: { start: 2, end: 5 },
-      tools: undefined,
     });
+  });
+
+  it("spreads RecipeSettings into RunConfig", async () => {
+    mockPrepRecipe.mockResolvedValue({ rowRange: { start: 2, end: 3 } });
+    const outputOnly: ColumnDef = fullColumns[3];
+    const { container, nav } = mount({
+      columns: [outputOnly],
+      settings: { tools: ["google_search"], applyMarkdown: true },
+    });
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    container.querySelector<HTMLButtonElement>("#cook-btn")!.click();
+    expect(nav.navigate).toHaveBeenCalledWith("configure-ai-run",
+      expect.objectContaining({ tools: ["google_search"], applyMarkdown: true }),
+    );
   });
 });
 
 // ── saved state ────────────────────────────────────────────────
 
 describe("unmount / saved state", () => {
-  it("unmount returns form values and prepComplete: false when not prepped", () => {
-    const { container, panel } = mount({
-      driveFolder: { colTitle: "Drive Link" },
-      outputCol: { colTitle: { value: "AI_Out", locked: true } },
-    });
-    container.querySelector<HTMLInputElement>("#drive-folder-input")!.value = "my-folder";
+  it("unmount returns colValues array and prepComplete: false when not prepped", () => {
+    const { container, panel } = mount({ columns: [fullColumns[0]] });
+    container.querySelector<HTMLInputElement>("#col-0-url-input")!.value = "my-folder-url";
     const state = panel.unmount();
     expect(state).toMatchObject({
-      driveFolderValue: "my-folder",
+      colValues: [expect.objectContaining({ url: "my-folder-url" })],
       prepComplete: false,
     });
   });
 
-  it("mounts with savedState — restores form values", () => {
+  it("restores url value from savedState", () => {
     const savedState = {
-      driveFolderValue: "restored-folder",
-      outputColTitle: "MyOutput",
+      colValues: [{ url: "restored-url" }],
       prepComplete: false,
     };
-    const { container } = mount(
-      {
-        driveFolder: { colTitle: "Drive Link" },
-        outputCol: { colTitle: { value: "AI_Out", locked: true } },
-      },
-      savedState,
-    );
-    expect(container.querySelector<HTMLInputElement>("#drive-folder-input")!.value).toBe(
-      "restored-folder",
-    );
+    const { container } = mount({ columns: [fullColumns[0]] }, savedState);
+    expect(container.querySelector<HTMLInputElement>("#col-0-url-input")!.value).toBe("restored-url");
   });
 
   it("mounts with savedState prepComplete: true — Cook is enabled", () => {
     const savedState = {
+      colValues: [{}],
       prepComplete: true,
-      preppedRunConfig: { outputCol: "Out", promptCols: [{ col: "User", kind: "text" as const }] },
+      preppedRunConfig: { outputCol: "Out", promptCols: [] },
     };
-    const { container } = mount(
-      { outputCol: { colTitle: { value: "Out", locked: true } } },
-      savedState,
-    );
+    const { container } = mount({ columns: [fullColumns[3]] }, savedState);
     expect(container.querySelector<HTMLButtonElement>("#cook-btn")!.disabled).toBe(false);
   });
 });

--- a/__tests__/services.test.ts
+++ b/__tests__/services.test.ts
@@ -107,12 +107,13 @@ describe("prepRecipe", () => {
   it("calls google.script.run.prepRecipe with params and resolves with result", async () => {
     const handlers = captureHandlers();
     const params: import("../src/shared/types").PrepRecipeParams = {
-      driveFolder: { url: "https://drive.google.com/folder/abc", colTitle: "Drive Link" },
-      outputCol: { colTitle: "AI_Summarization" },
+      cols: [
+        { colTitle: "Drive Link", strategy: { kind: "list-drive-folder", url: "https://drive.google.com/folder/abc" } },
+        { colTitle: "AI_Summarization", strategy: { kind: "create-empty" } },
+      ],
     };
     const result: import("../src/shared/types").PrepRecipeResult = {
       rowRange: { start: 2, end: 5 },
-      colNames: { driveLink: "Drive Link", outputCol: "AI_Summarization" },
     };
     const promise = services.prepRecipe(params);
     handlers.resolve(result);
@@ -122,7 +123,7 @@ describe("prepRecipe", () => {
 
   it("rejects on failure", async () => {
     const handlers = captureHandlers();
-    const promise = services.prepRecipe({});
+    const promise = services.prepRecipe({ cols: [] });
     handlers.reject(new Error("prep error"));
     await expect(promise).rejects.toThrow("prep error");
   });

--- a/appsscript.json
+++ b/appsscript.json
@@ -13,7 +13,8 @@
   "runtimeVersion": "V8",
   "oauthScopes": [
     "https://www.googleapis.com/auth/spreadsheets",
-    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/drive.readonly",
+    "https://www.googleapis.com/auth/drive.file",
     "https://www.googleapis.com/auth/documents",
     "https://www.googleapis.com/auth/script.external_request",
     "https://www.googleapis.com/auth/script.container.ui"

--- a/docs/plans/2026-03-26-recipe-prep-redesign-plan.md
+++ b/docs/plans/2026-03-26-recipe-prep-redesign-plan.md
@@ -1,0 +1,930 @@
+# Recipe Prep Redesign Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the named-field `PrepRecipeParams`/`RecipeParams` shape with an agnostic `ColumnDef[]` system that separates population strategy (server), semantic role (client), and UI configuration (client).
+
+**Architecture:** Three-phase refactor — (1) shared types + server, (2) client types + recipe migration, (3) RecipePanel rewrite. Each phase is independently committable. See `docs/plans/2026-03-26-recipe-prep-redesign.md` for full design rationale.
+
+**Tech Stack:** TypeScript, Jest/ts-jest, jsdom (client tests), Google Apps Script globals mocked via `globalThis`
+
+---
+
+## Phase 1: Shared Types + Server
+
+### Task 1: Replace PrepRecipeParams and PrepRecipeResult in shared/types.ts
+
+**Files:**
+- Modify: `src/shared/types.ts`
+
+**Step 1: Replace the recipe RPC types**
+
+In `src/shared/types.ts`, replace the entire `// ── Recipes ─────────────────────────────────────────────────────` section:
+
+```typescript
+// ── Recipes ─────────────────────────────────────────────────────
+
+export type ColStrategy =
+  | { kind: "list-drive-folder"; url: string }
+  | { kind: "fill-value"; value: string }
+  | { kind: "create-empty" };
+
+export interface PrepColSpec {
+  colTitle: string;
+  strategy: ColStrategy;
+}
+
+export interface PrepRecipeParams {
+  cols: PrepColSpec[];
+}
+
+export interface PrepRecipeResult {
+  rowRange: { start: number; end: number };
+}
+```
+
+Remove: the old `PrepRecipeParams` (with `driveFolder?`, `systemPrompt?`, `userPrompts?`, `outputCol?`, `tools?`) and the old `PrepRecipeResult` (with `rowRange`, `colNames`, `tools?`).
+
+**Step 2: Run typecheck to see what breaks**
+
+```bash
+npm run typecheck
+```
+
+Expected: type errors in `src/server/index.ts`, `src/client/panels/recipe.ts`, `__tests__/panels/recipe.test.ts`. These are addressed in subsequent tasks.
+
+**Step 3: Commit**
+
+```bash
+git add src/shared/types.ts
+git commit -m "refactor: replace named-field PrepRecipeParams/Result with agnostic ColStrategy shapes"
+```
+
+---
+
+### Task 2: Rewrite server prepRecipe()
+
+**Files:**
+- Modify: `src/server/index.ts`
+
+**Step 1: Replace the prepRecipe function body**
+
+Find `export function prepRecipe(params: PrepRecipeParams): PrepRecipeResult {` in `src/server/index.ts` and replace the entire function:
+
+```typescript
+export function prepRecipe(params: PrepRecipeParams): PrepRecipeResult {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+  let numRows = 1;
+
+  // Pass 1: scan Drive folders, cache results, determine numRows
+  const folderCache = new Map<string, string[]>();
+  for (const col of params.cols) {
+    if (col.strategy.kind === "list-drive-folder") {
+      const url = col.strategy.url;
+      if (!folderCache.has(url)) {
+        const folder = DriveApp.getFolderById(extractId(url));
+        const files: { url: string }[] = [];
+        getAllFilesRecursive(folder, files);
+        folderCache.set(url, files.map((f) => f.url));
+      }
+      numRows = Math.max(numRows, folderCache.get(url)!.length || 1);
+    }
+  }
+
+  // Pass 2: write all columns
+  for (const col of params.cols) {
+    const colIdx = findOrCreateColumn(sheet, col.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
+    switch (col.strategy.kind) {
+      case "list-drive-folder": {
+        const urls = folderCache.get(col.strategy.url) ?? [];
+        writeColumn(sheet, colIdx, urls, SpreadsheetApp.WrapStrategy.CLIP);
+        break;
+      }
+      case "fill-value":
+        writeColumn(
+          sheet,
+          colIdx,
+          Array(numRows).fill(col.strategy.value) as string[],
+          SpreadsheetApp.WrapStrategy.CLIP,
+        );
+        break;
+      case "create-empty":
+        break;
+    }
+  }
+
+  SpreadsheetApp.flush();
+  return { rowRange: { start: 2, end: 2 + numRows - 1 } };
+}
+```
+
+**Step 2: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: `src/server/index.ts` passes. Remaining errors are in client files (addressed next).
+
+**Step 3: Run tests**
+
+```bash
+npm test
+```
+
+Expected: `__tests__/panels/recipe.test.ts` fails (shape mismatch). All other suites pass.
+
+**Step 4: Commit**
+
+```bash
+git add src/server/index.ts
+git commit -m "refactor: rewrite prepRecipe() to iterate PrepColSpec[] with two-pass folder scan"
+```
+
+---
+
+## Phase 2: Client Types + Recipe Migration
+
+### Task 3: Add new client types to client/types.ts
+
+**Files:**
+- Modify: `src/client/types.ts`
+
+**Step 1: Add new types and replace RecipeParams**
+
+Add to imports at the top of `src/client/types.ts`:
+```typescript
+import type { ToolId } from "../shared/types";
+```
+
+Replace the existing `RecipeParams` interface and add the new types. The full additions/replacements:
+
+```typescript
+export type ColStrategyKind = "list-drive-folder" | "fill-value" | "create-empty";
+export type ColRole = "userPrompt" | "systemPrompt" | "driveLink" | "output";
+
+export interface AppendField {
+  id: string;
+  label: string;
+  placeholder?: string;
+  /** Text injected before the reporter's value, e.g. "\n\nYou are looking for:\n\n" */
+  prefix?: string;
+}
+
+export interface RecipeSettings {
+  tools?: ToolId[];
+  applyMarkdown?: boolean;
+  includeGrounding?: boolean;
+}
+
+export interface ColumnDef {
+  /** UI section heading shown in the recipe panel */
+  label: string;
+  /** How this column maps into RunConfig after prep */
+  role: ColRole;
+  /** What PrepColSpec.strategy type to generate during prep */
+  strategyKind: ColStrategyKind;
+  /** Lockable column header field */
+  colTitle: RecipeFieldConfig;
+  /** Lockable prompt text — present for fill-value columns */
+  prompt?: RecipeFieldConfig;
+  /** Lockable URL input — present for drive columns */
+  url?: RecipeFieldConfig;
+  /** Extra reporter inputs composed into the prompt before prep */
+  appendFields?: AppendField[];
+  helperText?: string;
+  /** Show * in section heading */
+  required?: boolean;
+}
+
+export interface RecipeParams {
+  columns: ColumnDef[];
+  settings?: RecipeSettings;
+}
+```
+
+Remove the old `RecipeParams` interface (with `driveFolder?`, `systemPrompt?`, `userPrompts?`, `outputCol?`).
+
+`RecipeDefinition` is unchanged — `params?: RecipeParams` already references the updated type.
+
+**Step 2: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: errors in `src/client/recipes.ts` and `src/client/panels/recipe.ts` (they use old RecipeParams shape). Addressed in subsequent tasks.
+
+**Step 3: Commit**
+
+```bash
+git add src/client/types.ts
+git commit -m "refactor: replace named-field RecipeParams with ColumnDef[] + RecipeSettings"
+```
+
+---
+
+### Task 4: Migrate document-summarization recipe
+
+**Files:**
+- Modify: `src/client/recipes.ts`
+
+**Step 1: Rewrite the document-summarization recipe entry**
+
+Replace the entire `document-summarization` entry in `RECIPES` with:
+
+```typescript
+{
+  id: "document-summarization",
+  name: "Document Summarization",
+  icon: "📄",
+  description: "Summarize each file in a Google Drive folder",
+  panelId: "recipe",
+  params: {
+    columns: [
+      {
+        label: "Drive Folder",
+        role: "driveLink",
+        strategyKind: "list-drive-folder",
+        colTitle: { value: "Drive Link", locked: true },
+        url: { value: "", locked: false, placeholder: "Paste Google Drive folder URL" },
+        helperText: "Make sure you have access to this folder",
+        required: true,
+      },
+      {
+        label: "System Prompt",
+        role: "systemPrompt",
+        strategyKind: "fill-value",
+        colTitle: { value: "System Prompt", locked: true },
+        prompt: {
+          value:
+            "You are an expert document analyst. Produce clear, structured summaries " +
+            "focusing on key themes, main arguments, important data points, and actionable conclusions.",
+          locked: true,
+        },
+      },
+      {
+        label: "User Prompt",
+        role: "userPrompt",
+        strategyKind: "fill-value",
+        colTitle: { value: "User Prompt", locked: true },
+        prompt: {
+          value:
+            "Please summarize the attached document. Include the main topics, key findings, " +
+            "and important conclusions. The document file will be attached as inline data.",
+          locked: true,
+        },
+      },
+      {
+        label: "Output Column",
+        role: "output",
+        strategyKind: "create-empty",
+        colTitle: { value: "AI_Summarization", locked: true },
+      },
+    ],
+  } satisfies RecipeParams,
+},
+```
+
+Update the import at the top if needed — `RecipeParams` is still exported from `"./types"`.
+
+**Step 2: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: `src/client/recipes.ts` passes. Remaining errors in `src/client/panels/recipe.ts`.
+
+**Step 3: Commit**
+
+```bash
+git add src/client/recipes.ts
+git commit -m "refactor: migrate document-summarization recipe to ColumnDef[] shape"
+```
+
+---
+
+## Phase 3: RecipePanel Rewrite
+
+This is the largest task. The panel's template, field mounting, prep params, run config assembly, and saved state all change together. Write the tests first, then implement.
+
+### Task 5: Rewrite RecipePanel tests
+
+**Files:**
+- Modify: `__tests__/panels/recipe.test.ts`
+
+**Step 1: Replace the test file**
+
+The new tests use `ColumnDef[]` shape and new DOM IDs (`#col-{i}-title-container`, `#col-{i}-prompt-container`, `#col-{i}-url-input`). Replace the full file:
+
+```typescript
+/**
+ * @jest-environment jsdom
+ */
+jest.mock("../../src/client/services", () => ({
+  prepRecipe: jest.fn(),
+}));
+
+import { RecipePanel } from "../../src/client/panels/recipe";
+import * as services from "../../src/client/services";
+import type { PrepRecipeResult } from "../../src/shared/types";
+import type { ColumnDef, RecipeDefinition, RecipeParams, NavigationContext } from "../../src/client/types";
+
+const mockPrepRecipe = services.prepRecipe as jest.Mock;
+
+function makeNav(): jest.Mocked<NavigationContext> {
+  return {
+    navigate: jest.fn(),
+    back: jest.fn(),
+    canGoBack: jest.fn().mockReturnValue(true),
+  };
+}
+
+function mount(params: RecipeParams, savedState?: unknown) {
+  const container = document.createElement("div");
+  const nav = makeNav();
+  const panel = new RecipePanel();
+  const definition: RecipeDefinition = {
+    id: "test",
+    name: "Test Recipe",
+    icon: "🧪",
+    description: "Test",
+    panelId: "recipe",
+    params,
+  };
+  panel.mount(container, nav, definition, savedState as never);
+  return { container, nav, panel, definition };
+}
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+// helper: a minimal column set covering all roles
+const fullColumns: ColumnDef[] = [
+  {
+    label: "Drive Folder",
+    role: "driveLink",
+    strategyKind: "list-drive-folder",
+    colTitle: { value: "Drive Link", locked: true },
+    url: { value: "", locked: false, placeholder: "Paste folder URL" },
+    required: true,
+  },
+  {
+    label: "System Prompt",
+    role: "systemPrompt",
+    strategyKind: "fill-value",
+    colTitle: { value: "System Prompt", locked: true },
+    prompt: { value: "You are helpful.", locked: true },
+  },
+  {
+    label: "User Prompt",
+    role: "userPrompt",
+    strategyKind: "fill-value",
+    colTitle: { value: "User Prompt", locked: true },
+    prompt: { value: "Summarize.", locked: true },
+  },
+  {
+    label: "Output Column",
+    role: "output",
+    strategyKind: "create-empty",
+    colTitle: { value: "AI_Out", locked: true },
+  },
+];
+
+const mockResult: PrepRecipeResult = {
+  rowRange: { start: 2, end: 11 },
+};
+
+// ── rendering ───────────────────────────────────────────────────
+
+describe("rendering", () => {
+  it("renders a url input for list-drive-folder columns", () => {
+    const { container } = mount({ columns: [fullColumns[0]] });
+    expect(container.querySelector("#col-0-url-input")).not.toBeNull();
+  });
+
+  it("does not render url input for fill-value columns", () => {
+    const { container } = mount({ columns: [fullColumns[2]] });
+    expect(container.querySelector("#col-0-url-input")).toBeNull();
+  });
+
+  it("renders a prompt container for fill-value columns", () => {
+    const { container } = mount({ columns: [fullColumns[1]] });
+    expect(container.querySelector("#col-0-prompt-container")).not.toBeNull();
+  });
+
+  it("does not render prompt container for create-empty columns", () => {
+    const { container } = mount({ columns: [fullColumns[3]] });
+    expect(container.querySelector("#col-0-prompt-container")).toBeNull();
+  });
+
+  it("renders one section per ColumnDef", () => {
+    const { container } = mount({ columns: fullColumns });
+    expect(container.querySelectorAll(".recipe-section-card")).toHaveLength(fullColumns.length);
+  });
+
+  it("renders append field inputs when appendFields present", () => {
+    const colWithAppend: ColumnDef = {
+      ...fullColumns[2],
+      appendFields: [{ id: "search", label: "What are you looking for?" }],
+    };
+    const { container } = mount({ columns: [colWithAppend] });
+    expect(container.querySelector("#col-0-append-search")).not.toBeNull();
+  });
+});
+
+// ── LockableField defaults ────────────────────────────────────────
+
+describe("LockableField defaults", () => {
+  it("initialises locked colTitle field as disabled", () => {
+    const { container } = mount({ columns: [fullColumns[3]] });
+    const input = container.querySelector<HTMLInputElement>("#col-0-title-container input")!;
+    expect(input.value).toBe("AI_Out");
+    expect(input.disabled).toBe(true);
+  });
+
+  it("initialises unlocked url field as enabled", () => {
+    const { container } = mount({ columns: [fullColumns[0]] });
+    const input = container.querySelector<HTMLInputElement>("#col-0-url-input")!;
+    expect(input.disabled).toBe(false);
+  });
+});
+
+// ── prep flow ──────────────────────────────────────────────────
+
+describe("Prep flow", () => {
+  beforeEach(() => mockPrepRecipe.mockClear());
+
+  it("calls services.prepRecipe with PrepColSpec[] built from resolved field values", async () => {
+    mockPrepRecipe.mockResolvedValue(mockResult);
+    const { container } = mount({ columns: fullColumns });
+    container.querySelector<HTMLInputElement>("#col-0-url-input")!.value =
+      "https://drive.google.com/drive/folders/abc123";
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    expect(mockPrepRecipe).toHaveBeenCalledWith({
+      cols: [
+        { colTitle: "Drive Link", strategy: { kind: "list-drive-folder", url: "https://drive.google.com/drive/folders/abc123" } },
+        { colTitle: "System Prompt", strategy: { kind: "fill-value", value: "You are helpful." } },
+        { colTitle: "User Prompt", strategy: { kind: "fill-value", value: "Summarize." } },
+        { colTitle: "AI_Out", strategy: { kind: "create-empty" } },
+      ],
+    });
+  });
+
+  it("composes appendFields into the fill-value prompt string", async () => {
+    mockPrepRecipe.mockResolvedValue(mockResult);
+    const colWithAppend: ColumnDef = {
+      ...fullColumns[2],
+      appendFields: [{ id: "search", label: "What?", prefix: "\n\nLooking for:\n\n" }],
+    };
+    const { container } = mount({ columns: [colWithAppend] });
+    container.querySelector<HTMLInputElement>("#col-0-append-search")!.value = "a signature";
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    expect(mockPrepRecipe).toHaveBeenCalledWith({
+      cols: [
+        {
+          colTitle: "User Prompt",
+          strategy: { kind: "fill-value", value: "Summarize.\n\nLooking for:\n\na signature" },
+        },
+      ],
+    });
+  });
+
+  it("shows alert and does not call prepRecipe when url input is empty for list-drive-folder", async () => {
+    const alertMock = jest.fn();
+    globalThis.alert = alertMock;
+    const { container } = mount({ columns: [fullColumns[0]] });
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    expect(alertMock).toHaveBeenCalledTimes(1);
+    expect(mockPrepRecipe).not.toHaveBeenCalled();
+  });
+});
+
+// ── Cook flow ──────────────────────────────────────────────────
+
+describe("Cook flow", () => {
+  it("navigates to configure-ai-run with RunConfig assembled from ColumnDef roles + rowRange", async () => {
+    mockPrepRecipe.mockResolvedValue({ rowRange: { start: 2, end: 5 } });
+    const { container, nav } = mount({ columns: fullColumns });
+    container.querySelector<HTMLInputElement>("#col-0-url-input")!.value =
+      "https://drive.google.com/abc";
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    container.querySelector<HTMLButtonElement>("#cook-btn")!.click();
+    expect(nav.navigate).toHaveBeenCalledWith("configure-ai-run", {
+      promptCols: [
+        { col: "Drive Link", kind: "file" },
+        { col: "User Prompt", kind: "text" },
+      ],
+      systemPromptCol: "System Prompt",
+      outputCol: "AI_Out",
+      rowRange: { start: 2, end: 5 },
+    });
+  });
+
+  it("spreads RecipeSettings into RunConfig", async () => {
+    mockPrepRecipe.mockResolvedValue({ rowRange: { start: 2, end: 3 } });
+    const outputOnly: ColumnDef = fullColumns[3];
+    const { container, nav } = mount({
+      columns: [outputOnly],
+      settings: { tools: ["google_search"], applyMarkdown: true },
+    });
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    container.querySelector<HTMLButtonElement>("#cook-btn")!.click();
+    expect(nav.navigate).toHaveBeenCalledWith("configure-ai-run",
+      expect.objectContaining({ tools: ["google_search"], applyMarkdown: true }),
+    );
+  });
+});
+
+// ── saved state ────────────────────────────────────────────────
+
+describe("unmount / saved state", () => {
+  it("unmount returns colValues array and prepComplete: false when not prepped", () => {
+    const { container, panel } = mount({ columns: [fullColumns[0]] });
+    container.querySelector<HTMLInputElement>("#col-0-url-input")!.value = "my-folder-url";
+    const state = panel.unmount();
+    expect(state).toMatchObject({
+      colValues: [expect.objectContaining({ url: "my-folder-url" })],
+      prepComplete: false,
+    });
+  });
+
+  it("restores url value from savedState", () => {
+    const savedState = {
+      colValues: [{ url: "restored-url" }],
+      prepComplete: false,
+    };
+    const { container } = mount({ columns: [fullColumns[0]] }, savedState);
+    expect(container.querySelector<HTMLInputElement>("#col-0-url-input")!.value).toBe("restored-url");
+  });
+
+  it("mounts with savedState prepComplete: true — Cook is enabled", () => {
+    const savedState = {
+      colValues: [{}],
+      prepComplete: true,
+      preppedRunConfig: { outputCol: "Out", promptCols: [] },
+    };
+    const { container } = mount({ columns: [fullColumns[3]] }, savedState);
+    expect(container.querySelector<HTMLButtonElement>("#cook-btn")!.disabled).toBe(false);
+  });
+});
+```
+
+**Step 2: Run the new tests to verify they all fail**
+
+```bash
+npx jest __tests__/panels/recipe.test.ts
+```
+
+Expected: multiple failures — DOM IDs not found, shape mismatches. This confirms the tests are exercising the right new behavior.
+
+---
+
+### Task 6: Rewrite RecipePanel
+
+**Files:**
+- Modify: `src/client/panels/recipe.ts`
+
+**Step 1: Replace the full file**
+
+The panel's private fields, SavedState, template, mountFields, buildPrepParams, buildRunConfig, and unmount all change. Replace the full file content:
+
+```typescript
+import type { NavigationContext, Panel, RecipeDefinition, ColumnDef } from "../types";
+import type { ColStrategy, PrepColSpec, PrepRecipeParams, PrepRecipeResult, RunConfig, PromptColumnSpec } from "../../shared/types";
+import { LockableField } from "../components/lockable-field";
+import { RecipePrepCook } from "../components/recipe-prep-cook";
+import { prepRecipe } from "../services";
+
+type ColFieldRefs = {
+  colTitle?: LockableField;
+  prompt?: LockableField;
+  urlInput?: HTMLInputElement;
+  appendInputs?: Record<string, HTMLInputElement>;
+};
+
+type ColSavedValues = {
+  colTitle?: string;
+  prompt?: string;
+  url?: string;
+  appendValues?: Record<string, string>;
+};
+
+type SavedState = {
+  colValues: ColSavedValues[];
+  prepComplete: boolean;
+  preppedRunConfig?: Partial<RunConfig>;
+};
+
+export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
+  private nav: NavigationContext | null = null;
+  private definition: RecipeDefinition | null = null;
+  private prepCook: RecipePrepCook | null = null;
+  private preppedRunConfig: Partial<RunConfig> | null = null;
+  private fields: ColFieldRefs[] = [];
+
+  mount(
+    container: HTMLElement,
+    nav: NavigationContext,
+    definition?: RecipeDefinition,
+    savedState?: SavedState,
+  ): void {
+    this.nav = nav;
+    this.definition = definition ?? null;
+    this.fields = [];
+    this.preppedRunConfig = savedState?.preppedRunConfig ?? null;
+
+    container.innerHTML = this.template(definition);
+    container.querySelector("#back-btn")?.addEventListener("click", () => nav.back());
+
+    this.mountFields(container, definition?.params?.columns ?? [], savedState);
+    this.mountPrepCook(container, savedState?.prepComplete ?? false);
+  }
+
+  unmount(): SavedState {
+    const colValues: ColSavedValues[] = this.fields.map((f) => ({
+      colTitle: f.colTitle?.getValue(),
+      prompt: f.prompt?.getValue(),
+      url: f.urlInput?.value,
+      appendValues: f.appendInputs
+        ? Object.fromEntries(
+            Object.entries(f.appendInputs).map(([id, el]) => [id, el.value]),
+          )
+        : undefined,
+    }));
+    return {
+      colValues,
+      prepComplete: this.prepCook?.isPrepComplete() ?? false,
+      preppedRunConfig: this.preppedRunConfig ?? undefined,
+    };
+  }
+
+  private mountFields(
+    container: HTMLElement,
+    columns: ColumnDef[],
+    savedState?: SavedState,
+  ): void {
+    const reset = (): void => this.prepCook?.reset();
+
+    columns.forEach((col, i) => {
+      const saved = savedState?.colValues?.[i];
+      const refs: ColFieldRefs = {};
+
+      refs.colTitle = new LockableField(
+        container.querySelector(`#col-${i}-title-container`)!,
+        {
+          label: "Column",
+          defaultValue: saved?.colTitle ?? col.colTitle.value,
+          locked: col.colTitle.locked,
+          onUnlock: reset,
+        },
+      );
+
+      if (col.prompt !== undefined) {
+        refs.prompt = new LockableField(
+          container.querySelector(`#col-${i}-prompt-container`)!,
+          {
+            label: "Prompt",
+            defaultValue: saved?.prompt ?? col.prompt.value,
+            locked: col.prompt.locked,
+            multiline: true,
+            onUnlock: reset,
+          },
+        );
+      }
+
+      if (col.url !== undefined) {
+        const urlEl = container.querySelector<HTMLInputElement>(`#col-${i}-url-input`);
+        if (urlEl) {
+          if (saved?.url) urlEl.value = saved.url;
+          urlEl.addEventListener("input", reset);
+          refs.urlInput = urlEl;
+        }
+      }
+
+      if (col.appendFields?.length) {
+        refs.appendInputs = {};
+        for (const af of col.appendFields) {
+          const el = container.querySelector<HTMLInputElement>(`#col-${i}-append-${af.id}`);
+          if (el) {
+            if (saved?.appendValues?.[af.id]) el.value = saved.appendValues[af.id];
+            refs.appendInputs[af.id] = el;
+          }
+        }
+      }
+
+      this.fields[i] = refs;
+    });
+  }
+
+  private mountPrepCook(container: HTMLElement, prepComplete: boolean): void {
+    this.prepCook = new RecipePrepCook(container.querySelector("#prep-cook-container")!, {
+      onPrep: async (): Promise<void> => {
+        const params = this.buildPrepParams();
+        if (!params) throw null;
+        const result = await prepRecipe(params);
+        this.preppedRunConfig = this.buildRunConfig(result);
+      },
+      onCook: (): void => {
+        if (this.preppedRunConfig) {
+          this.nav?.navigate("configure-ai-run", this.preppedRunConfig);
+        }
+      },
+      prepComplete,
+    });
+  }
+
+  private buildPrepParams(): PrepRecipeParams | null {
+    const columns = this.definition?.params?.columns ?? [];
+    const cols: PrepColSpec[] = [];
+
+    for (let i = 0; i < columns.length; i++) {
+      const col = columns[i];
+      const colTitle = this.fields[i]?.colTitle?.getValue() ?? col.colTitle.value;
+
+      let strategy: ColStrategy;
+      switch (col.strategyKind) {
+        case "list-drive-folder": {
+          const url = this.fields[i]?.urlInput?.value.trim() ?? "";
+          if (!url) {
+            globalThis.alert(`Please enter a URL for "${col.label}".`);
+            return null;
+          }
+          strategy = { kind: "list-drive-folder", url };
+          break;
+        }
+        case "fill-value": {
+          const base = this.fields[i]?.prompt?.getValue() ?? col.prompt?.value ?? "";
+          const appended = (col.appendFields ?? [])
+            .map((af) => {
+              const v = this.fields[i]?.appendInputs?.[af.id]?.value.trim() ?? "";
+              return v ? (af.prefix ?? "") + v : "";
+            })
+            .join("");
+          strategy = { kind: "fill-value", value: base + appended };
+          break;
+        }
+        case "create-empty":
+          strategy = { kind: "create-empty" };
+          break;
+      }
+
+      cols.push({ colTitle, strategy });
+    }
+
+    return { cols };
+  }
+
+  private buildRunConfig(result: PrepRecipeResult): Partial<RunConfig> {
+    const columns = this.definition?.params?.columns ?? [];
+    const settings = this.definition?.params?.settings ?? {};
+    const promptCols: PromptColumnSpec[] = [];
+    let systemPromptCol: string | undefined;
+    let outputCol = "";
+
+    for (let i = 0; i < columns.length; i++) {
+      const col = columns[i];
+      const resolvedTitle = this.fields[i]?.colTitle?.getValue() ?? col.colTitle.value;
+
+      switch (col.role) {
+        case "userPrompt":
+          promptCols.push({ col: resolvedTitle, kind: "text" });
+          break;
+        case "driveLink":
+          promptCols.push({ col: resolvedTitle, kind: "file" });
+          break;
+        case "systemPrompt":
+          systemPromptCol = resolvedTitle;
+          break;
+        case "output":
+          outputCol = resolvedTitle;
+          break;
+      }
+    }
+
+    return { promptCols, systemPromptCol, outputCol, rowRange: result.rowRange, ...settings };
+  }
+
+  private template(definition: RecipeDefinition | undefined | null): string {
+    const columns = definition?.params?.columns ?? [];
+    const title = definition ? `${definition.icon} ${definition.name}` : "Recipe";
+
+    const columnSections = columns
+      .map((col, i) => {
+        const requiredMark = col.required ? ` <span class="required">*</span>` : "";
+        const helperHtml = col.helperText ? `<p class="field-helper">${col.helperText}</p>` : "";
+
+        const urlInputHtml =
+          col.url !== undefined
+            ? `<input id="col-${i}-url-input" type="text" class="text-input"
+                placeholder="${col.url.placeholder ?? "Paste Google Drive URL"}" />`
+            : "";
+
+        const promptContainerHtml =
+          col.prompt !== undefined ? `<div id="col-${i}-prompt-container"></div>` : "";
+
+        const appendFieldsHtml = (col.appendFields ?? [])
+          .map(
+            (af) =>
+              `<div class="append-field">
+                <label class="field-label">${af.label}</label>
+                <input id="col-${i}-append-${af.id}" type="text" class="text-input"
+                  placeholder="${af.placeholder ?? ""}" />
+              </div>`,
+          )
+          .join("");
+
+        return `
+          <div class="recipe-section-card">
+            <div class="recipe-section-card-title">${col.label}${requiredMark}</div>
+            ${helperHtml}
+            <div id="col-${i}-title-container"></div>
+            ${urlInputHtml}
+            ${promptContainerHtml}
+            ${appendFieldsHtml}
+          </div>`;
+      })
+      .join("");
+
+    return `
+      <div class="panel-header">
+        <button id="back-btn" class="back-btn">← Back</button>
+        <span class="panel-title">${title}</span>
+      </div>
+      ${columnSections}
+      <div id="prep-cook-container"></div>
+    `;
+  }
+}
+```
+
+**Step 2: Run the recipe panel tests**
+
+```bash
+npx jest __tests__/panels/recipe.test.ts
+```
+
+Expected: all tests pass.
+
+**Step 3: Run the full test suite**
+
+```bash
+npm test
+```
+
+Expected: all 332+ tests pass. Fix any unexpected failures before proceeding.
+
+**Step 4: Run typecheck and lint**
+
+```bash
+npm run typecheck && npm run lint
+```
+
+Expected: no errors.
+
+**Step 5: Commit**
+
+```bash
+git add src/client/panels/recipe.ts __tests__/panels/recipe.test.ts
+git commit -m "refactor: rewrite RecipePanel for ColumnDef[] — agnostic column specs, role-based RunConfig assembly"
+```
+
+---
+
+## Final Verification
+
+**Step 1: Full test suite with coverage**
+
+```bash
+npm run test:coverage
+```
+
+Expected: all tests pass, all per-file thresholds met.
+
+**Step 2: Typecheck both configs**
+
+```bash
+npm run typecheck
+```
+
+Expected: clean.
+
+**Step 3: Lint**
+
+```bash
+npm run lint
+```
+
+Expected: clean.
+
+**Step 4: Final commit if anything was cleaned up**
+
+If clean, no commit needed. The branch is ready for PR to `develop`.

--- a/docs/plans/2026-03-26-recipe-prep-redesign.md
+++ b/docs/plans/2026-03-26-recipe-prep-redesign.md
@@ -1,0 +1,400 @@
+# Recipe Prep Redesign: Agnostic Column Specs
+
+**Date:** 2026-03-26
+**Status:** Design complete, implementation plan ready
+
+---
+
+## Motivation
+
+The existing `PrepRecipeParams` conflates three separate concerns in one named-field shape:
+- **Population strategy** — how the server fills a column (scan a folder, fill a value, create empty)
+- **Semantic role** — what the column means in a RunConfig (file input, text prompt, system prompt, output)
+- **UI configuration** — what fields to render and what their defaults/locks are
+
+This made the "single source of truth" invariant (`preppedRunConfig` assembled from `PrepRecipeResult` alone) load-bearing. But that invariant was solving the wrong problem: users **should** be able to modify column titles, prompt values, and settings between prep and cook. Once that's accepted, `PrepRecipeResult` no longer needs to echo anything back — the client already has everything except the row count.
+
+A secondary issue: `PrepRecipeResult` echoed `tools` and `colNames` back from the server despite the server doing no processing on them. These were only there to preserve the invariant.
+
+---
+
+## Design
+
+### Core Insight
+
+Split the three concerns across the right owners:
+
+| Concern | Owner | Lives in |
+|---|---|---|
+| Population strategy | Server | `PrepColSpec.strategy` (sent in `PrepRecipeParams`) |
+| Semantic role | Client | `ColumnDef.role` (recipe definition, never sent to server) |
+| UI configuration | Client | `ColumnDef.colTitle / prompt / url / appendFields` |
+
+`PrepRecipeResult` shrinks to just `{ rowRange }` — the only thing the client genuinely couldn't know before prep ran.
+
+---
+
+### Shared Types (`src/shared/types.ts`)
+
+```typescript
+export type ColStrategy =
+  | { kind: "list-drive-folder"; url: string }  // scan folder, one row per file
+  | { kind: "fill-value"; value: string }        // fill N rows with the same value
+  | { kind: "create-empty" };                    // create column header only
+
+export interface PrepColSpec {
+  colTitle: string;
+  strategy: ColStrategy;
+}
+
+export interface PrepRecipeParams {
+  cols: PrepColSpec[];
+}
+
+export interface PrepRecipeResult {
+  rowRange: { start: number; end: number };
+}
+```
+
+`tools`, `colNames`, and the `settings` echo are all removed. The old named-field `PrepRecipeParams` and `PrepRecipeResult` are replaced entirely.
+
+---
+
+### Client Types (`src/client/types.ts`)
+
+```typescript
+export type ColStrategyKind = "list-drive-folder" | "fill-value" | "create-empty";
+export type ColRole = "userPrompt" | "systemPrompt" | "driveLink" | "output";
+
+export interface AppendField {
+  id: string;
+  label: string;
+  placeholder?: string;
+  /** Injected before the reporter's value when composing the final prompt string. */
+  prefix?: string;
+}
+
+export interface RecipeSettings {
+  tools?: ToolId[];
+  applyMarkdown?: boolean;
+  includeGrounding?: boolean;
+}
+
+export interface ColumnDef {
+  label: string;                  // UI section heading ("Drive Folder", "System Prompt", …)
+  role: ColRole;                  // how this column maps into RunConfig
+  strategyKind: ColStrategyKind;  // what PrepColSpec.strategy type to generate
+  colTitle: RecipeFieldConfig;    // lockable column header field
+  prompt?: RecipeFieldConfig;     // lockable prompt text (for fill-value columns)
+  url?: RecipeFieldConfig;        // lockable URL input (for drive columns)
+  appendFields?: AppendField[];   // extra reporter inputs appended to prompt before prep
+  helperText?: string;
+  required?: boolean;             // shows * in section heading
+}
+
+export interface RecipeParams {
+  columns: ColumnDef[];
+  settings?: RecipeSettings;
+}
+```
+
+`RecipeDefinition` is unchanged structurally — `params?: RecipeParams` already references the updated type.
+
+---
+
+### Server `prepRecipe()` (`src/server/index.ts`)
+
+Two-pass approach to avoid double folder scans:
+
+```typescript
+export function prepRecipe(params: PrepRecipeParams): PrepRecipeResult {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+  let numRows = 1;
+
+  // Pass 1: scan folders, build URL cache, determine numRows
+  const folderCache = new Map<string, string[]>();
+  for (const col of params.cols) {
+    if (col.strategy.kind === "list-drive-folder") {
+      const url = col.strategy.url;
+      if (!folderCache.has(url)) {
+        const folder = DriveApp.getFolderById(extractId(url));
+        const files: { url: string }[] = [];
+        getAllFilesRecursive(folder, files);
+        folderCache.set(url, files.map((f) => f.url));
+      }
+      numRows = Math.max(numRows, folderCache.get(url)!.length || 1);
+    }
+  }
+
+  // Pass 2: write all columns
+  for (const col of params.cols) {
+    const colIdx = findOrCreateColumn(sheet, col.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
+    switch (col.strategy.kind) {
+      case "list-drive-folder": {
+        const urls = folderCache.get(col.strategy.url) ?? [];
+        writeColumn(sheet, colIdx, urls, SpreadsheetApp.WrapStrategy.CLIP);
+        break;
+      }
+      case "fill-value":
+        writeColumn(
+          sheet, colIdx,
+          Array(numRows).fill(col.strategy.value) as string[],
+          SpreadsheetApp.WrapStrategy.CLIP,
+        );
+        break;
+      case "create-empty":
+        break; // findOrCreateColumn already created the header
+    }
+  }
+
+  SpreadsheetApp.flush();
+  return { rowRange: { start: 2, end: 2 + numRows - 1 } };
+}
+```
+
+---
+
+### Client `buildPrepParams()` (`src/client/panels/recipe.ts`)
+
+Iterates `ColumnDef[]`, resolves UI field values, constructs `PrepColSpec[]`. `appendFields` are composed into the prompt string before the server sees anything:
+
+```typescript
+private buildPrepParams(): PrepRecipeParams | null {
+  const columns = this.definition!.params!.columns;
+  const cols: PrepColSpec[] = [];
+
+  for (let i = 0; i < columns.length; i++) {
+    const col = columns[i];
+    const colTitle = this.fields[i].colTitle?.getValue() ?? col.colTitle.value;
+
+    let strategy: ColStrategy;
+    switch (col.strategyKind) {
+      case "list-drive-folder": {
+        const url = this.fields[i].url?.value.trim() ?? "";
+        if (!url) {
+          globalThis.alert(`Please enter a URL for "${col.label}".`);
+          return null;
+        }
+        strategy = { kind: "list-drive-folder", url };
+        break;
+      }
+      case "fill-value": {
+        const base = this.fields[i].prompt?.getValue() ?? col.prompt?.value ?? "";
+        const appended = (col.appendFields ?? [])
+          .map((af) => {
+            const v = this.fields[i].appendInputs?.[af.id]?.value.trim() ?? "";
+            return v ? (af.prefix ?? "") + v : "";
+          })
+          .join("");
+        strategy = { kind: "fill-value", value: base + appended };
+        break;
+      }
+      case "create-empty":
+        strategy = { kind: "create-empty" };
+        break;
+    }
+
+    cols.push({ colTitle, strategy });
+  }
+
+  return { cols };
+}
+```
+
+---
+
+### Client `buildRunConfig()` (`src/client/panels/recipe.ts`)
+
+Reads `ColumnDef.role` for RunConfig mapping. `tools` and other settings come from `definition.params.settings`, not from the server result:
+
+```typescript
+private buildRunConfig(result: PrepRecipeResult): Partial<RunConfig> {
+  const columns = this.definition!.params!.columns ?? [];
+  const settings = this.definition!.params!.settings ?? {};
+  const promptCols: PromptColumnSpec[] = [];
+  let systemPromptCol: string | undefined;
+  let outputCol = "";
+
+  for (let i = 0; i < columns.length; i++) {
+    const col = columns[i];
+    const resolvedTitle = this.fields[i].colTitle?.getValue() ?? col.colTitle.value;
+
+    switch (col.role) {
+      case "userPrompt":
+        promptCols.push({ col: resolvedTitle, kind: "text" });
+        break;
+      case "driveLink":
+        promptCols.push({ col: resolvedTitle, kind: "file" });
+        break;
+      case "systemPrompt":
+        systemPromptCol = resolvedTitle;
+        break;
+      case "output":
+        outputCol = resolvedTitle;
+        break;
+    }
+  }
+
+  return {
+    promptCols,
+    systemPromptCol,
+    outputCol,
+    rowRange: result.rowRange,
+    ...settings,
+  };
+}
+```
+
+---
+
+### Saved State
+
+Named fields are replaced with a column-indexed array:
+
+```typescript
+type ColSavedValues = {
+  colTitle?: string;
+  prompt?: string;
+  url?: string;
+  appendValues?: Record<string, string>;
+};
+
+type SavedState = {
+  colValues: ColSavedValues[];
+  prepComplete: boolean;
+  preppedRunConfig?: Partial<RunConfig>;
+};
+```
+
+---
+
+### `appendFields` flow
+
+`appendFields` live in `ColumnDef` (recipe definition). They are rendered by `RecipePanel` as plain `<input>` elements. When `buildPrepParams()` runs, it reads these inputs and composes them into the `fill-value` strategy's `value` — the server receives the composed string and never knows `appendFields` exist.
+
+---
+
+### Recipe Definition Example: Document Summarization
+
+```typescript
+{
+  id: "document-summarization",
+  name: "Document Summarization",
+  icon: "📄",
+  description: "Summarize each file in a Google Drive folder",
+  panelId: "recipe",
+  params: {
+    columns: [
+      {
+        label: "Drive Folder",
+        role: "driveLink",
+        strategyKind: "list-drive-folder",
+        colTitle: { value: "Drive Link", locked: true },
+        url: { value: "", locked: false, placeholder: "Paste Google Drive folder URL" },
+        helperText: "Make sure you have access to this folder",
+        required: true,
+      },
+      {
+        label: "System Prompt",
+        role: "systemPrompt",
+        strategyKind: "fill-value",
+        colTitle: { value: "System Prompt", locked: true },
+        prompt: {
+          value:
+            "You are an expert document analyst. Produce clear, structured summaries " +
+            "focusing on key themes, main arguments, important data points, and actionable conclusions.",
+          locked: true,
+        },
+      },
+      {
+        label: "User Prompt",
+        role: "userPrompt",
+        strategyKind: "fill-value",
+        colTitle: { value: "User Prompt", locked: true },
+        prompt: {
+          value:
+            "Please summarize the attached document. Include the main topics, key findings, " +
+            "and important conclusions. The document file will be attached as inline data.",
+          locked: true,
+        },
+      },
+      {
+        label: "Output Column",
+        role: "output",
+        strategyKind: "create-empty",
+        colTitle: { value: "AI_Summarization", locked: true },
+      },
+    ],
+  } satisfies RecipeParams,
+},
+```
+
+---
+
+## What This Enables
+
+### Find a Thing in a Thing recipe
+
+```typescript
+columns: [
+  {
+    label: "Documents Folder",
+    role: "driveLink",
+    strategyKind: "list-drive-folder",
+    colTitle: { value: "Drive Link", locked: true },
+    url: { value: "", locked: false },
+    required: true,
+  },
+  {
+    label: "Reference File",
+    role: "driveLink",
+    strategyKind: "fill-value",      // same URL in every row
+    colTitle: { value: "Reference File", locked: true },
+    url: { value: "", locked: false, placeholder: "Paste reference file URL" },
+  },
+  {
+    label: "System Prompt",
+    role: "systemPrompt",
+    strategyKind: "fill-value",
+    colTitle: { value: "System Prompt", locked: true },
+    prompt: { value: "You are a document analyst...", locked: true },
+  },
+  {
+    label: "User Prompt",
+    role: "userPrompt",
+    strategyKind: "fill-value",
+    colTitle: { value: "User Prompt", locked: true },
+    prompt: { value: "Does this document contain the following item?", locked: true },
+    appendFields: [
+      {
+        id: "search-description",
+        label: "What are you looking for?",
+        placeholder: "e.g. a signature, an exhibit sticker, a person's name",
+        prefix: "\n\nYou are specifically looking for:\n\n",
+      },
+    ],
+  },
+  {
+    label: "Output Column",
+    role: "output",
+    strategyKind: "create-empty",
+    colTitle: { value: "AI_FindResult", locked: true },
+  },
+],
+settings: { tools: ["google_search"] },
+```
+
+Note: `fill-value` for a `driveLink` role correctly maps to `{ kind: "file" }` in `promptCols`. The distinction between "folder scan" and "constant file link" is a strategy concern only — both become file parts in the Gemini request.
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `src/shared/types.ts` | Replace `PrepRecipeParams`/`PrepRecipeResult` with new agnostic shapes; add `ColStrategy`, `PrepColSpec` |
+| `src/client/types.ts` | Replace `RecipeParams` named fields with `ColumnDef[]`; add `ColStrategyKind`, `ColRole`, `AppendField`, `RecipeSettings` |
+| `src/client/recipes.ts` | Migrate document-summarization to new `ColumnDef` shape |
+| `src/client/panels/recipe.ts` | Rewrite `template()`, `mountFields()`, `buildPrepParams()`, `buildRunConfig()`, `unmount()` |
+| `src/server/index.ts` | Rewrite `prepRecipe()` to iterate `PrepColSpec[]` with two-pass folder scan |
+| `__tests__/panels/recipe.test.ts` | Rewrite tests for new `ColumnDef` shape and DOM structure |

--- a/docs/plans/2026-03-31-chunked-batch-execution-design.md
+++ b/docs/plans/2026-03-31-chunked-batch-execution-design.md
@@ -1,0 +1,293 @@
+# Chunked Batch Execution — Design Document
+
+## Problem
+
+`runBatchAI` is a monolithic server-side function that processes all requested rows in a
+single Apps Script execution. Apps Script enforces a **6-minute execution time limit** on
+`google.script.run` calls. A batch that exceeds this wall is killed mid-run — the job
+fails with a GAS timeout error, the user doesn't know which rows were written, and there
+is no recovery path.
+
+At realistic Gemini API latencies (3–6 seconds per row including sheet writes), the
+practical row ceiling before timeout is **60–120 rows** depending on configuration.
+Users who request more than this will encounter silent partial failures.
+
+Additionally, once a batch is dispatched, there is no mechanism to stop it. A user who
+accidentally submits 500 rows has no recourse.
+
+## Non-Goals
+
+This design does **not** address:
+
+- **True background processing** (sidebar can be closed mid-batch). That requires GAS
+  installable time-based triggers, which is a separate architectural effort. The current
+  design requires the sidebar to remain open for the entire run. This limitation is
+  documented explicitly in the UI.
+- **Batches larger than ~5,000 rows**. At that scale, the appropriate tool is a Vertex AI
+  batch pipeline, not a Sheets add-on. This design targets the realistic Sheets use case.
+- **`extractText` or `importDriveLinks`**. Those tools are generally faster per-row and
+  less commonly run at large scale. They can be chunked in a follow-up if needed.
+
+## Solution
+
+Split the client-side dispatch of `runBatchAI` into a **sequence of smaller calls**, each
+covering a fixed-size row slice. The server is unaware of chunking — `runBatchAI` already
+accepts a `rowRange` slice via `RunConfig`. Chunking is orchestrated entirely in the
+client.
+
+A new `JobStore.dispatchChunked()` method sequences the chunk calls, exposes a
+between-chunk cancellation point, and reports overall progress. From the user's
+perspective, the batch is one logical job in the strip — a single progress indicator,
+a single stop button, a single completion event.
+
+A pre-flight confirmation dialog warns the user before large batches start, communicating
+the chunk count, estimated duration, and the sidebar-open requirement.
+
+## Chunk Size
+
+**50 rows per chunk** — fixed constant, not user-configurable.
+
+Rationale: at 6 seconds/row (conservative, grounded run with Drive files), 50 rows = 5
+minutes, leaving a 1-minute safety margin before the GAS wall. At 3 seconds/row (text
+only), 50 rows = 2.5 minutes. The constant is defined once in `configure-ai-run.ts` and
+can be adjusted later without architectural change.
+
+## Pre-flight Warning
+
+When the user clicks "Run AI" and the row range covers more than `CHUNK_WARN_THRESHOLD`
+rows (initial value: **50**), show a `globalThis.confirm()` dialog before dispatching:
+
+```
+You're about to process 300 rows across 6 chunks.
+
+This will take roughly 30 minutes. The sidebar must remain open
+throughout — closing it will stop the run after the current chunk finishes.
+
+Continue?
+```
+
+If the user dismisses, nothing is dispatched.
+
+The warning fires **only when `rowRange` is explicitly set**. When `rowRange` is absent,
+the server uses the active sheet selection (resolved server-side), so the client doesn't
+know the count at dispatch time — skip the warning in that case.
+
+## Cancellation
+
+Cancellation is **between-chunk only**. There is no mechanism to interrupt an in-flight
+GAS execution (the current chunk completes before the run stops). This is expected
+behavior and is communicated in the UI ("Stopping after current chunk...").
+
+`JobStore` tracks a per-job cancel flag. When the user clicks the stop button:
+1. The flag is set immediately
+2. The job state transitions to `"cancelling"` — the stop button becomes a
+   "Stopping..." label
+3. When the current chunk's promise resolves, the dispatch loop checks the flag and exits
+   instead of starting the next chunk
+4. The job completes normally (toast is shown with how many rows were processed)
+
+The cancel flag is a plain `Map<string, boolean>` in `JobStore` — no RPC, no
+`CacheService`, no server involvement. This is the key architectural simplification over
+the originally discussed cancel approach.
+
+## New `LoadingStatus` value: `"cancelling"`
+
+`"cancelling"` is added to the `LoadingStatus` union in `client/types.ts`. It means:
+the user has requested cancellation, the current chunk is still in-flight, we're waiting
+for it to finish. The job is still in the strip's "active" filter but renders differently
+(no stop button, "Stopping..." label).
+
+This is distinct from `"error"` (unexpected failure) and `"complete"` (normal finish).
+
+## `JobStore` Changes
+
+### Design principle
+
+`JobStore.dispatch()` has one contract: **the caller creates the work, the store tracks
+it.** The store is an observer and reporter — it does not orchestrate sequences of
+operations. This design is preserved. `dispatch()` is unchanged.
+
+Three narrow additions support chunked execution from the outside:
+
+### New private field
+
+```ts
+private cancelFlags: Map<string, boolean> = new Map();
+```
+
+### New public method: `cancel(id)`
+
+Sets the cancel flag and transitions job state to `"cancelling"`. No-ops if the job is
+not in an active state. Called by `JobIndicator` when the user clicks the stop button.
+
+### New public method: `isCancelled(id)`
+
+```ts
+isCancelled(id: string): boolean
+```
+
+Returns whether the cancel flag has been set for a job. Called by the panel between
+chunks to decide whether to continue.
+
+### New public method: `setProgress(id, message)`
+
+```ts
+setProgress(id: string, message: string): void
+```
+
+Writes an intermediate status message directly to the job state without waiting for the
+server poll. Used by the panel to show `"Chunk 2 of 6..."` between chunks. Does not
+affect the polling interval.
+
+### Sequencing lives in the panel, not the store
+
+`ConfigureAIRunPanel.handleRun()` owns the chunk loop and calls `dispatch()` with a
+single Promise — the settled result of an immediately-invoked async function:
+
+```ts
+const runChunks = async (): Promise<void> => {
+  for (let i = 0; i < chunks.length; i++) {
+    if (jobStore.isCancelled(jobId)) break;
+    jobStore.setProgress(jobId, `Chunk ${i + 1} of ${chunks.length}`);
+    await runBatchAI({ ...config, rowRange: chunks[i] }, jobId);
+  }
+};
+
+jobStore.dispatch(jobId, "Batch AI Run", runChunks());
+```
+
+`JobStore` receives one Promise and tracks it as before. It has no knowledge of chunks,
+steps, or cancellation logic. The store's existing `complete()` path fires when `runChunks`
+resolves — whether all chunks ran or the loop exited early due to cancellation.
+
+## `JobIndicator` Changes
+
+### Stop button
+
+Active and progress jobs render a `✕` stop button:
+
+```html
+<button class="job-strip__cancel" data-cancel-job="${jobId}" title="Stop after current chunk">✕</button>
+```
+
+Cancelling jobs render a static label instead:
+
+```html
+<span class="job-strip__cancelling">Stopping...</span>
+```
+
+### Event delegation
+
+`JobIndicator` currently wires no click listeners (it replaces `innerHTML` on each
+render, which destroys child listeners). A single delegated listener on `this.el` handles
+stop button clicks without being destroyed by re-renders:
+
+```ts
+this.el.addEventListener("click", (e) => {
+  const btn = (e.target as HTMLElement).closest<HTMLElement>("[data-cancel-job]");
+  if (btn) store.cancel(btn.getAttribute("data-cancel-job")!);
+});
+```
+
+`store` must be retained as an instance field (currently it is only a constructor
+parameter).
+
+## `ConfigureAIRunPanel` Changes
+
+`handleRun()` is extended in two ways:
+
+**1. Pre-flight check** (before dispatch):
+```ts
+if (config.rowRange && rowCount > CHUNK_WARN_THRESHOLD) {
+  const chunkCount = Math.ceil(rowCount / CHUNK_SIZE);
+  const ok = globalThis.confirm(`...`);
+  if (!ok) return;
+}
+```
+
+**2. Chunk dispatch** (replaces single `runBatchAI` call):
+```ts
+const chunks = computeChunks(config.rowRange!, CHUNK_SIZE);
+const steps = chunks.map((slice) => () => runBatchAI({ ...config, rowRange: slice }, jobId));
+jobStore.dispatchChunked(jobId, "Batch AI Run", steps);
+```
+
+`computeChunks` is a pure exported helper in `configure-ai-run.ts`:
+
+```ts
+export function computeChunks(
+  rowRange: { start: number; end: number },
+  chunkSize: number,
+): Array<{ start: number; end: number }> {
+  const chunks = [];
+  for (let start = rowRange.start; start <= rowRange.end; start += chunkSize) {
+    chunks.push({ start, end: Math.min(start + chunkSize - 1, rowRange.end) });
+  }
+  return chunks;
+}
+```
+
+Exporting it allows direct unit testing without mounting the panel.
+
+When `rowRange` is absent (active selection mode), dispatch falls back to a single
+`runBatchAI` call via `dispatch()` as before — chunking only applies when the client
+knows the row count.
+
+## Progress Display
+
+Within each chunk, the server writes per-row progress to `CacheService` as before — the
+`JobStore` poll picks it up and the strip shows `"Processing row N of 50"`.
+
+Between chunks, `dispatchChunked` updates the job state to `"Chunk N of M — starting..."`
+before awaiting the next step. This is written directly to `this.jobs` inside `JobStore`,
+so it is visible immediately without a poll round-trip.
+
+The user therefore sees:
+- Within chunk: `"Processing row 23 of 50"` (server-driven)
+- Between chunks: `"Chunk 3 of 10 — starting..."` (client-driven)
+
+No changes to `getJobProgress` or the server-side `writeJobProgress` call are needed.
+
+## What Does Not Change
+
+- `src/server/index.ts` (`runBatchAI`, `getJobProgress`) — no server changes
+- `src/shared/types.ts` — no RPC boundary changes
+- `src/client/services.ts` — no new RPC calls
+- `src/client/google.d.ts` — no new server declarations
+- `rollup.config.js` — no new global stubs
+- `JobStore.dispatch()` — unchanged; existing jobs use it as before
+- The `CacheService` job progress channel — unchanged
+
+## Files Touched
+
+| File | Change |
+|---|---|
+| `src/client/types.ts` | Add `"cancelling"` to `LoadingStatus` |
+| `src/client/job-store.ts` | Add `cancelFlags` field; add `cancel()`, `isCancelled()`, and `setProgress()` methods. `dispatch()` is unchanged. |
+| `src/client/components/job-indicator.ts` | Add stop button; event delegation; handle `"cancelling"` render |
+| `src/client/sidebar.css` | Style `.job-strip__cancel` and `.job-strip__cancelling` |
+| `src/client/panels/configure-ai-run.ts` | Add `computeChunks` helper; pre-flight warning; chunked dispatch in `handleRun()` |
+
+## User-Facing Limitation to Document
+
+The sidebar must remain open for the entire batch run. If it is closed:
+
+- The currently in-flight chunk completes server-side (rows are written)
+- No further chunks are dispatched
+- The batch stops without error or notification
+
+This should be surfaced in two places:
+1. The pre-flight confirmation dialog (already included in the warning copy above)
+2. A note in the sidebar UI near the Run button when a large row range is detected
+
+## Future Work
+
+**Time-based trigger chaining** would remove the sidebar-open requirement. Each chunk
+completion creates a GAS installable trigger for the next chunk, allowing the user to
+close everything. Progress would be persisted in `PropertiesService` rather than
+`CacheService`. This is a meaningful architectural addition and is deferred.
+
+**External pipeline dispatch** — for batches beyond ~5,000 rows, the right tool is a
+Vertex AI batch inference job. The `dispatchChunked` interface is designed to be
+replaceable: a future `dispatchExternal()` path would accept the same `RunConfig` and
+return the same `Promise<void>`, with the strip UI unchanged.

--- a/docs/plans/2026-03-31-chunked-batch-execution.md
+++ b/docs/plans/2026-03-31-chunked-batch-execution.md
@@ -1,0 +1,599 @@
+# Chunked Batch Execution Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the monolithic `runBatchAI` dispatch with client-driven chunked execution, a pre-flight warning, and a between-chunk stop button.
+
+**Architecture:** Chunking is entirely client-side — the server receives one `RunConfig` slice per chunk and is unaware of sequencing. `JobStore` gains three narrow additions (`cancel`, `isCancelled`, `setProgress`) while `dispatch()` remains unchanged. The chunk loop lives in `ConfigureAIRunPanel.handleRun()`.
+
+**Tech Stack:** TypeScript, Jest/ts-jest, existing `JobStore`/`JobIndicator`/`ConfigureAIRunPanel` classes.
+
+**Read before starting:**
+- `docs/plans/2026-03-31-chunked-batch-execution-design.md` — full design rationale
+- `src/client/job-store.ts` — current `dispatch()` contract
+- `src/client/panels/configure-ai-run.ts` — `handleRun()` and `assembleRunConfig()`
+- `src/client/components/job-indicator.ts` — current render pattern
+- `src/client/types.ts` — `LoadingStatus` union
+
+---
+
+### Task 1: Add `"cancelling"` to `LoadingStatus`
+
+**Files:**
+- Modify: `src/client/types.ts:5`
+
+**Step 1: Make the change**
+
+```ts
+// src/client/types.ts — line 5
+export type LoadingStatus = "idle" | "loading" | "progress" | "cancelling" | "complete" | "error";
+```
+
+**Step 2: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: passes with no errors (no consumers reference the union exhaustively yet).
+
+**Step 3: Commit**
+
+```bash
+git add src/client/types.ts
+git commit -m "feat: add cancelling to LoadingStatus"
+```
+
+---
+
+### Task 2: JobStore — `cancel()`, `isCancelled()`, `setProgress()`
+
+**Files:**
+- Modify: `src/client/job-store.ts`
+- Modify: `__tests__/job-store.test.ts`
+
+**Step 1: Write failing tests**
+
+Append to the existing `describe("JobStore")` block in `__tests__/job-store.test.ts`:
+
+```ts
+describe("cancel()", () => {
+  it("transitions a loading job to cancelling", () => {
+    const listener = jest.fn();
+    store.subscribe(listener);
+
+    store.dispatch("job-c1", "Test", new Promise(() => {}));
+    store.cancel("job-c1");
+
+    const lastJobs = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{ id: string; state: { status: string } }>;
+    const job = lastJobs.find((j) => j.id === "job-c1");
+    expect(job?.state.status).toBe("cancelling");
+  });
+
+  it("transitions a progress job to cancelling", () => {
+    const listener = jest.fn();
+    store.subscribe(listener);
+
+    store.dispatch("job-c2", "Test", new Promise(() => {}));
+    store.setProgress("job-c2", "Row 3 of 10");
+    store.cancel("job-c2");
+
+    const lastJobs = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{ id: string; state: { status: string } }>;
+    const job = lastJobs.find((j) => j.id === "job-c2");
+    expect(job?.state.status).toBe("cancelling");
+  });
+
+  it("is a no-op for unknown job id", () => {
+    expect(() => store.cancel("nonexistent")).not.toThrow();
+  });
+
+  it("is a no-op if job is already complete", async () => {
+    const listener = jest.fn();
+    store.subscribe(listener);
+
+    await store.dispatch("job-c3", "Test", Promise.resolve());
+    listener.mockClear();
+
+    store.cancel("job-c3");
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe("isCancelled()", () => {
+  it("returns false before cancel is called", () => {
+    store.dispatch("job-ic1", "Test", new Promise(() => {}));
+    expect(store.isCancelled("job-ic1")).toBe(false);
+  });
+
+  it("returns true after cancel is called", () => {
+    store.dispatch("job-ic2", "Test", new Promise(() => {}));
+    store.cancel("job-ic2");
+    expect(store.isCancelled("job-ic2")).toBe(true);
+  });
+
+  it("returns false for unknown job id", () => {
+    expect(store.isCancelled("nonexistent")).toBe(false);
+  });
+
+  it("returns false after the job completes (flag cleaned up)", async () => {
+    store.dispatch("job-ic3", "Test", new Promise(() => {}));
+    store.cancel("job-ic3");
+    expect(store.isCancelled("job-ic3")).toBe(true);
+
+    // Simulate the promise resolving via the internal complete path —
+    // easiest to test indirectly by checking flag cleanup after dispatch resolves.
+    await store.dispatch("job-ic4", "Cleanup test", Promise.resolve());
+    // ic3 flag still set (separate job), ic4 flag cleaned up (never set)
+    expect(store.isCancelled("job-ic4")).toBe(false);
+  });
+});
+
+describe("setProgress()", () => {
+  it("updates the job state message", () => {
+    const listener = jest.fn();
+    store.subscribe(listener);
+
+    store.dispatch("job-sp1", "Test", new Promise(() => {}));
+    store.setProgress("job-sp1", "Chunk 2 of 6");
+
+    const lastJobs = listener.mock.calls[listener.mock.calls.length - 1][0] as Array<{ id: string; state: { status: string; message?: string } }>;
+    const job = lastJobs.find((j) => j.id === "job-sp1");
+    expect(job?.state.status).toBe("progress");
+    expect(job?.state.message).toBe("Chunk 2 of 6");
+  });
+
+  it("is a no-op for unknown job id", () => {
+    expect(() => store.setProgress("nonexistent", "msg")).not.toThrow();
+  });
+});
+```
+
+**Step 2: Run tests to confirm they fail**
+
+```bash
+npx jest __tests__/job-store.test.ts --bail
+```
+
+Expected: fails with `store.cancel is not a function` (or similar).
+
+**Step 3: Implement the changes in `src/client/job-store.ts`**
+
+Add a private field after the existing `pollIntervals` declaration:
+
+```ts
+private cancelFlags: Map<string, boolean> = new Map();
+```
+
+Add three public methods before `getJobs()`:
+
+```ts
+cancel(id: string): void {
+  const job = this.jobs.get(id);
+  if (!job) return;
+  if (job.state.status !== "loading" && job.state.status !== "progress") return;
+  this.cancelFlags.set(id, true);
+  this.jobs.set(id, { ...job, state: { status: "cancelling", message: "Stopping after current chunk..." } });
+  this.notify();
+}
+
+isCancelled(id: string): boolean {
+  return this.cancelFlags.get(id) ?? false;
+}
+
+setProgress(id: string, message: string): void {
+  const job = this.jobs.get(id);
+  if (!job) return;
+  this.jobs.set(id, { ...job, state: { status: "progress", message } });
+  this.notify();
+}
+```
+
+Clean up the cancel flag in the existing private `complete()` and `fail()` methods — add `this.cancelFlags.delete(id);` immediately after `this.stopPolling(id);` in each:
+
+```ts
+private complete(id: string): void {
+  this.stopPolling(id);
+  this.cancelFlags.delete(id); // ← add this line
+  // ... rest unchanged
+}
+
+private fail(id: string, message: string): void {
+  this.stopPolling(id);
+  this.cancelFlags.delete(id); // ← add this line
+  // ... rest unchanged
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+npx jest __tests__/job-store.test.ts
+```
+
+Expected: all pass.
+
+**Step 5: Full test suite**
+
+```bash
+npm test
+```
+
+Expected: all pass.
+
+**Step 6: Commit**
+
+```bash
+git add src/client/job-store.ts __tests__/job-store.test.ts
+git commit -m "feat: add cancel, isCancelled, setProgress to JobStore"
+```
+
+---
+
+### Task 3: `computeChunks` — pure helper with tests
+
+**Files:**
+- Modify: `src/client/panels/configure-ai-run.ts`
+- Create: `__tests__/configure-ai-run.test.ts`
+
+**Step 1: Write the failing test**
+
+Create `__tests__/configure-ai-run.test.ts`:
+
+```ts
+import { computeChunks } from "../src/client/panels/configure-ai-run";
+
+describe("computeChunks", () => {
+  it("returns a single chunk when row count equals chunk size", () => {
+    expect(computeChunks({ start: 2, end: 51 }, 50)).toEqual([{ start: 2, end: 51 }]);
+  });
+
+  it("returns a single chunk when row count is less than chunk size", () => {
+    expect(computeChunks({ start: 2, end: 11 }, 50)).toEqual([{ start: 2, end: 11 }]);
+  });
+
+  it("returns multiple full chunks", () => {
+    expect(computeChunks({ start: 2, end: 101 }, 50)).toEqual([
+      { start: 2, end: 51 },
+      { start: 52, end: 101 },
+    ]);
+  });
+
+  it("trims the last chunk to the actual end row", () => {
+    expect(computeChunks({ start: 2, end: 75 }, 50)).toEqual([
+      { start: 2, end: 51 },
+      { start: 52, end: 75 },
+    ]);
+  });
+
+  it("handles a start row other than 2", () => {
+    expect(computeChunks({ start: 10, end: 69 }, 50)).toEqual([
+      { start: 10, end: 59 },
+      { start: 60, end: 69 },
+    ]);
+  });
+
+  it("returns a single chunk for exactly one row", () => {
+    expect(computeChunks({ start: 5, end: 5 }, 50)).toEqual([{ start: 5, end: 5 }]);
+  });
+});
+```
+
+**Step 2: Run to confirm failure**
+
+```bash
+npx jest __tests__/configure-ai-run.test.ts --bail
+```
+
+Expected: fails — `computeChunks` is not exported yet.
+
+**Step 3: Add the export to `configure-ai-run.ts`**
+
+Add near the top of `src/client/panels/configure-ai-run.ts`, after the imports and before the `SavedState` type:
+
+```ts
+export const CHUNK_SIZE = 50;
+
+export function computeChunks(
+  rowRange: { start: number; end: number },
+  chunkSize: number,
+): Array<{ start: number; end: number }> {
+  const chunks: Array<{ start: number; end: number }> = [];
+  for (let start = rowRange.start; start <= rowRange.end; start += chunkSize) {
+    chunks.push({ start, end: Math.min(start + chunkSize - 1, rowRange.end) });
+  }
+  return chunks;
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+npx jest __tests__/configure-ai-run.test.ts
+```
+
+Expected: all pass.
+
+**Step 5: Full test suite**
+
+```bash
+npm test
+```
+
+Expected: all pass.
+
+**Step 6: Commit**
+
+```bash
+git add src/client/panels/configure-ai-run.ts __tests__/configure-ai-run.test.ts
+git commit -m "feat: add computeChunks helper with tests"
+```
+
+---
+
+### Task 4: Pre-flight warning and chunked dispatch in `handleRun()`
+
+**Files:**
+- Modify: `src/client/panels/configure-ai-run.ts`
+
+**Step 1: Replace `handleRun()`**
+
+Find the existing `handleRun()` method (currently around line 192) and replace it entirely:
+
+```ts
+private handleRun(container: HTMLElement): void {
+  const config = this.assembleRunConfig();
+  if (!config) return;
+
+  const jobId = `batch-ai-${Date.now()}`;
+
+  if (config.rowRange) {
+    const rowCount = config.rowRange.end - config.rowRange.start + 1;
+    if (rowCount > CHUNK_SIZE) {
+      const chunkCount = Math.ceil(rowCount / CHUNK_SIZE);
+      const estimatedMins = Math.ceil((rowCount * 5) / 60);
+      const ok = globalThis.confirm(
+        `You're about to process ${rowCount} rows across ${chunkCount} chunks.\n\n` +
+          `This will take roughly ${estimatedMins} minutes. ` +
+          `The sidebar must remain open throughout — closing it will stop the run after the current chunk finishes.\n\n` +
+          `Continue?`,
+      );
+      if (!ok) return;
+    }
+  }
+
+  if (config.rowRange) {
+    const chunks = computeChunks(config.rowRange, CHUNK_SIZE);
+    const runChunks = async (): Promise<void> => {
+      for (let i = 0; i < chunks.length; i++) {
+        if (jobStore.isCancelled(jobId)) break;
+        jobStore.setProgress(jobId, `Chunk ${i + 1} of ${chunks.length}`);
+        await runBatchAI({ ...config, rowRange: chunks[i] }, jobId);
+      }
+    };
+    jobStore.dispatch(jobId, "Batch AI Run", runChunks()).catch((err: Error) => {
+      globalThis.alert("Error: " + err.message);
+    });
+  } else {
+    // No explicit row range — active sheet selection, resolved server-side.
+    // Fall back to single dispatch (no chunking, no warning).
+    jobStore.dispatch(jobId, "Batch AI Run", runBatchAI(config, jobId)).catch((err: Error) => {
+      globalThis.alert("Error: " + err.message);
+    });
+  }
+
+  this.loadHeaders(container, this.currentPreset());
+}
+```
+
+**Step 2: Build**
+
+```bash
+npm run build
+```
+
+Expected: clean build, no TypeScript errors.
+
+**Step 3: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: passes.
+
+**Step 4: Full test suite**
+
+```bash
+npm test
+```
+
+Expected: all pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/client/panels/configure-ai-run.ts
+git commit -m "feat: pre-flight warning and chunked dispatch in handleRun"
+```
+
+---
+
+### Task 5: Stop button in `JobIndicator`
+
+**Files:**
+- Modify: `src/client/components/job-indicator.ts`
+- Modify: `src/client/sidebar.css`
+
+**Step 1: Rewrite `job-indicator.ts`**
+
+Replace the file contents entirely:
+
+```ts
+import type { Job } from "../types";
+import type { JobStore } from "../job-store";
+
+/**
+ * Renders active and recently failed jobs into the sidebar chrome strip.
+ * Mounts to #job-strip which lives outside the router's #app container
+ * and therefore persists across panel navigation.
+ */
+export class JobIndicator {
+  private el: HTMLElement;
+  private store: JobStore;
+
+  constructor(container: HTMLElement, store: JobStore) {
+    this.el = container;
+    this.store = store;
+    store.subscribe((jobs) => this.render(jobs));
+    // Event delegation — survives innerHTML re-renders on each notify()
+    this.el.addEventListener("click", (e) => {
+      const btn = (e.target as HTMLElement).closest<HTMLElement>("[data-cancel-job]");
+      if (btn) {
+        const jobId = btn.getAttribute("data-cancel-job");
+        if (jobId) this.store.cancel(jobId);
+      }
+    });
+  }
+
+  private render(jobs: Job[]): void {
+    const active = jobs.filter(
+      (j) =>
+        j.state.status === "loading" ||
+        j.state.status === "progress" ||
+        j.state.status === "cancelling",
+    );
+    const failed = jobs.filter((j) => j.state.status === "error");
+
+    if (active.length === 0 && failed.length === 0) {
+      this.el.hidden = true;
+      this.el.innerHTML = "";
+      return;
+    }
+
+    this.el.hidden = false;
+
+    const items = [
+      ...active.map((j) => this.renderActive(j)),
+      ...failed.map((j) => this.renderFailed(j)),
+    ];
+
+    this.el.innerHTML = items.join("");
+  }
+
+  private renderActive(job: Job): string {
+    const msg = job.state.message ?? job.label;
+    const isCancelling = job.state.status === "cancelling";
+    const action = isCancelling
+      ? `<span class="job-strip__cancelling">Stopping...</span>`
+      : `<button class="job-strip__cancel" data-cancel-job="${this.escape(job.id)}" title="Stop after current chunk">&#x2715;</button>`;
+    return `<span class="job-strip__item job-strip__item--active">
+      <span class="job-strip__spinner"></span>
+      <span class="job-strip__label">${this.escape(msg)}</span>
+      ${action}
+    </span>`;
+  }
+
+  private renderFailed(job: Job): string {
+    return `<span class="job-strip__item job-strip__item--error">
+      <span class="job-strip__label">&#x26A0; ${this.escape(job.label)} failed</span>
+    </span>`;
+  }
+
+  private escape(str: string): string {
+    return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+}
+```
+
+**Step 2: Add CSS to `src/client/sidebar.css`**
+
+Append to the end of the file:
+
+```css
+.job-strip__cancel {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 11px;
+  line-height: 1;
+  opacity: 0.6;
+  padding: 0 2px;
+}
+
+.job-strip__cancel:hover {
+  opacity: 1;
+}
+
+.job-strip__cancelling {
+  font-size: 11px;
+  font-style: italic;
+  opacity: 0.6;
+}
+```
+
+**Step 3: Build**
+
+```bash
+npm run build
+```
+
+Expected: clean build. Verify `dist/Sidebar.html` contains the new CSS.
+
+**Step 4: Full test suite**
+
+```bash
+npm test
+```
+
+Expected: all pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/client/components/job-indicator.ts src/client/sidebar.css
+git commit -m "feat: stop button and cancelling state in JobIndicator"
+```
+
+---
+
+### Task 6: Lint, format, final verification
+
+**Step 1: Lint**
+
+```bash
+npm run lint
+```
+
+Fix any reported issues before continuing.
+
+**Step 2: Format**
+
+```bash
+npm run format:check
+```
+
+If it reports differences, run `npm run format` and re-stage the affected files.
+
+**Step 3: Full build and test**
+
+```bash
+npm run build && npm test
+```
+
+Expected: clean build, all tests pass.
+
+**Step 4: Typecheck both configs**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors on either server or client tsconfig.
+
+**Step 5: Final commit if any formatting fixes were needed**
+
+```bash
+git add -p  # stage only formatting changes
+git commit -m "chore: lint and format fixes"
+```

--- a/docs/plans/2026-04-02-least-privilege-auth-design.md
+++ b/docs/plans/2026-04-02-least-privilege-auth-design.md
@@ -1,0 +1,108 @@
+# Least-Privilege Auth Scope Reduction — Design Document
+
+## Problem
+
+The SSI Toolkit's current OAuth manifest requests `https://www.googleapis.com/auth/drive`
+— full read, write, and delete access to every file in the user's Google Drive. This scope
+produces the consent screen warning: **"See, edit, create, and delete all of your Google
+Drive files."** Every user who has seen this prompt has expressed concern, creating friction
+that slows adoption and triggers internal security reviews.
+
+The same problem exists, to a lesser degree, with the `documents` scope ("See, edit,
+create, and delete all your Google Docs documents"), though the primary complaint is
+about Drive.
+
+## Non-Goals
+
+- **Google Picker integration.** Replacing text inputs with a Picker component was
+  evaluated and rejected. The `drive.file` scope (Picker-based per-file authorization) does
+  not support recursive folder scanning — a core requirement of the Import Drive Links tool.
+  A "Service Account Bridge" workaround was also rejected: it introduces persistent ACL
+  entries on user files, requires service account credential management, and would be
+  blocked by the organizational Drive sharing policies that motivated this change.
+
+- **`spreadsheets.currentonly` migration.** The Run AI tool's file export path calls
+  `SpreadsheetApp.openById()` to enumerate all sheets in a Drive-linked Google Sheet. This
+  requires the full `spreadsheets` scope. Switching to `Drive.Files.export()` for Sheets
+  would limit export to the first sheet only. Multi-sheet support is retained; this
+  migration is deferred.
+
+- **`documents` scope elimination.** Replacing `DocumentApp.openById()` with
+  `Drive.Files.export()` was considered but the existing codebase contains an explicit
+  warning that `Drive.Files.export()` returns metadata rather than file content in the Apps
+  Script Advanced Service. Eliminating `documents` safely would require a verified
+  alternative (e.g., direct `UrlFetchApp` export call), which is deferred.
+
+## Solution
+
+Replace the single `drive` scope with two narrower scopes that together cover the same
+functional surface:
+
+- **`drive.readonly`** — read access to all Drive files. Covers folder scanning, file
+  metadata lookups, and file content reads for Extract Text and Run AI.
+- **`drive.file`** — write access scoped to files the app creates. Covers the temporary
+  Google Doc created (and deleted) during OCR in Extract Text.
+
+No code changes are required. This is a manifest-only change.
+
+## Scope Changes
+
+| Scope | Before | After | Reason |
+|---|---|---|---|
+| `spreadsheets` | `auth/spreadsheets` | unchanged | `SpreadsheetApp.openById()` needed for multi-sheet Drive file export |
+| `drive` | `auth/drive` | **`auth/drive.readonly` + `auth/drive.file`** | Split into read-all + app-files-write |
+| `documents` | `auth/documents` | unchanged | `DocumentApp.openById()` used for OCR; safe alternative deferred |
+| `script.external_request` | — | unchanged | Required for `UrlFetchApp` (Gemini API) |
+| `script.container.ui` | — | unchanged | Required for sidebar and menu |
+
+## Why This Works
+
+Each Drive operation in the codebase maps to exactly one of the two new scopes:
+
+| Operation | Location | Scope |
+|---|---|---|
+| `DriveApp.getFolderById()` + recursive listing | `index.ts`, `utils.ts` | `drive.readonly` |
+| `DriveApp.getFileById()` (metadata, blob reads) | `drive.ts` | `drive.readonly` |
+| `Drive.Files.list()` | `utils.ts` via Advanced Service | `drive.readonly` |
+| `Drive.Files.create()` (temp OCR doc) | `drive.ts:57` | `drive.file` |
+| `Drive.Files.remove()` (temp OCR doc cleanup) | `drive.ts:60` | `drive.file` |
+| `SpreadsheetApp.openById()` (Sheets file export) | `drive.ts:103` | `spreadsheets` |
+
+No operation in the codebase requires Drive write access to files other than the
+app-created OCR temp docs. The `drive` scope was over-provisioned.
+
+## Consent Screen Impact
+
+Before:
+- "See, edit, create, and delete **all** of your Google Drive files"
+- "See, edit, create, and delete **all** your Google Docs documents"
+
+After:
+- "See and download **all** your Google Drive files" (`drive.readonly`)
+- "See, edit, create, and delete only the **specific** Google Drive files you use with this app" (`drive.file`)
+- "See, edit, create, and delete **all** your Google Docs documents" (`documents` — unchanged)
+
+## Re-Authorization
+
+Changing OAuth scopes in `appsscript.json` triggers a re-authorization prompt for all
+existing users on their next interaction with the add-on. This is expected behavior.
+Users should be informed before the change is deployed.
+
+## Files Touched
+
+| File | Change |
+|---|---|
+| `appsscript.json` | Replace `auth/drive` with `auth/drive.readonly` + `auth/drive.file` |
+
+## Manual Test Plan
+
+Deploy to a test instance and verify each tool end-to-end:
+
+| Tool | Operation | Expected scope |
+|---|---|---|
+| Import Drive Links | Recursive folder scan, write URLs to sheet | `drive.readonly` + `spreadsheets` |
+| Extract Text — Google Doc | Read doc body text | `drive.readonly` + `documents` |
+| Extract Text — PDF/image | Create temp doc, OCR, delete temp doc | `drive.readonly` + `drive.file` + `documents` |
+| Run AI — text columns | Batch inference, write to sheet | `spreadsheets` + `script.external_request` |
+| Run AI — Drive file inputs (Doc, PDF, image) | Fetch and encode file for Gemini | `drive.readonly` |
+| Run AI — Drive file inputs (Sheets) | Open spreadsheet, enumerate all sheets | `spreadsheets` |

--- a/docs/plans/2026-04-02-prompt-col-list-design.md
+++ b/docs/plans/2026-04-02-prompt-col-list-design.md
@@ -1,0 +1,218 @@
+# PromptColList — Design Document
+
+## Problem
+
+`ConfigureAIRunPanel` still renders two separate `TokenInput` pickers — "User prompt columns"
+(text kind) and "Drive file columns" (file kind) — and merges them text-first on save. This
+discards the ordering that `RunConfig.promptCols: PromptColumnSpec[]` is designed to preserve.
+The data layer (Phase 2 of the ordered-parts refactor) is complete; this is the UI layer fix.
+
+## Solution
+
+Replace the two `TokenInput` pickers with a single `PromptColList` component: an ordered list
+of rows where each row represents one `PromptColumnSpec`. Users can add, remove, and reorder
+rows. The system prompt and output column fields are unchanged.
+
+## Component: `PromptColList`
+
+**File:** `src/client/components/prompt-col-list.ts`
+
+**Constructor:** `(container: HTMLElement, headers: string[], initialValue?: PromptColumnSpec[])`
+
+**Public API:**
+- `getValue(): PromptColumnSpec[]` — returns only rows with a column selected, in declared order
+- `destroy(): void` — destroys all child `TokenInput` instances and removes the component
+
+### State
+
+A plain mutable array of row objects:
+
+```ts
+interface PromptRow {
+  tokenInput: TokenInput;   // manages column selection for this row
+  kind: "text" | "file";
+  el: HTMLElement;          // the row's root DOM element
+}
+```
+
+On any mutation (add, remove, move), all rows are torn down and re-rendered from the
+current state array. With the 1–5 rows typical in practice, full re-render is negligible.
+
+### Row Layout
+
+Each row uses two lines to avoid cramping in the ~268px sidebar:
+
+```
+Line 1: TokenInput (single-select, full width) — column picker
+Line 2: [Text pill] [File pill]   (right-aligned) [↑] [↓] [×]
+```
+
+- **Line 1** — a `TokenInput` with `multi: false`, constructed with the full `headers` array.
+  Empty state shows `[+ Add]`; selected state shows the column chip with its own `×` to
+  re-open the picker. The two `×` buttons are visually distinct: the chip `×` is inline in
+  the blue chip on line 1; the row `×` is a gray button on line 2.
+
+- **Line 2** — kind toggle uses `.tag` / `.tag.selected` pill buttons ("Text" / "File") —
+  the same visual language used throughout the panel. Action buttons `↑` `↓` `×` sit
+  right-aligned. `↑` is disabled on the first row; `↓` is disabled on the last.
+
+### Add Row
+
+A full-width `+ Add column` ghost button sits below the list. Clicking it appends a new
+empty row (no column selected, kind defaults to `"text"`) and re-renders.
+
+### getValue()
+
+Iterates `rows`, calls `tokenInput.getValue()[0]` for each, skips rows where the value is
+empty or undefined, and returns `PromptColumnSpec[]` in the current order.
+
+## CSS
+
+New classes added to `sidebar.css`:
+
+```css
+.pcol-list { display: flex; flex-direction: column; gap: 8px; }
+
+.pcol-row { display: flex; flex-direction: column; gap: 4px; }
+
+/* Line 2 */
+.pcol-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.pcol-kind-pills { display: flex; gap: 4px; }
+
+/* Spacer that pushes action buttons to the right */
+.pcol-kind-pills + .pcol-spacer { flex: 1; }
+
+.pcol-btn-up,
+.pcol-btn-down,
+.pcol-btn-remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 13px;
+  padding: 2px 4px;
+  line-height: 1;
+}
+.pcol-btn-up:hover, .pcol-btn-down:hover { color: var(--primary-blue); }
+.pcol-btn-remove:hover { color: #d93025; }
+.pcol-btn-up:disabled, .pcol-btn-down:disabled { opacity: 0.25; cursor: default; }
+
+.pcol-add-btn {
+  width: 100%;
+  margin-top: 4px;
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  padding: 5px 8px;
+  cursor: pointer;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+  box-sizing: border-box;
+}
+.pcol-add-btn:hover { border-color: var(--primary-blue); color: var(--primary-blue); }
+```
+
+The kind toggle reuses existing `.tag` and `.tag.selected` — no new pill styles needed.
+
+## Integration into `configure-ai-run.ts`
+
+### Fields removed
+- `userPromptList: TokenInput | null`
+- `driveFileList: TokenInput | null`
+
+### Field added
+- `promptColList: PromptColList | null`
+
+### `loadHeaders()`
+Replace:
+```ts
+const presetTextCols = preset.promptCols?.filter(...).map(...) ?? [];
+const presetFileCols = preset.promptCols?.filter(...).map(...) ?? [];
+this.userPromptList = new TokenInput(..., { selected: presetTextCols });
+this.driveFileList  = new TokenInput(..., { selected: presetFileCols });
+```
+With:
+```ts
+this.promptColList = new PromptColList(
+  container.querySelector("#prompt-col-list")!,
+  headers,
+  preset.promptCols,
+);
+```
+`preset.promptCols` is already an ordered `PromptColumnSpec[]` — no splitting needed.
+
+### `unmount()` / `currentPreset()` / `assembleRunConfig()`
+Replace the two-array merge:
+```ts
+promptCols: [
+  ...this.userPromptList.getValue().map((col) => ({ col, kind: "text" as const })),
+  ...(this.driveFileList?.getValue() ?? []).map((col) => ({ col, kind: "file" as const })),
+],
+```
+With:
+```ts
+promptCols: this.promptColList?.getValue() ?? [],
+```
+
+### Validation
+`assembleRunConfig()` keeps its existing guard — `if (promptCols.length === 0)` alert —
+unchanged. `getValue()` already filters out empty rows.
+
+### Template
+Replace:
+```html
+<div class="field-group">
+  <span class="field-label">User prompt columns <span class="required">*</span></span>
+  <div id="user-prompt-cols" class="tag-list"></div>
+</div>
+<div class="field-group">
+  <span class="field-label">Drive file columns <span class="optional">(optional)</span></span>
+  <div id="drive-file-cols" class="tag-list"></div>
+</div>
+```
+With:
+```html
+<div class="field-group">
+  <span class="field-label">Prompt columns <span class="required">*</span></span>
+  <div id="prompt-col-list"></div>
+</div>
+```
+
+## Recipe System
+
+No changes required. `RecipePanel.buildRunConfig()` already returns
+`promptCols: PromptColumnSpec[]` in the recipe's intended order and passes it to
+`ConfigureAIRunPanel` via navigation. Previously `loadHeaders()` split this array apart,
+losing the order. With `PromptColList`, `preset.promptCols` is passed directly as
+`initialValue` — order preserved end-to-end.
+
+## Files Touched
+
+| File | Change |
+|---|---|
+| `src/client/components/prompt-col-list.ts` | New component |
+| `src/client/sidebar.css` | Add `.pcol-*` styles (~35 lines) |
+| `src/client/panels/configure-ai-run.ts` | Replace 2 `TokenInput` fields with `PromptColList`; update template, `loadHeaders`, `unmount`, `currentPreset`, `assembleRunConfig` |
+| `__tests__/configure-ai-run.test.ts` | Update any tests that reference `userPromptList` / `driveFileList` |
+
+No changes to `shared/types.ts`, `server/`, `recipe.ts`, or `recipes.ts`.
+
+## Implementation Entry Point
+
+Start by reading:
+- This document
+- `src/client/components/token-input.ts` — component to embed per row
+- `src/client/panels/configure-ai-run.ts` — panel to update
+- `src/client/sidebar.css` — styles to extend
+
+Build and verify in this order:
+1. `PromptColList` component with CSS
+2. Integration into `configure-ai-run.ts`
+3. Manual smoke test: add rows, reorder, verify `getValue()` order matches display order
+4. Recipe handoff smoke test: navigate from a recipe's Cook button, verify `promptCols` preset renders in correct order

--- a/docs/plans/2026-04-02-prompt-col-list-implementation.md
+++ b/docs/plans/2026-04-02-prompt-col-list-implementation.md
@@ -1,0 +1,892 @@
+# PromptColList Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the two separate "User prompt columns" / "Drive file columns" `TokenInput` pickers in `ConfigureAIRunPanel` with a single `PromptColList` component that renders an ordered, user-reorderable list of `PromptColumnSpec` rows.
+
+**Architecture:** New `PromptColList` component wraps one `TokenInput` per row (single-select, column picker) alongside kind-toggle pills and up/down/remove buttons. `configure-ai-run.ts` replaces two `TokenInput` fields with one `PromptColList`. No server-side changes.
+
+**Tech Stack:** TypeScript + DOM APIs + existing `TokenInput` component + existing `.tag`/`.tag.selected` CSS.
+
+**Design doc:** `docs/plans/2026-04-02-prompt-col-list-design.md`
+
+---
+
+## Task 1: `PromptColList` component — failing tests
+
+**Files:**
+- Create: `__tests__/components/prompt-col-list.test.ts`
+
+**Step 1: Write the test file**
+
+```ts
+/**
+ * @jest-environment jsdom
+ */
+import { PromptColList } from "../../src/client/components/prompt-col-list";
+import type { PromptColumnSpec } from "../../src/shared/types";
+
+const HEADERS = ["col_a", "col_b", "col_c"];
+
+function makeContainer(): HTMLElement {
+  document.body.innerHTML = '<div id="app"></div>';
+  return document.getElementById("app")!;
+}
+
+/** Clicks the column TokenInput add btn in the Nth row, then selects value from dropdown. */
+function selectColInRow(container: HTMLElement, rowIndex: number, value: string): void {
+  const rows = container.querySelectorAll(".pcol-row");
+  const row = rows[rowIndex] as HTMLElement;
+  row.querySelector<HTMLElement>(".token-add-btn")!.click();
+  row.querySelector<HTMLElement>(`.token-option[data-value="${value}"]`)!.click();
+}
+
+/** Returns the selected column value chip in the Nth row, or "" if none. */
+function getColInRow(container: HTMLElement, rowIndex: number): string {
+  const rows = container.querySelectorAll(".pcol-row");
+  const row = rows[rowIndex] as HTMLElement;
+  return row.querySelector<HTMLElement>(".token-chip[data-value]")?.getAttribute("data-value") ?? "";
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("PromptColList — construction", () => {
+  it("renders no rows and an add button when constructed with no initialValue", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS);
+    expect(container.querySelectorAll(".pcol-row").length).toBe(0);
+    expect(container.querySelector(".pcol-add-btn")).not.toBeNull();
+    list.destroy();
+  });
+
+  it("renders one row per entry in initialValue", () => {
+    const container = makeContainer();
+    const initial: PromptColumnSpec[] = [
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "file" },
+    ];
+    const list = new PromptColList(container, HEADERS, initial);
+    expect(container.querySelectorAll(".pcol-row").length).toBe(2);
+    list.destroy();
+  });
+
+  it("pre-selects the column chip for each initialValue entry", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [{ col: "col_a", kind: "text" }]);
+    expect(getColInRow(container, 0)).toBe("col_a");
+    list.destroy();
+  });
+
+  it("pre-selects the correct kind pill for each initialValue entry", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "file" },
+    ]);
+    const rows = container.querySelectorAll(".pcol-row");
+    const textPillRow0 = rows[0].querySelector<HTMLElement>(".pcol-kind-pills .tag:first-child");
+    const filePillRow1 = rows[1].querySelector<HTMLElement>(".pcol-kind-pills .tag:last-child");
+    expect(textPillRow0?.classList.contains("selected")).toBe(true);
+    expect(filePillRow1?.classList.contains("selected")).toBe(true);
+    list.destroy();
+  });
+});
+
+describe("PromptColList — getValue()", () => {
+  it("returns [] when there are no rows", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS);
+    expect(list.getValue()).toEqual([]);
+    list.destroy();
+  });
+
+  it("returns [] when rows have no column selected", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS);
+    container.querySelector<HTMLElement>(".pcol-add-btn")!.click();
+    expect(list.getValue()).toEqual([]);
+    list.destroy();
+  });
+
+  it("returns spec for a row with a selected column", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS);
+    container.querySelector<HTMLElement>(".pcol-add-btn")!.click();
+    selectColInRow(container, 0, "col_a");
+    expect(list.getValue()).toEqual([{ col: "col_a", kind: "text" }]);
+    list.destroy();
+  });
+
+  it("returns rows in display order", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "file" },
+    ]);
+    expect(list.getValue()).toEqual([
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "file" },
+    ]);
+    list.destroy();
+  });
+
+  it("skips rows with no column selected when mixed with filled rows", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [{ col: "col_a", kind: "text" }]);
+    container.querySelector<HTMLElement>(".pcol-add-btn")!.click(); // empty row
+    expect(list.getValue()).toEqual([{ col: "col_a", kind: "text" }]);
+    list.destroy();
+  });
+});
+
+describe("PromptColList — add row", () => {
+  it("clicking add button appends a new empty row", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS);
+    container.querySelector<HTMLElement>(".pcol-add-btn")!.click();
+    expect(container.querySelectorAll(".pcol-row").length).toBe(1);
+    expect(getColInRow(container, 0)).toBe("");
+    list.destroy();
+  });
+
+  it("new row defaults to text kind", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS);
+    container.querySelector<HTMLElement>(".pcol-add-btn")!.click();
+    const rows = container.querySelectorAll(".pcol-row");
+    const textPill = rows[0].querySelector<HTMLElement>(".pcol-kind-pills .tag:first-child");
+    expect(textPill?.classList.contains("selected")).toBe(true);
+    list.destroy();
+  });
+});
+
+describe("PromptColList — remove row", () => {
+  it("clicking remove on a row removes it from the DOM and getValue()", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "file" },
+    ]);
+    container.querySelector<HTMLElement>(".pcol-btn-remove")!.click();
+    expect(container.querySelectorAll(".pcol-row").length).toBe(1);
+    expect(list.getValue()).toEqual([{ col: "col_b", kind: "file" }]);
+    list.destroy();
+  });
+});
+
+describe("PromptColList — kind toggle", () => {
+  it("clicking File pill changes kind to file in getValue()", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [{ col: "col_a", kind: "text" }]);
+    const row = container.querySelector<HTMLElement>(".pcol-row")!;
+    row.querySelector<HTMLElement>(".pcol-kind-pills .tag:last-child")!.click(); // File
+    expect(list.getValue()).toEqual([{ col: "col_a", kind: "file" }]);
+    list.destroy();
+  });
+
+  it("clicking Text pill after File restores text kind", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [{ col: "col_a", kind: "file" }]);
+    const row = container.querySelector<HTMLElement>(".pcol-row")!;
+    row.querySelector<HTMLElement>(".pcol-kind-pills .tag:first-child")!.click(); // Text
+    expect(list.getValue()).toEqual([{ col: "col_a", kind: "text" }]);
+    list.destroy();
+  });
+});
+
+describe("PromptColList — reorder", () => {
+  it("up button disabled on first row", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "text" },
+    ]);
+    const firstUpBtn = container.querySelector<HTMLButtonElement>(".pcol-btn-up");
+    expect(firstUpBtn?.disabled).toBe(true);
+    list.destroy();
+  });
+
+  it("down button disabled on last row", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "text" },
+    ]);
+    const downBtns = container.querySelectorAll<HTMLButtonElement>(".pcol-btn-down");
+    expect(downBtns[downBtns.length - 1].disabled).toBe(true);
+    list.destroy();
+  });
+
+  it("clicking up on second row moves it to first position in getValue()", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "file" },
+    ]);
+    const upBtns = container.querySelectorAll<HTMLButtonElement>(".pcol-btn-up");
+    upBtns[1].click(); // up on second row
+    expect(list.getValue()).toEqual([
+      { col: "col_b", kind: "file" },
+      { col: "col_a", kind: "text" },
+    ]);
+    list.destroy();
+  });
+
+  it("clicking down on first row moves it to second position in getValue()", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [
+      { col: "col_a", kind: "text" },
+      { col: "col_b", kind: "file" },
+    ]);
+    container.querySelector<HTMLButtonElement>(".pcol-btn-down")!.click(); // down on first row
+    expect(list.getValue()).toEqual([
+      { col: "col_b", kind: "file" },
+      { col: "col_a", kind: "text" },
+    ]);
+    list.destroy();
+  });
+});
+
+describe("PromptColList — destroy()", () => {
+  it("removes all DOM elements from the container", () => {
+    const container = makeContainer();
+    const list = new PromptColList(container, HEADERS, [{ col: "col_a", kind: "text" }]);
+    list.destroy();
+    expect(container.querySelector(".pcol-list")).toBeNull();
+    expect(container.querySelector(".pcol-add-btn")).toBeNull();
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+```bash
+cd .worktrees/prompt-col-list
+npx jest __tests__/components/prompt-col-list.test.ts
+```
+
+Expected: `Cannot find module '../../src/client/components/prompt-col-list'`
+
+---
+
+## Task 2: `PromptColList` component — implementation
+
+**Files:**
+- Create: `src/client/components/prompt-col-list.ts`
+
+**Step 1: Write the implementation**
+
+```ts
+import type { PromptColumnSpec } from "../../shared/types";
+import { TokenInput } from "./token-input";
+
+interface PromptRow {
+  kind: "text" | "file";
+  tokenInput: TokenInput;
+  el: HTMLElement;
+}
+
+export class PromptColList {
+  private readonly headers: string[];
+  private rows: PromptRow[] = [];
+  private readonly listEl: HTMLElement;
+  private readonly addBtn: HTMLButtonElement;
+
+  constructor(container: HTMLElement, headers: string[], initialValue?: PromptColumnSpec[]) {
+    this.headers = headers;
+
+    this.listEl = document.createElement("div");
+    this.listEl.className = "pcol-list";
+
+    this.addBtn = document.createElement("button");
+    this.addBtn.type = "button";
+    this.addBtn.className = "pcol-add-btn";
+    this.addBtn.textContent = "+ Add column";
+    this.addBtn.addEventListener("click", () => this.addRow("text", ""));
+
+    container.appendChild(this.listEl);
+    container.appendChild(this.addBtn);
+
+    for (const spec of initialValue ?? []) {
+      this.addRow(spec.kind, spec.col);
+    }
+  }
+
+  getValue(): PromptColumnSpec[] {
+    return this.rows
+      .map((row) => ({ col: row.tokenInput.getValue()[0] ?? "", kind: row.kind }))
+      .filter((spec) => spec.col !== "");
+  }
+
+  destroy(): void {
+    for (const row of this.rows) {
+      row.tokenInput.destroy();
+    }
+    this.rows = [];
+    this.listEl.remove();
+    this.addBtn.remove();
+  }
+
+  // ─── Private ────────────────────────────────────────────────────────────────
+
+  private addRow(kind: "text" | "file", initialCol: string): void {
+    const row = this.buildRow(kind, initialCol);
+    this.rows.push(row);
+    this.listEl.appendChild(row.el);
+    this.updateArrows();
+  }
+
+  private buildRow(kind: "text" | "file", initialCol: string): PromptRow {
+    const el = document.createElement("div");
+    el.className = "pcol-row";
+
+    // Line 1: TokenInput for column selection
+    const line1 = document.createElement("div");
+    line1.className = "pcol-row-line1";
+    const tokenInput = new TokenInput(line1, this.headers, {
+      multi: false,
+      selected: initialCol ? [initialCol] : [],
+    });
+    el.appendChild(line1);
+
+    // Line 2: kind pills + spacer + action buttons
+    const line2 = document.createElement("div");
+    line2.className = "pcol-row-line2";
+
+    const pillsWrap = document.createElement("div");
+    pillsWrap.className = "pcol-kind-pills";
+
+    const textPill = this.makePill("Text", kind === "text");
+    const filePill = this.makePill("File", kind === "file");
+    pillsWrap.appendChild(textPill);
+    pillsWrap.appendChild(filePill);
+
+    const spacer = document.createElement("div");
+    spacer.className = "pcol-spacer";
+
+    const upBtn = this.makeBtn("↑", "pcol-btn-up");
+    const downBtn = this.makeBtn("↓", "pcol-btn-down");
+    const removeBtn = this.makeBtn("×", "pcol-btn-remove");
+
+    line2.appendChild(pillsWrap);
+    line2.appendChild(spacer);
+    line2.appendChild(upBtn);
+    line2.appendChild(downBtn);
+    line2.appendChild(removeBtn);
+    el.appendChild(line2);
+
+    // Assemble the row object — listeners reference it by closure
+    const row: PromptRow = { kind, tokenInput, el };
+
+    textPill.addEventListener("click", () => {
+      row.kind = "text";
+      textPill.classList.add("selected");
+      filePill.classList.remove("selected");
+    });
+    filePill.addEventListener("click", () => {
+      row.kind = "file";
+      filePill.classList.add("selected");
+      textPill.classList.remove("selected");
+    });
+    upBtn.addEventListener("click", () => this.moveRow(row, -1));
+    downBtn.addEventListener("click", () => this.moveRow(row, 1));
+    removeBtn.addEventListener("click", () => this.removeRow(row));
+
+    return row;
+  }
+
+  private makePill(label: string, selected: boolean): HTMLButtonElement {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "tag" + (selected ? " selected" : "");
+    btn.textContent = label;
+    return btn;
+  }
+
+  private makeBtn(label: string, className: string): HTMLButtonElement {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = className;
+    btn.textContent = label;
+    return btn;
+  }
+
+  private moveRow(row: PromptRow, delta: -1 | 1): void {
+    const idx = this.rows.indexOf(row);
+    const newIdx = idx + delta;
+    if (newIdx < 0 || newIdx >= this.rows.length) return;
+
+    // Save elements before swapping array
+    const elA = this.rows[idx].el;
+    const elB = this.rows[newIdx].el;
+
+    // Swap in state array
+    [this.rows[idx], this.rows[newIdx]] = [this.rows[newIdx], this.rows[idx]];
+
+    // Swap in DOM
+    if (delta === -1) {
+      this.listEl.insertBefore(elA, elB); // move A before B
+    } else {
+      this.listEl.insertBefore(elB, elA); // move B before A
+    }
+
+    this.updateArrows();
+  }
+
+  private removeRow(row: PromptRow): void {
+    row.tokenInput.destroy();
+    row.el.remove();
+    this.rows = this.rows.filter((r) => r !== row);
+    this.updateArrows();
+  }
+
+  private updateArrows(): void {
+    this.rows.forEach((row, idx) => {
+      const upBtn = row.el.querySelector<HTMLButtonElement>(".pcol-btn-up");
+      const downBtn = row.el.querySelector<HTMLButtonElement>(".pcol-btn-down");
+      if (upBtn) upBtn.disabled = idx === 0;
+      if (downBtn) downBtn.disabled = idx === this.rows.length - 1;
+    });
+  }
+}
+```
+
+**Step 2: Run tests**
+
+```bash
+npx jest __tests__/components/prompt-col-list.test.ts
+```
+
+Expected: all tests pass.
+
+**Step 3: Commit**
+
+```bash
+git add src/client/components/prompt-col-list.ts __tests__/components/prompt-col-list.test.ts
+git commit -m "feat: add PromptColList component for ordered prompt column selection"
+```
+
+---
+
+## Task 3: CSS for `PromptColList`
+
+**Files:**
+- Modify: `src/client/sidebar.css` (append at end)
+
+**Step 1: Append the new styles**
+
+Add to the bottom of `src/client/sidebar.css`:
+
+```css
+/* ── Prompt Column List ──────────────────────────────────────────────────── */
+
+.pcol-list { display: flex; flex-direction: column; gap: 8px; }
+
+.pcol-row { display: flex; flex-direction: column; gap: 4px; }
+
+.pcol-row-line1 { width: 100%; }
+
+.pcol-row-line2 {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.pcol-kind-pills { display: flex; gap: 4px; }
+
+.pcol-spacer { flex: 1; }
+
+.pcol-btn-up,
+.pcol-btn-down,
+.pcol-btn-remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 13px;
+  padding: 2px 4px;
+  line-height: 1;
+}
+
+.pcol-btn-up:hover,
+.pcol-btn-down:hover { color: var(--primary-blue); }
+.pcol-btn-remove:hover { color: #d93025; }
+.pcol-btn-up:disabled,
+.pcol-btn-down:disabled { opacity: 0.25; cursor: default; }
+
+.pcol-add-btn {
+  width: 100%;
+  margin-top: 4px;
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  padding: 5px 8px;
+  cursor: pointer;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+  box-sizing: border-box;
+}
+
+.pcol-add-btn:hover { border-color: var(--primary-blue); color: var(--primary-blue); }
+```
+
+**Step 2: Verify build still compiles**
+
+```bash
+npm run build
+```
+
+Expected: no errors, `dist/` updated.
+
+**Step 3: Commit**
+
+```bash
+git add src/client/sidebar.css
+git commit -m "feat: add pcol-* styles for PromptColList component"
+```
+
+---
+
+## Task 4: Update `configure-ai-run.ts`
+
+**Files:**
+- Modify: `src/client/panels/configure-ai-run.ts`
+
+Make the following changes. Read the current file before editing.
+
+**Step 1: Add import**
+
+At the top of the file, add:
+```ts
+import { PromptColList } from "../components/prompt-col-list";
+```
+
+**Step 2: Replace `userPromptList` and `driveFileList` fields**
+
+Remove:
+```ts
+private userPromptList: TokenInput | null = null;
+private driveFileList: TokenInput | null = null;
+```
+
+Add:
+```ts
+private promptColList: PromptColList | null = null;
+```
+
+**Step 3: Update `loadHeaders()` — remove destroy calls and construction**
+
+Remove:
+```ts
+this.userPromptList?.destroy();
+this.driveFileList?.destroy();
+```
+
+Add:
+```ts
+this.promptColList?.destroy();
+this.promptColList = null;
+```
+
+Remove:
+```ts
+const presetTextCols =
+  preset.promptCols?.filter((p) => p.kind === "text").map((p) => p.col) ?? [];
+const presetFileCols =
+  preset.promptCols?.filter((p) => p.kind === "file").map((p) => p.col) ?? [];
+this.userPromptList = new TokenInput(
+  container.querySelector("#user-prompt-cols")!,
+  headers,
+  { selected: presetTextCols },
+);
+this.driveFileList = new TokenInput(container.querySelector("#drive-file-cols")!, headers, {
+  selected: presetFileCols,
+});
+```
+
+Add:
+```ts
+this.promptColList = new PromptColList(
+  container.querySelector("#prompt-col-list")!,
+  headers,
+  preset.promptCols,
+);
+```
+
+**Step 4: Update `unmount()`**
+
+Change the guard from:
+```ts
+if (!this.userPromptList) return undefined;
+```
+To:
+```ts
+if (!this.promptColList) return undefined;
+```
+
+Remove:
+```ts
+this.userPromptList.destroy();
+this.driveFileList?.destroy();
+```
+Add:
+```ts
+this.promptColList.destroy();
+```
+
+Replace the two-array merge in the return value:
+```ts
+promptCols: [
+  ...this.userPromptList.getValue().map((col) => ({ col, kind: "text" as const })),
+  ...(this.driveFileList?.getValue() ?? []).map((col) => ({ col, kind: "file" as const })),
+],
+```
+With:
+```ts
+promptCols: this.promptColList.getValue(),
+```
+
+**Step 5: Update `currentPreset()`**
+
+Remove:
+```ts
+const textCols = this.userPromptList?.getValue() ?? [];
+const fileCols = this.driveFileList?.getValue() ?? [];
+return {
+  promptCols: [
+    ...textCols.map((col) => ({ col, kind: "text" as const })),
+    ...fileCols.map((col) => ({ col, kind: "file" as const })),
+  ],
+```
+
+Add:
+```ts
+return {
+  promptCols: this.promptColList?.getValue() ?? [],
+```
+
+**Step 6: Update `assembleRunConfig()`**
+
+Remove:
+```ts
+const textCols = this.userPromptList?.getValue() ?? [];
+if (textCols.length === 0) {
+  globalThis.alert("Please select at least one User prompt column.");
+  return null;
+}
+const fileCols = this.driveFileList?.getValue() ?? [];
+const promptCols: PromptColumnSpec[] = [
+  ...textCols.map((col) => ({ col, kind: "text" as const })),
+  ...fileCols.map((col) => ({ col, kind: "file" as const })),
+];
+```
+
+Add:
+```ts
+const promptCols = this.promptColList?.getValue() ?? [];
+if (promptCols.length === 0) {
+  globalThis.alert("Please select at least one User prompt column.");
+  return null;
+}
+```
+
+**Step 7: Update the template**
+
+Replace:
+```html
+<div class="field-group">
+  <span class="field-label">User prompt columns <span class="required">*</span></span>
+  <div id="user-prompt-cols" class="tag-list"></div>
+</div>
+<div class="field-group">
+  <span class="field-label">Drive file columns <span class="optional">(optional)</span></span>
+  <div id="drive-file-cols" class="tag-list"></div>
+</div>
+```
+
+With:
+```html
+<div class="field-group">
+  <span class="field-label">Prompt columns <span class="required">*</span></span>
+  <div id="prompt-col-list"></div>
+</div>
+```
+
+**Step 8: Remove unused `TokenInput` import if no longer referenced**
+
+Check whether `TokenInput` is still imported. If the only import was for `userPromptList` / `driveFileList`, remove the import line. (The systemPromptList and outputColList still use `TokenInput`, so the import stays.)
+
+**Step 9: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors.
+
+**Step 10: Commit**
+
+```bash
+git add src/client/panels/configure-ai-run.ts
+git commit -m "feat: replace split TokenInput pickers with PromptColList in ConfigureAIRunPanel"
+```
+
+---
+
+## Task 5: Update `configure-ai-run` tests
+
+**Files:**
+- Modify: `__tests__/panels/configure-ai-run.test.ts`
+
+The existing tests use `selectColumn(container, "user-prompt-cols", value)` and
+`getChipValues(container, "user-prompt-cols")`. These helpers target the old `#user-prompt-cols`
+TokenInput container. After the refactor that element is gone; instead `#prompt-col-list`
+contains `PromptColList` rows.
+
+**Step 1: Replace `selectColumn` and `getChipValues` helpers**
+
+Remove the old helpers:
+```ts
+function selectColumn(container: HTMLElement, fieldId: string, value: string): void { ... }
+function getChipValues(container: HTMLElement, fieldId: string): string[] { ... }
+```
+
+Keep `selectColumn` for `system-prompt-col`, `output-col` fields (these are unchanged TokenInputs). Add new helpers for the PromptColList:
+
+```ts
+/** Clicks the "+ Add column" button and selects value in the newly appended row. */
+function addPromptCol(
+  container: HTMLElement,
+  value: string,
+  kind: "text" | "file" = "text",
+): void {
+  container.querySelector<HTMLElement>(".pcol-add-btn")!.click();
+  const rows = container.querySelectorAll(".pcol-row");
+  const row = rows[rows.length - 1] as HTMLElement;
+  row.querySelector<HTMLElement>(".token-add-btn")!.click();
+  row.querySelector<HTMLElement>(`.token-option[data-value="${value}"]`)!.click();
+  if (kind === "file") {
+    const pills = row.querySelectorAll<HTMLElement>(".pcol-kind-pills .tag");
+    pills[1].click();
+  }
+}
+
+/** Returns column values of all filled rows in the PromptColList. */
+function getPromptColValues(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll(".pcol-row"))
+    .map((row) => row.querySelector<HTMLElement>(".token-chip[data-value]")?.getAttribute("data-value") ?? "")
+    .filter(Boolean);
+}
+
+/** Selects a column in a non-PromptColList TokenInput field (system-prompt-col, output-col). */
+function selectColumn(container: HTMLElement, fieldId: string, value: string): void {
+  container.querySelector<HTMLElement>(`#${fieldId} .token-add-btn`)!.click();
+  container.querySelector<HTMLElement>(`#${fieldId} .token-option[data-value="${value}"]`)!.click();
+}
+```
+
+**Step 2: Update assertions that reference old field IDs**
+
+Find and update each failing assertion:
+
+- `"pre-selects params on mount"`:
+  ```ts
+  // Before:
+  expect(getChipValues(container, "user-prompt-cols")).toContain("col_a");
+  // After:
+  expect(getPromptColValues(container)).toContain("col_a");
+  ```
+
+- `"restores savedState over params"`:
+  ```ts
+  // Before:
+  expect(getChipValues(container, "user-prompt-cols")).toContain("col_b");
+  // After:
+  expect(getPromptColValues(container)).toContain("col_b");
+  ```
+
+- `"alerts when no output column selected"`:
+  ```ts
+  // Before:
+  selectColumn(container, "user-prompt-cols", "col_a");
+  // After:
+  addPromptCol(container, "col_a");
+  ```
+
+- `"unmount() returns current form state"`:
+  ```ts
+  // Before:
+  selectColumn(container, "user-prompt-cols", "col_a");
+  // After:
+  addPromptCol(container, "col_a");
+  ```
+
+- `"unmount saves includeGrounding state"`:
+  ```ts
+  // Before:
+  selectColumn(container, "user-prompt-cols", "col_a");
+  // After:
+  addPromptCol(container, "col_a");
+  ```
+
+- `"refresh-btn refetches headers preserving current selections"`:
+  ```ts
+  // Before:
+  expect(getChipValues(container, "user-prompt-cols")).toContain("col_a");
+  // After:
+  expect(getPromptColValues(container)).toContain("col_a");
+  ```
+
+**Step 3: Run the full test suite**
+
+```bash
+npm test
+```
+
+Expected: 391+ tests passing (new component tests add to the total), 0 failures.
+
+**Step 4: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors.
+
+**Step 5: Commit**
+
+```bash
+git add __tests__/panels/configure-ai-run.test.ts
+git commit -m "test: update configure-ai-run tests for PromptColList"
+```
+
+---
+
+## Task 6: Final verification
+
+**Step 1: Full test suite with coverage**
+
+```bash
+npm run test:coverage
+```
+
+Expected: all tests pass, coverage thresholds met.
+
+**Step 2: Lint**
+
+```bash
+npm run lint
+```
+
+Expected: no errors or warnings.
+
+**Step 3: Build**
+
+```bash
+npm run build
+```
+
+Expected: `dist/` builds cleanly with no errors.

--- a/src/client/components/job-indicator.ts
+++ b/src/client/components/job-indicator.ts
@@ -8,15 +8,28 @@ import type { JobStore } from "../job-store";
  */
 export class JobIndicator {
   private el: HTMLElement;
+  private store: JobStore;
 
   constructor(container: HTMLElement, store: JobStore) {
     this.el = container;
+    this.store = store;
     store.subscribe((jobs) => this.render(jobs));
+    // Event delegation — survives innerHTML re-renders on each notify()
+    this.el.addEventListener("click", (e) => {
+      const btn = (e.target as HTMLElement).closest<HTMLElement>("[data-cancel-job]");
+      if (btn) {
+        const jobId = btn.getAttribute("data-cancel-job");
+        if (jobId) this.store.cancel(jobId);
+      }
+    });
   }
 
   private render(jobs: Job[]): void {
     const active = jobs.filter(
-      (j) => j.state.status === "loading" || j.state.status === "progress",
+      (j) =>
+        j.state.status === "loading" ||
+        j.state.status === "progress" ||
+        j.state.status === "cancelling",
     );
     const failed = jobs.filter((j) => j.state.status === "error");
 
@@ -38,9 +51,14 @@ export class JobIndicator {
 
   private renderActive(job: Job): string {
     const msg = job.state.message ?? job.label;
+    const isCancelling = job.state.status === "cancelling";
+    const action = isCancelling
+      ? ``
+      : `<button class="job-strip__cancel" data-cancel-job="${this.escape(job.id)}" title="Stop after current chunk">&#x2715;</button>`;
     return `<span class="job-strip__item job-strip__item--active">
       <span class="job-strip__spinner"></span>
       <span class="job-strip__label">${this.escape(msg)}</span>
+      ${action}
     </span>`;
   }
 
@@ -51,6 +69,10 @@ export class JobIndicator {
   }
 
   private escape(str: string): string {
-    return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    return str
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
   }
 }

--- a/src/client/components/job-indicator.ts
+++ b/src/client/components/job-indicator.ts
@@ -69,6 +69,10 @@ export class JobIndicator {
   }
 
   private escape(str: string): string {
-    return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    return str
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
   }
 }

--- a/src/client/components/job-indicator.ts
+++ b/src/client/components/job-indicator.ts
@@ -8,15 +8,28 @@ import type { JobStore } from "../job-store";
  */
 export class JobIndicator {
   private el: HTMLElement;
+  private store: JobStore;
 
   constructor(container: HTMLElement, store: JobStore) {
     this.el = container;
+    this.store = store;
     store.subscribe((jobs) => this.render(jobs));
+    // Event delegation — survives innerHTML re-renders on each notify()
+    this.el.addEventListener("click", (e) => {
+      const btn = (e.target as HTMLElement).closest<HTMLElement>("[data-cancel-job]");
+      if (btn) {
+        const jobId = btn.getAttribute("data-cancel-job");
+        if (jobId) this.store.cancel(jobId);
+      }
+    });
   }
 
   private render(jobs: Job[]): void {
     const active = jobs.filter(
-      (j) => j.state.status === "loading" || j.state.status === "progress",
+      (j) =>
+        j.state.status === "loading" ||
+        j.state.status === "progress" ||
+        j.state.status === "cancelling",
     );
     const failed = jobs.filter((j) => j.state.status === "error");
 
@@ -38,9 +51,14 @@ export class JobIndicator {
 
   private renderActive(job: Job): string {
     const msg = job.state.message ?? job.label;
+    const isCancelling = job.state.status === "cancelling";
+    const action = isCancelling
+      ? `<span class="job-strip__cancelling">Stopping...</span>`
+      : `<button class="job-strip__cancel" data-cancel-job="${this.escape(job.id)}" title="Stop after current chunk">&#x2715;</button>`;
     return `<span class="job-strip__item job-strip__item--active">
       <span class="job-strip__spinner"></span>
       <span class="job-strip__label">${this.escape(msg)}</span>
+      ${action}
     </span>`;
   }
 

--- a/src/client/components/prompt-col-list.ts
+++ b/src/client/components/prompt-col-list.ts
@@ -1,0 +1,169 @@
+import type { PromptColumnSpec } from "../../shared/types";
+import { TokenInput } from "./token-input";
+
+interface PromptRow {
+  kind: "text" | "file";
+  tokenInput: TokenInput;
+  el: HTMLElement;
+}
+
+export class PromptColList {
+  private readonly headers: string[];
+  private rows: PromptRow[] = [];
+  private readonly listEl: HTMLElement;
+  private readonly addBtn: HTMLButtonElement;
+
+  constructor(container: HTMLElement, headers: string[], initialValue?: PromptColumnSpec[]) {
+    this.headers = headers;
+
+    this.listEl = document.createElement("div");
+    this.listEl.className = "pcol-list";
+
+    this.addBtn = document.createElement("button");
+    this.addBtn.type = "button";
+    this.addBtn.className = "pcol-add-btn";
+    this.addBtn.textContent = "+ Add column";
+    this.addBtn.addEventListener("click", () => this.addRow("text", ""));
+
+    container.appendChild(this.listEl);
+    container.appendChild(this.addBtn);
+
+    for (const spec of initialValue ?? []) {
+      this.addRow(spec.kind, spec.col);
+    }
+  }
+
+  getValue(): PromptColumnSpec[] {
+    return this.rows
+      .map((row) => ({ col: row.tokenInput.getValue()[0] ?? "", kind: row.kind }))
+      .filter((spec) => spec.col !== "");
+  }
+
+  destroy(): void {
+    for (const row of this.rows) {
+      row.tokenInput.destroy();
+    }
+    this.rows = [];
+    this.listEl.remove();
+    this.addBtn.remove();
+  }
+
+  private addRow(kind: "text" | "file", initialCol: string): void {
+    const row = this.buildRow(kind, initialCol);
+    this.rows.push(row);
+    this.listEl.appendChild(row.el);
+    this.updateArrows();
+  }
+
+  private buildRow(kind: "text" | "file", initialCol: string): PromptRow {
+    const el = document.createElement("div");
+    el.className = "pcol-row";
+
+    // Line 1: TokenInput for column selection
+    const line1 = document.createElement("div");
+    line1.className = "pcol-row-line1";
+    const tokenInput = new TokenInput(line1, this.headers, {
+      multi: false,
+      selected: initialCol ? [initialCol] : [],
+    });
+    el.appendChild(line1);
+
+    // Line 2: kind pills + spacer + action buttons
+    const line2 = document.createElement("div");
+    line2.className = "pcol-row-line2";
+
+    const pillsWrap = document.createElement("div");
+    pillsWrap.className = "pcol-kind-pills";
+
+    const textPill = this.makePill("Text", kind === "text");
+    const filePill = this.makePill("File", kind === "file");
+    pillsWrap.appendChild(textPill);
+    pillsWrap.appendChild(filePill);
+
+    const spacer = document.createElement("div");
+    spacer.className = "pcol-spacer";
+
+    const upBtn = this.makeBtn("↑", "pcol-btn-up");
+    const downBtn = this.makeBtn("↓", "pcol-btn-down");
+    const removeBtn = this.makeBtn("×", "pcol-btn-remove");
+
+    line2.appendChild(pillsWrap);
+    line2.appendChild(spacer);
+    line2.appendChild(upBtn);
+    line2.appendChild(downBtn);
+    line2.appendChild(removeBtn);
+    el.appendChild(line2);
+
+    const row: PromptRow = { kind, tokenInput, el };
+
+    textPill.addEventListener("click", () => {
+      row.kind = "text";
+      textPill.classList.add("selected");
+      filePill.classList.remove("selected");
+    });
+    filePill.addEventListener("click", () => {
+      row.kind = "file";
+      filePill.classList.add("selected");
+      textPill.classList.remove("selected");
+    });
+    upBtn.addEventListener("click", () => this.moveRow(row, -1));
+    downBtn.addEventListener("click", () => this.moveRow(row, 1));
+    removeBtn.addEventListener("click", () => this.removeRow(row));
+
+    return row;
+  }
+
+  private makePill(label: string, selected: boolean): HTMLButtonElement {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "tag" + (selected ? " selected" : "");
+    btn.textContent = label;
+    return btn;
+  }
+
+  private makeBtn(label: string, className: string): HTMLButtonElement {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = className;
+    btn.textContent = label;
+    return btn;
+  }
+
+  private moveRow(row: PromptRow, delta: -1 | 1): void {
+    const idx = this.rows.indexOf(row);
+    const newIdx = idx + delta;
+    if (newIdx < 0 || newIdx >= this.rows.length) return;
+
+    // Capture elements by their role before mutating the array
+    const elMoving = this.rows[idx].el;
+    const elDisplaced = this.rows[newIdx].el;
+
+    [this.rows[idx], this.rows[newIdx]] = [this.rows[newIdx], this.rows[idx]];
+
+    // For move-up: insert the moving element before the displaced one
+    // For move-down: insert the displaced element before the moving one (same net swap)
+    if (delta === -1) {
+      this.listEl.insertBefore(elMoving, elDisplaced);
+    } else {
+      this.listEl.insertBefore(elDisplaced, elMoving);
+    }
+
+    this.updateArrows();
+  }
+
+  private removeRow(row: PromptRow): void {
+    row.tokenInput.destroy();
+    row.el.remove();
+    this.rows = this.rows.filter((r) => r !== row);
+    this.updateArrows();
+  }
+
+  private updateArrows(): void {
+    this.rows.forEach((row, idx) => {
+      const upBtn = row.el.querySelector<HTMLButtonElement>(".pcol-btn-up");
+      const downBtn = row.el.querySelector<HTMLButtonElement>(".pcol-btn-down");
+      if (upBtn) upBtn.disabled = idx === 0;
+      if (downBtn) downBtn.disabled = idx === this.rows.length - 1;
+    });
+  }
+}

--- a/src/client/components/row-range.ts
+++ b/src/client/components/row-range.ts
@@ -45,7 +45,10 @@ export class RowRange {
     rangeRadio.name = groupName;
     rangeRadio.value = "range";
     rangeRadio.checked = !!selected;
-    rangeLabel.append(rangeRadio, " Specify range");
+    const rangeHint = document.createElement("span");
+    rangeHint.className = "optional";
+    rangeHint.textContent = " (better for large jobs)";
+    rangeLabel.append(rangeRadio, " Specify range", rangeHint);
 
     const rangeInputs = document.createElement("div");
     rangeInputs.className = "range-inputs";

--- a/src/client/components/token-input.ts
+++ b/src/client/components/token-input.ts
@@ -1,0 +1,314 @@
+/**
+ * TokenInput — searchable token/chip field for column selection.
+ *
+ * USE THIS when the list of items is potentially large (8+ items) and users
+ * know what they're looking for. Selected items appear as removable chips
+ * inside the field; unselected items appear in a filtered dropdown.
+ *
+ * Supports multi-select (default) and single-select (`multi: false`).
+ * Use `includeNew: true` on single-select output fields to allow the user to
+ * type a brand-new column name.
+ *
+ * Prefer TagList when the item count is small and users benefit from seeing
+ * all options at a glance (e.g. the Tools section with ~5 fixed entries).
+ *
+ * Naming note: selected items are called "chips" here (inline removable tokens).
+ * They reuse the `.tag.selected` CSS class from TagList for visual consistency —
+ * same appearance, different interaction model (chips are removed individually;
+ * tags are toggled).
+ */
+
+export interface TokenInputOpts {
+  /** Values to pre-select on construction. */
+  selected?: string[];
+  /** Allow multiple selections. Defaults to true. */
+  multi?: boolean;
+  /** Append a "+ New column" option for creating a new named column. */
+  includeNew?: boolean;
+  /** Initial value pre-filled in the new-column chip input. Defaults to "". */
+  newDefault?: string;
+}
+
+export class TokenInput {
+  private readonly field: HTMLElement;
+  private readonly chipsArea: HTMLElement;
+  private readonly addBtn: HTMLButtonElement;
+  private readonly searchInput: HTMLInputElement;
+  private readonly dropdown: HTMLElement;
+
+  private readonly allItems: string[];
+  private readonly multi: boolean;
+  private readonly includeNew: boolean;
+  private readonly newDefault: string;
+
+  /** Ordered list of currently selected values (preserves insertion order). */
+  private selected: string[];
+  /** True when the editable "+ New column" chip is present. */
+  private hasNewChip = false;
+
+  private readonly onDocumentClick: (e: MouseEvent) => void;
+
+  constructor(container: HTMLElement, items: string[], opts: TokenInputOpts) {
+    this.allItems = items;
+    this.multi = opts.multi !== false;
+    this.includeNew = opts.includeNew === true;
+    this.newDefault = opts.newDefault ?? "";
+    this.selected = [];
+
+    // Build DOM
+    this.field = document.createElement("div");
+    this.field.className = "token-field";
+
+    this.chipsArea = document.createElement("div");
+    this.chipsArea.className = "token-chips";
+
+    this.addBtn = document.createElement("button");
+    this.addBtn.type = "button";
+    this.addBtn.className = "token-add-btn tag";
+    this.addBtn.textContent = "+ Add";
+    this.chipsArea.appendChild(this.addBtn);
+
+    this.field.appendChild(this.chipsArea);
+
+    this.dropdown = document.createElement("div");
+    this.dropdown.className = "token-dropdown";
+    this.dropdown.style.display = "none";
+    this.field.appendChild(this.dropdown);
+
+    this.searchInput = document.createElement("input");
+    this.searchInput.type = "text";
+    this.searchInput.className = "token-search";
+    this.searchInput.placeholder = "Search...";
+    this.searchInput.autocomplete = "off";
+    this.dropdown.appendChild(this.searchInput);
+
+    container.appendChild(this.field);
+
+    this.onDocumentClick = (e: MouseEvent): void => {
+      if (!this.field.contains(e.target as Node)) this.closeDropdown();
+    };
+    this.wireEvents();
+    this.renderDropdown();
+
+    // Apply pre-selections
+    const initial = opts.selected ?? [];
+    if (this.includeNew && initial.length > 0 && !items.includes(initial[0])) {
+      // Custom value not in known items — treat as a "new column" selection
+      this.addNewChip(initial[0]);
+    } else {
+      for (const val of initial) {
+        if (items.includes(val)) {
+          this.selected.push(val);
+          this.addChip(val);
+        }
+      }
+    }
+
+    this.updateAddBtn();
+  }
+
+  // ─── Public API ─────────────────────────────────────────────────────────────
+
+  destroy(): void {
+    document.removeEventListener("click", this.onDocumentClick);
+    this.field.remove();
+  }
+
+  /**
+   * Returns the current selected values.
+   * Note: returns [] if the "+ New column" chip is present but its input is empty.
+   */
+  getValue(): string[] {
+    if (this.hasNewChip) {
+      const val = this.chipsArea.querySelector<HTMLInputElement>(".token-chip-input")?.value.trim();
+      return val ? [val] : [];
+    }
+    return [...this.selected];
+  }
+
+  // ─── Events ─────────────────────────────────────────────────────────────────
+
+  private wireEvents(): void {
+    this.addBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.openDropdown();
+      this.searchInput.focus();
+    });
+
+    this.searchInput.addEventListener("input", () => this.applyFilter());
+
+    this.searchInput.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") this.closeDropdown();
+    });
+
+    document.addEventListener("click", this.onDocumentClick);
+  }
+
+  // ─── Dropdown ───────────────────────────────────────────────────────────────
+
+  private openDropdown(): void {
+    this.renderDropdown();
+    this.searchInput.value = "";
+    this.applyFilter();
+    this.dropdown.style.display = "block";
+  }
+
+  private closeDropdown(): void {
+    this.dropdown.style.display = "none";
+    this.searchInput.value = "";
+  }
+
+  private updateAddBtn(): void {
+    const hasSelection = this.selected.length > 0 || this.hasNewChip;
+    this.addBtn.style.display = !this.multi && hasSelection ? "none" : "";
+  }
+
+  private renderDropdown(): void {
+    // Clear only option elements, preserving the searchInput as first child
+    const options = this.dropdown.querySelectorAll(".token-option, .token-no-match");
+    options.forEach((el) => el.remove());
+
+    const unselected = this.allItems.filter((item) => !this.selected.includes(item));
+
+    for (const item of unselected) {
+      const opt = document.createElement("div");
+      opt.className = "token-option";
+      opt.setAttribute("data-value", item);
+      opt.textContent = item;
+      opt.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this.selectItem(item);
+      });
+      this.dropdown.appendChild(opt);
+    }
+
+    if (this.includeNew) {
+      const newOpt = document.createElement("div");
+      newOpt.className = "token-option";
+      newOpt.setAttribute("data-value", "__new__");
+      newOpt.textContent = "+ New column";
+      newOpt.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this.selectNewColumn();
+      });
+      this.dropdown.appendChild(newOpt);
+    }
+  }
+
+  private applyFilter(): void {
+    const query = this.searchInput.value.toLowerCase();
+    const options = this.dropdown.querySelectorAll<HTMLElement>(".token-option");
+    let anyVisible = false;
+
+    options.forEach((opt) => {
+      const matches =
+        opt.getAttribute("data-value") === "__new__" ||
+        (opt.textContent ?? "").toLowerCase().includes(query);
+      opt.style.display = matches ? "block" : "none";
+      if (matches) anyVisible = true;
+    });
+
+    // Remove stale no-match message before re-evaluating
+    this.dropdown.querySelector(".token-no-match")?.remove();
+
+    if (!anyVisible) {
+      const msg = document.createElement("div");
+      msg.className = "token-no-match";
+      msg.textContent = "No matches";
+      this.dropdown.appendChild(msg);
+    }
+  }
+
+  // ─── Selection ──────────────────────────────────────────────────────────────
+
+  private selectItem(value: string): void {
+    if (!this.multi) {
+      // Single-select: clear existing selection first
+      this.selected = [];
+      this.hasNewChip = false;
+      this.chipsArea.querySelectorAll<HTMLElement>(".token-chip").forEach((chip) => chip.remove());
+    }
+
+    this.selected.push(value);
+    this.addChip(value);
+    this.renderDropdown();
+
+    this.closeDropdown();
+    this.updateAddBtn();
+  }
+
+  private selectNewColumn(): void {
+    if (!this.multi) {
+      this.selected = [];
+      this.hasNewChip = false;
+      this.chipsArea.querySelectorAll<HTMLElement>(".token-chip").forEach((chip) => chip.remove());
+    }
+
+    this.closeDropdown();
+    this.addNewChip(this.newDefault);
+    this.updateAddBtn();
+  }
+
+  // ─── Chips ──────────────────────────────────────────────────────────────────
+
+  private addChip(value: string): void {
+    const chip = document.createElement("span");
+    chip.className = "token-chip tag selected";
+    chip.setAttribute("data-value", value);
+    chip.textContent = value;
+
+    const removeBtn = document.createElement("button");
+    removeBtn.className = "token-chip-remove";
+    removeBtn.setAttribute("data-value", value);
+    removeBtn.type = "button";
+    removeBtn.textContent = "×";
+    removeBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.removeChip(value, chip);
+    });
+
+    chip.appendChild(removeBtn);
+    this.chipsArea.insertBefore(chip, this.addBtn);
+  }
+
+  private addNewChip(initialValue: string): void {
+    this.hasNewChip = true;
+
+    const chip = document.createElement("span");
+    chip.className = "token-chip token-chip-new tag selected";
+
+    const chipInput = document.createElement("input");
+    chipInput.type = "text";
+    chipInput.className = "token-chip-input";
+    chipInput.value = initialValue;
+    chipInput.addEventListener("click", (e) => e.stopPropagation());
+
+    const removeBtn = document.createElement("button");
+    removeBtn.className = "token-chip-remove";
+    removeBtn.setAttribute("data-value", "__new__");
+    removeBtn.type = "button";
+    removeBtn.textContent = "×";
+    removeBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      chip.remove();
+      this.hasNewChip = false;
+      this.updateAddBtn();
+    });
+
+    chip.appendChild(chipInput);
+    chip.appendChild(removeBtn);
+    this.chipsArea.insertBefore(chip, this.addBtn);
+    chipInput.focus();
+  }
+
+  private removeChip(value: string, chipEl: HTMLElement): void {
+    this.selected = this.selected.filter((v) => v !== value);
+    chipEl.remove();
+    // Refresh dropdown so the removed item reappears
+    if (this.dropdown.style.display !== "none") {
+      this.renderDropdown();
+      this.applyFilter();
+    }
+    this.updateAddBtn();
+  }
+}

--- a/src/client/google.d.ts
+++ b/src/client/google.d.ts
@@ -1,6 +1,7 @@
 import type {
   RunConfig,
   PrepRecipeParams,
+  PrepRecipeResult,
   ImportDriveLinksConfig,
   ExtractTextConfig,
 } from "../shared/types";
@@ -14,7 +15,7 @@ declare global {
     runBatchAI(config: RunConfig, jobId?: string): void;
     importDriveLinks(config: ImportDriveLinksConfig, jobId?: string): void;
     extractText(config: ExtractTextConfig, jobId?: string): void;
-    prepRecipe(params: PrepRecipeParams): void;
+    prepRecipe(params: PrepRecipeParams): PrepRecipeResult;
     getJobProgress(jobId: string): void;
   }
 

--- a/src/client/job-store.ts
+++ b/src/client/job-store.ts
@@ -7,6 +7,7 @@ export class JobStore {
   private jobs: Map<string, Job> = new Map();
   private listeners: Set<JobListener> = new Set();
   private pollIntervals: Map<string, ReturnType<typeof setInterval>> = new Map();
+  private cancelFlags: Map<string, boolean> = new Map();
 
   subscribe(fn: JobListener): () => void {
     this.listeners.add(fn);
@@ -52,6 +53,29 @@ export class JobStore {
     );
   }
 
+  cancel(id: string): void {
+    const job = this.jobs.get(id);
+    if (!job) return;
+    if (job.state.status !== "loading" && job.state.status !== "progress") return;
+    this.cancelFlags.set(id, true);
+    this.jobs.set(id, {
+      ...job,
+      state: { status: "cancelling", message: "Stopping after current chunk..." },
+    });
+    this.notify();
+  }
+
+  isCancelled(id: string): boolean {
+    return this.cancelFlags.get(id) ?? false;
+  }
+
+  setProgress(id: string, message: string): void {
+    const job = this.jobs.get(id);
+    if (!job) return;
+    this.jobs.set(id, { ...job, state: { status: "progress", message } });
+    this.notify();
+  }
+
   getJobs(): Job[] {
     return Array.from(this.jobs.values());
   }
@@ -65,6 +89,7 @@ export class JobStore {
 
   private complete(id: string): void {
     this.stopPolling(id);
+    this.cancelFlags.delete(id);
     const job = this.jobs.get(id);
     if (!job) return;
     this.jobs.set(id, { ...job, state: { status: "complete" }, completedAt: Date.now() });
@@ -77,6 +102,7 @@ export class JobStore {
 
   private fail(id: string, message: string): void {
     this.stopPolling(id);
+    this.cancelFlags.delete(id);
     const job = this.jobs.get(id);
     if (!job) return;
     this.jobs.set(id, { ...job, state: { status: "error", message }, completedAt: Date.now() });

--- a/src/client/job-store.ts
+++ b/src/client/job-store.ts
@@ -7,6 +7,7 @@ export class JobStore {
   private jobs: Map<string, Job> = new Map();
   private listeners: Set<JobListener> = new Set();
   private pollIntervals: Map<string, ReturnType<typeof setInterval>> = new Map();
+  private cancelFlags: Map<string, boolean> = new Map();
 
   subscribe(fn: JobListener): () => void {
     this.listeners.add(fn);
@@ -29,6 +30,23 @@ export class JobStore {
       getJobProgress(id)
         .then((progress) => {
           if (!progress) return;
+          const current = this.jobs.get(id);
+          if (!current) return;
+          if (current.state.status === "cancelling") {
+            // Keep cancelling status but surface the current row so the user
+            // can see how close the chunk is to finishing.
+            if (progress.message) {
+              this.jobs.set(id, {
+                ...current,
+                state: {
+                  status: "cancelling",
+                  message: `Stopping — ${progress.message.toLowerCase()}`,
+                },
+              });
+              this.notify();
+            }
+            return;
+          }
           this.update(id, {
             status: "progress",
             message: progress.message,
@@ -52,6 +70,29 @@ export class JobStore {
     );
   }
 
+  cancel(id: string): void {
+    const job = this.jobs.get(id);
+    if (!job) return;
+    if (job.state.status !== "loading" && job.state.status !== "progress") return;
+    this.cancelFlags.set(id, true);
+    this.jobs.set(id, {
+      ...job,
+      state: { status: "cancelling", message: "Stopping after this chunk..." },
+    });
+    this.notify();
+  }
+
+  isCancelled(id: string): boolean {
+    return this.cancelFlags.get(id) ?? false;
+  }
+
+  setProgress(id: string, message: string): void {
+    const job = this.jobs.get(id);
+    if (!job) return;
+    this.jobs.set(id, { ...job, state: { status: "progress", message } });
+    this.notify();
+  }
+
   getJobs(): Job[] {
     return Array.from(this.jobs.values());
   }
@@ -65,6 +106,7 @@ export class JobStore {
 
   private complete(id: string): void {
     this.stopPolling(id);
+    this.cancelFlags.delete(id);
     const job = this.jobs.get(id);
     if (!job) return;
     this.jobs.set(id, { ...job, state: { status: "complete" }, completedAt: Date.now() });
@@ -77,6 +119,7 @@ export class JobStore {
 
   private fail(id: string, message: string): void {
     this.stopPolling(id);
+    this.cancelFlags.delete(id);
     const job = this.jobs.get(id);
     if (!job) return;
     this.jobs.set(id, { ...job, state: { status: "error", message }, completedAt: Date.now() });

--- a/src/client/job-store.ts
+++ b/src/client/job-store.ts
@@ -77,7 +77,7 @@ export class JobStore {
     this.cancelFlags.set(id, true);
     this.jobs.set(id, {
       ...job,
-      state: { status: "cancelling", message: "Stopping after this chunk..." },
+      state: { status: "cancelling", message: "Stopping — finishing current chunk..." },
     });
     this.notify();
   }
@@ -86,9 +86,13 @@ export class JobStore {
     return this.cancelFlags.get(id) ?? false;
   }
 
+  // Only call this when the job is in loading or progress state.
+  // It will no-op for unknown jobs but does not guard against overwriting
+  // "cancelling" — callers must check isCancelled() before calling.
   setProgress(id: string, message: string): void {
     const job = this.jobs.get(id);
     if (!job) return;
+    if (job.state.status === "cancelling") return;
     this.jobs.set(id, { ...job, state: { status: "progress", message } });
     this.notify();
   }

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -8,6 +8,19 @@ import { getSheetHeaders, runBatchAI } from "../services";
 import { jobStore } from "../job-store";
 import { TOOL_CATALOG } from "../tools";
 
+export const CHUNK_SIZE = 50;
+
+export function computeChunks(
+  rowRange: { start: number; end: number },
+  chunkSize: number,
+): Array<{ start: number; end: number }> {
+  const chunks: Array<{ start: number; end: number }> = [];
+  for (let start = rowRange.start; start <= rowRange.end; start += chunkSize) {
+    chunks.push({ start, end: Math.min(start + chunkSize - 1, rowRange.end) });
+  }
+  return chunks;
+}
+
 export type SavedState = Required<
   Omit<RunConfig, "rowRange" | "tools" | "includeGrounding" | "applyMarkdown">
 > &

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -210,6 +210,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
 
     if (config.rowRange) {
       const rowCount = config.rowRange.end - config.rowRange.start + 1;
+      // Only warn when chunking will actually occur (more than one chunk needed).
       if (rowCount > CHUNK_SIZE) {
         const chunkCount = Math.ceil(rowCount / CHUNK_SIZE);
         const estimatedMins = Math.ceil((rowCount * 5) / 60);
@@ -225,16 +226,21 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
 
     if (config.rowRange) {
       const chunks = computeChunks(config.rowRange, CHUNK_SIZE);
-      const runChunks = async (): Promise<void> => {
-        for (let i = 0; i < chunks.length; i++) {
-          if (jobStore.isCancelled(jobId)) break;
-          jobStore.setProgress(jobId, `Chunk ${i + 1} of ${chunks.length}`);
-          await runBatchAI({ ...config, rowRange: chunks[i] }, jobId);
-        }
-      };
-      jobStore.dispatch(jobId, "Batch AI Run", runChunks()).catch((err: Error) => {
-        globalThis.alert("Error: " + err.message);
-      });
+      jobStore
+        .dispatch(
+          jobId,
+          "Batch AI Run",
+          (async () => {
+            for (let i = 0; i < chunks.length; i++) {
+              if (jobStore.isCancelled(jobId)) break;
+              jobStore.setProgress(jobId, `Chunk ${i + 1} of ${chunks.length}`);
+              await runBatchAI({ ...config, rowRange: chunks[i] }, jobId);
+            }
+          })(),
+        )
+        .catch((err: Error) => {
+          globalThis.alert("Error: " + err.message);
+        });
     } else {
       // No explicit row range — active sheet selection, resolved server-side.
       // Fall back to single dispatch (no chunking, no warning).

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -215,6 +215,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
       const rowCount = config.rowRange.end - config.rowRange.start + 1;
       if (rowCount > CHUNK_WARN_THRESHOLD) {
         const chunkCount = Math.ceil(rowCount / CHUNK_SIZE);
+        // ~5 s/row is a conservative estimate based on typical Gemini API latency.
         const estimatedMins = Math.ceil((rowCount * 5) / 60);
         const ok = globalThis.confirm(
           `You're about to process ${rowCount} rows across ${chunkCount} chunks.\n\n` +
@@ -229,18 +230,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
     if (config.rowRange) {
       const chunks = computeChunks(config.rowRange, CHUNK_SIZE);
       jobStore
-        .dispatch(
-          jobId,
-          "Batch AI Run",
-          (async () => {
-            const lastRow = chunks[chunks.length - 1].end;
-            for (let i = 0; i < chunks.length; i++) {
-              if (jobStore.isCancelled(jobId)) break;
-              jobStore.setProgress(jobId, `Rows ${chunks[i].start}–${chunks[i].end} of ${lastRow}`);
-              await runBatchAI({ ...config, rowRange: chunks[i] }, jobId);
-            }
-          })(),
-        )
+        .dispatch(jobId, "Batch AI Run", this.runChunks(jobId, config, chunks))
         .catch((err: Error) => {
           globalThis.alert("Error: " + err.message);
         });
@@ -253,6 +243,19 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
     }
 
     this.loadHeaders(container, this.currentPreset());
+  }
+
+  private async runChunks(
+    jobId: string,
+    config: RunConfig,
+    chunks: Array<{ start: number; end: number }>,
+  ): Promise<void> {
+    const lastRow = chunks[chunks.length - 1].end;
+    for (let i = 0; i < chunks.length; i++) {
+      if (jobStore.isCancelled(jobId)) break;
+      jobStore.setProgress(jobId, `Rows ${chunks[i].start}–${chunks[i].end} of ${lastRow}`);
+      await runBatchAI({ ...config, rowRange: chunks[i] }, jobId);
+    }
   }
 
   private assembleRunConfig(): RunConfig | null {

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -1,7 +1,7 @@
 import type { NavigationContext, Panel } from "../types";
 import type { RunConfig, ToolId, PromptColumnSpec } from "../../shared/types";
 import { TagList } from "../components/tag-list";
-import { SingleTagList } from "../components/single-tag-list";
+import { TokenInput } from "../components/token-input";
 import { RowRange } from "../components/row-range";
 import { PanelLoader } from "../components/panel-loader";
 import { getSheetHeaders, runBatchAI } from "../services";
@@ -30,14 +30,15 @@ export type SavedState = Required<
   Pick<RunConfig, "rowRange" | "tools" | "includeGrounding" | "applyMarkdown">;
 
 export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState> {
-  private userPromptList: TagList | null = null;
-  private driveFileList: TagList | null = null;
-  private systemPromptList: SingleTagList | null = null;
-  private outputColList: SingleTagList | null = null;
+  private userPromptList: TokenInput | null = null;
+  private driveFileList: TokenInput | null = null;
+  private systemPromptList: TokenInput | null = null;
+  private outputColList: TokenInput | null = null;
   private rowRangeComp: RowRange | null = null;
   private toolsList: TagList | null = null;
   private includeGroundingCb: HTMLInputElement | null = null;
   private applyMarkdownCb: HTMLInputElement | null = null;
+  private outputColObserver: MutationObserver | null = null;
   private nav: NavigationContext | null = null;
   private headersLoaded = false;
 
@@ -96,6 +97,12 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
   }
 
   private loadHeaders(container: HTMLElement, preset: Partial<RunConfig>): Promise<void> {
+    this.outputColObserver?.disconnect();
+    this.outputColObserver = null;
+    this.userPromptList?.destroy();
+    this.driveFileList?.destroy();
+    this.systemPromptList?.destroy();
+    this.outputColList?.destroy();
     return getSheetHeaders().then(
       (headers) => {
         if (headers.length === 0) {
@@ -107,26 +114,24 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
           preset.promptCols?.filter((p) => p.kind === "text").map((p) => p.col) ?? [];
         const presetFileCols =
           preset.promptCols?.filter((p) => p.kind === "file").map((p) => p.col) ?? [];
-        this.userPromptList = new TagList(
+        this.userPromptList = new TokenInput(
           container.querySelector("#user-prompt-cols")!,
           headers,
-          presetTextCols,
+          { selected: presetTextCols },
         );
-        this.driveFileList = new TagList(
-          container.querySelector("#drive-file-cols")!,
-          headers,
-          presetFileCols,
-        );
-        this.systemPromptList = new SingleTagList(
+        this.driveFileList = new TokenInput(container.querySelector("#drive-file-cols")!, headers, {
+          selected: presetFileCols,
+        });
+        this.systemPromptList = new TokenInput(
           container.querySelector("#system-prompt-col")!,
           headers,
-          { selected: preset.systemPromptCol },
+          { multi: false, selected: preset.systemPromptCol ? [preset.systemPromptCol] : [] },
         );
-        this.outputColList = new SingleTagList(container.querySelector("#output-col")!, headers, {
+        this.outputColList = new TokenInput(container.querySelector("#output-col")!, headers, {
+          multi: false,
           includeNew: true,
-          selected: preset.outputCol,
-          newPlaceholder: "ai_column_name",
           newDefault: "ai_",
+          selected: preset.outputCol ? [preset.outputCol] : [],
         });
         this.rowRangeComp = new RowRange(
           container.querySelector("#row-range-container")!,
@@ -134,15 +139,17 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
         );
 
         const updateGroundingLabel = (): void => {
-          const val = this.outputColList?.getValue() ?? "";
+          const val = this.outputColList?.getValue()[0] ?? "";
           const label = container.querySelector<HTMLElement>("#grounding-col-name");
           if (label) label.textContent = val ? `${val}_grounding` : "_grounding";
         };
         updateGroundingLabel();
-        container.querySelector("#output-col")?.addEventListener("click", updateGroundingLabel);
-        container
-          .querySelector("#output-col input")
-          ?.addEventListener("input", updateGroundingLabel);
+        const outputColEl = container.querySelector("#output-col");
+        if (outputColEl) {
+          const observer = new MutationObserver(updateGroundingLabel);
+          observer.observe(outputColEl, { childList: true, subtree: true });
+          this.outputColObserver = observer;
+        }
 
         if (!this.headersLoaded) {
           container.querySelector<HTMLElement>("#config-form")!.style.display = "block";
@@ -161,13 +168,18 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
 
   unmount(): SavedState | undefined {
     if (!this.userPromptList) return undefined;
+    this.outputColObserver?.disconnect();
+    this.userPromptList.destroy();
+    this.driveFileList?.destroy();
+    this.systemPromptList?.destroy();
+    this.outputColList?.destroy();
     return {
       promptCols: [
         ...this.userPromptList.getValue().map((col) => ({ col, kind: "text" as const })),
         ...(this.driveFileList?.getValue() ?? []).map((col) => ({ col, kind: "file" as const })),
       ],
-      systemPromptCol: this.systemPromptList?.getValue() ?? "",
-      outputCol: this.outputColList?.getValue() ?? "",
+      systemPromptCol: this.systemPromptList?.getValue()[0] ?? "",
+      outputCol: this.outputColList?.getValue()[0] ?? "",
       rowRange: this.rowRangeComp?.getValue(),
       tools: (this.toolsList?.getValue() ?? []) as ToolId[],
       includeGrounding: this.includeGroundingCb?.checked ?? false,
@@ -196,8 +208,8 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
         ...textCols.map((col) => ({ col, kind: "text" as const })),
         ...fileCols.map((col) => ({ col, kind: "file" as const })),
       ],
-      systemPromptCol: this.systemPromptList?.getValue() || undefined,
-      outputCol: this.outputColList?.getValue() || undefined,
+      systemPromptCol: this.systemPromptList?.getValue()[0] || undefined,
+      outputCol: this.outputColList?.getValue()[0] || undefined,
       rowRange: this.rowRangeComp?.getValue(),
       tools: (this.toolsList?.getValue() ?? []) as ToolId[],
       includeGrounding: this.includeGroundingCb?.checked,
@@ -205,7 +217,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
     };
   }
 
-  private handleRun(container: HTMLElement): void {
+  private handleRun(_container: HTMLElement): void {
     const config = this.assembleRunConfig();
     if (!config) return;
 
@@ -241,8 +253,8 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
         globalThis.alert("Error: " + err.message);
       });
     }
-
-    this.loadHeaders(container, this.currentPreset());
+    // NOTE: loadHeaders() is intentionally NOT called here.
+    // Reloading after dispatch caused flicker and re-initialization mid-run.
   }
 
   private async runChunks(
@@ -269,8 +281,8 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
       ...textCols.map((col) => ({ col, kind: "text" as const })),
       ...fileCols.map((col) => ({ col, kind: "file" as const })),
     ];
-    const systemPromptCol = this.systemPromptList?.getValue() || undefined;
-    const outputCol = this.outputColList?.getValue() ?? "";
+    const systemPromptCol = this.systemPromptList?.getValue()[0] || undefined;
+    const outputCol = this.outputColList?.getValue()[0] ?? "";
     if (!outputCol) {
       globalThis.alert("Please select an output column.");
       return null;

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -207,9 +207,41 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
     if (!config) return;
 
     const jobId = `batch-ai-${Date.now()}`;
-    jobStore.dispatch(jobId, "Batch AI Run", runBatchAI(config, jobId)).catch((err: Error) => {
-      globalThis.alert("Error: " + err.message);
-    });
+
+    if (config.rowRange) {
+      const rowCount = config.rowRange.end - config.rowRange.start + 1;
+      if (rowCount > CHUNK_SIZE) {
+        const chunkCount = Math.ceil(rowCount / CHUNK_SIZE);
+        const estimatedMins = Math.ceil((rowCount * 5) / 60);
+        const ok = globalThis.confirm(
+          `You're about to process ${rowCount} rows across ${chunkCount} chunks.\n\n` +
+            `This will take roughly ${estimatedMins} minutes. ` +
+            `The sidebar must remain open throughout — closing it will stop the run after the current chunk finishes.\n\n` +
+            `Continue?`,
+        );
+        if (!ok) return;
+      }
+    }
+
+    if (config.rowRange) {
+      const chunks = computeChunks(config.rowRange, CHUNK_SIZE);
+      const runChunks = async (): Promise<void> => {
+        for (let i = 0; i < chunks.length; i++) {
+          if (jobStore.isCancelled(jobId)) break;
+          jobStore.setProgress(jobId, `Chunk ${i + 1} of ${chunks.length}`);
+          await runBatchAI({ ...config, rowRange: chunks[i] }, jobId);
+        }
+      };
+      jobStore.dispatch(jobId, "Batch AI Run", runChunks()).catch((err: Error) => {
+        globalThis.alert("Error: " + err.message);
+      });
+    } else {
+      // No explicit row range — active sheet selection, resolved server-side.
+      // Fall back to single dispatch (no chunking, no warning).
+      jobStore.dispatch(jobId, "Batch AI Run", runBatchAI(config, jobId)).catch((err: Error) => {
+        globalThis.alert("Error: " + err.message);
+      });
+    }
 
     this.loadHeaders(container, this.currentPreset());
   }

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -1,7 +1,8 @@
 import type { NavigationContext, Panel } from "../types";
-import type { RunConfig, ToolId, PromptColumnSpec } from "../../shared/types";
+import type { RunConfig, ToolId } from "../../shared/types";
 import { TagList } from "../components/tag-list";
 import { TokenInput } from "../components/token-input";
+import { PromptColList } from "../components/prompt-col-list";
 import { RowRange } from "../components/row-range";
 import { PanelLoader } from "../components/panel-loader";
 import { getSheetHeaders, runBatchAI } from "../services";
@@ -30,8 +31,7 @@ export type SavedState = Required<
   Pick<RunConfig, "rowRange" | "tools" | "includeGrounding" | "applyMarkdown">;
 
 export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState> {
-  private userPromptList: TokenInput | null = null;
-  private driveFileList: TokenInput | null = null;
+  private promptColList: PromptColList | null = null;
   private systemPromptList: TokenInput | null = null;
   private outputColList: TokenInput | null = null;
   private rowRangeComp: RowRange | null = null;
@@ -49,7 +49,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
     savedState?: SavedState,
   ): void {
     this.nav = nav;
-    this.userPromptList = null; // reset so unmount() guards correctly before load
+    this.promptColList = null; // reset so unmount() guards correctly before load
     this.headersLoaded = false;
     container.innerHTML = this.template();
     this.wireNavButtons(container);
@@ -99,8 +99,8 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
   private loadHeaders(container: HTMLElement, preset: Partial<RunConfig>): Promise<void> {
     this.outputColObserver?.disconnect();
     this.outputColObserver = null;
-    this.userPromptList?.destroy();
-    this.driveFileList?.destroy();
+    this.promptColList?.destroy();
+    this.promptColList = null;
     this.systemPromptList?.destroy();
     this.outputColList?.destroy();
     return getSheetHeaders().then(
@@ -110,18 +110,11 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
           return;
         }
 
-        const presetTextCols =
-          preset.promptCols?.filter((p) => p.kind === "text").map((p) => p.col) ?? [];
-        const presetFileCols =
-          preset.promptCols?.filter((p) => p.kind === "file").map((p) => p.col) ?? [];
-        this.userPromptList = new TokenInput(
-          container.querySelector("#user-prompt-cols")!,
+        this.promptColList = new PromptColList(
+          container.querySelector("#prompt-col-list")!,
           headers,
-          { selected: presetTextCols },
+          preset.promptCols,
         );
-        this.driveFileList = new TokenInput(container.querySelector("#drive-file-cols")!, headers, {
-          selected: presetFileCols,
-        });
         this.systemPromptList = new TokenInput(
           container.querySelector("#system-prompt-col")!,
           headers,
@@ -167,17 +160,14 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
   }
 
   unmount(): SavedState | undefined {
-    if (!this.userPromptList) return undefined;
+    if (!this.promptColList) return undefined;
     this.outputColObserver?.disconnect();
-    this.userPromptList.destroy();
-    this.driveFileList?.destroy();
+    const promptCols = this.promptColList.getValue();
+    this.promptColList.destroy();
     this.systemPromptList?.destroy();
     this.outputColList?.destroy();
     return {
-      promptCols: [
-        ...this.userPromptList.getValue().map((col) => ({ col, kind: "text" as const })),
-        ...(this.driveFileList?.getValue() ?? []).map((col) => ({ col, kind: "file" as const })),
-      ],
+      promptCols,
       systemPromptCol: this.systemPromptList?.getValue()[0] ?? "",
       outputCol: this.outputColList?.getValue()[0] ?? "",
       rowRange: this.rowRangeComp?.getValue(),
@@ -201,13 +191,8 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
   }
 
   private currentPreset(): Partial<RunConfig> {
-    const textCols = this.userPromptList?.getValue() ?? [];
-    const fileCols = this.driveFileList?.getValue() ?? [];
     return {
-      promptCols: [
-        ...textCols.map((col) => ({ col, kind: "text" as const })),
-        ...fileCols.map((col) => ({ col, kind: "file" as const })),
-      ],
+      promptCols: this.promptColList?.getValue() ?? [],
       systemPromptCol: this.systemPromptList?.getValue()[0] || undefined,
       outputCol: this.outputColList?.getValue()[0] || undefined,
       rowRange: this.rowRangeComp?.getValue(),
@@ -271,16 +256,11 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
   }
 
   private assembleRunConfig(): RunConfig | null {
-    const textCols = this.userPromptList?.getValue() ?? [];
-    if (textCols.length === 0) {
+    const promptCols = this.promptColList?.getValue() ?? [];
+    if (promptCols.length === 0) {
       globalThis.alert("Please select at least one User prompt column.");
       return null;
     }
-    const fileCols = this.driveFileList?.getValue() ?? [];
-    const promptCols: PromptColumnSpec[] = [
-      ...textCols.map((col) => ({ col, kind: "text" as const })),
-      ...fileCols.map((col) => ({ col, kind: "file" as const })),
-    ];
     const systemPromptCol = this.systemPromptList?.getValue()[0] || undefined;
     const outputCol = this.outputColList?.getValue()[0] ?? "";
     if (!outputCol) {
@@ -321,12 +301,8 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
       </div>
       <div id="config-form" style="display:none">
         <div class="field-group">
-          <span class="field-label">User prompt columns <span class="required">*</span></span>
-          <div id="user-prompt-cols" class="tag-list"></div>
-        </div>
-        <div class="field-group">
-          <span class="field-label">Drive file columns <span class="optional">(optional)</span></span>
-          <div id="drive-file-cols" class="tag-list"></div>
+          <span class="field-label">Prompt columns <span class="required">*</span></span>
+          <div id="prompt-col-list"></div>
         </div>
         <div class="field-group">
           <span class="field-label">System prompt column <span class="optional">(optional)</span></span>

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -8,6 +8,22 @@ import { getSheetHeaders, runBatchAI } from "../services";
 import { jobStore } from "../job-store";
 import { TOOL_CATALOG } from "../tools";
 
+export const CHUNK_SIZE = 10;
+// Warn before dispatch when the batch exceeds this many rows, regardless of chunk count.
+// Kept separate from CHUNK_SIZE so small multi-chunk runs don't trigger the dialog.
+export const CHUNK_WARN_THRESHOLD = 50;
+
+export function computeChunks(
+  rowRange: { start: number; end: number },
+  chunkSize: number,
+): Array<{ start: number; end: number }> {
+  const chunks: Array<{ start: number; end: number }> = [];
+  for (let start = rowRange.start; start <= rowRange.end; start += chunkSize) {
+    chunks.push({ start, end: Math.min(start + chunkSize - 1, rowRange.end) });
+  }
+  return chunks;
+}
+
 export type SavedState = Required<
   Omit<RunConfig, "rowRange" | "tools" | "includeGrounding" | "applyMarkdown">
 > &
@@ -194,9 +210,47 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
     if (!config) return;
 
     const jobId = `batch-ai-${Date.now()}`;
-    jobStore.dispatch(jobId, "Batch AI Run", runBatchAI(config, jobId)).catch((err: Error) => {
-      globalThis.alert("Error: " + err.message);
-    });
+
+    if (config.rowRange) {
+      const rowCount = config.rowRange.end - config.rowRange.start + 1;
+      if (rowCount > CHUNK_WARN_THRESHOLD) {
+        const chunkCount = Math.ceil(rowCount / CHUNK_SIZE);
+        const estimatedMins = Math.ceil((rowCount * 5) / 60);
+        const ok = globalThis.confirm(
+          `You're about to process ${rowCount} rows across ${chunkCount} chunks.\n\n` +
+            `This will take roughly ${estimatedMins} minutes. ` +
+            `The sidebar must remain open throughout — closing it will stop the run after the current chunk finishes.\n\n` +
+            `Continue?`,
+        );
+        if (!ok) return;
+      }
+    }
+
+    if (config.rowRange) {
+      const chunks = computeChunks(config.rowRange, CHUNK_SIZE);
+      jobStore
+        .dispatch(
+          jobId,
+          "Batch AI Run",
+          (async () => {
+            const lastRow = chunks[chunks.length - 1].end;
+            for (let i = 0; i < chunks.length; i++) {
+              if (jobStore.isCancelled(jobId)) break;
+              jobStore.setProgress(jobId, `Rows ${chunks[i].start}–${chunks[i].end} of ${lastRow}`);
+              await runBatchAI({ ...config, rowRange: chunks[i] }, jobId);
+            }
+          })(),
+        )
+        .catch((err: Error) => {
+          globalThis.alert("Error: " + err.message);
+        });
+    } else {
+      // No explicit row range — active sheet selection, resolved server-side.
+      // Fall back to single dispatch (no chunking, no warning).
+      jobStore.dispatch(jobId, "Batch AI Run", runBatchAI(config, jobId)).catch((err: Error) => {
+        globalThis.alert("Error: " + err.message);
+      });
+    }
 
     this.loadHeaders(container, this.currentPreset());
   }

--- a/src/client/panels/extract-text.ts
+++ b/src/client/panels/extract-text.ts
@@ -1,6 +1,6 @@
 import type { NavigationContext, Panel } from "../types";
 import type { ExtractTextConfig } from "../../shared/types";
-import { SingleTagList } from "../components/single-tag-list";
+import { TokenInput } from "../components/token-input";
 import { RowRange } from "../components/row-range";
 import { PanelLoader } from "../components/panel-loader";
 import { getSheetHeaders, extractText } from "../services";
@@ -14,8 +14,8 @@ type SavedState = {
 };
 
 export class ExtractTextPanel implements Panel<undefined, SavedState> {
-  private sourceColList: SingleTagList | null = null;
-  private outputColList: SingleTagList | null = null;
+  private sourceColList: TokenInput | null = null;
+  private outputColList: TokenInput | null = null;
   private rowRange: RowRange | null = null;
   private nav: NavigationContext | null = null;
 
@@ -32,17 +32,20 @@ export class ExtractTextPanel implements Panel<undefined, SavedState> {
     const loader = new PanelLoader(container);
 
     const loadHeaders = (selectedSource?: string, selectedOutput?: string): Promise<void> => {
+      this.sourceColList?.destroy();
+      this.outputColList?.destroy();
       loader.setState({ status: "loading", message: "Loading columns..." });
       return getSheetHeaders().then(
         (headers) => {
-          this.sourceColList = new SingleTagList(container.querySelector("#source-col")!, headers, {
-            selected: selectedSource,
+          this.sourceColList = new TokenInput(container.querySelector("#source-col")!, headers, {
+            multi: false,
+            selected: selectedSource ? [selectedSource] : [],
           });
-          this.outputColList = new SingleTagList(container.querySelector("#output-col")!, headers, {
+          this.outputColList = new TokenInput(container.querySelector("#output-col")!, headers, {
+            multi: false,
             includeNew: true,
-            selected: selectedOutput,
-            newPlaceholder: "extracted_text",
-            newDefault: "",
+            newDefault: "extracted_text",
+            selected: selectedOutput ? [selectedOutput] : [],
           });
           container.querySelector<HTMLElement>("#config-form")!.style.display = "block";
           loader.setState({ status: "idle" });
@@ -69,10 +72,12 @@ export class ExtractTextPanel implements Panel<undefined, SavedState> {
       const btn = container.querySelector<HTMLButtonElement>("#refresh-btn")!;
       btn.classList.add("spinning");
       btn.disabled = true;
-      loadHeaders(this.sourceColList?.getValue(), this.outputColList?.getValue()).finally(() => {
-        btn.classList.remove("spinning");
-        btn.disabled = false;
-      });
+      loadHeaders(this.sourceColList?.getValue()[0], this.outputColList?.getValue()[0]).finally(
+        () => {
+          btn.classList.remove("spinning");
+          btn.disabled = false;
+        },
+      );
     });
 
     loadHeaders(savedState?.sourceCol, savedState?.outputCol);
@@ -80,9 +85,13 @@ export class ExtractTextPanel implements Panel<undefined, SavedState> {
 
   unmount(): SavedState {
     const range = this.rowRange?.getValue();
+    const sourceCol = this.sourceColList?.getValue()[0] ?? "";
+    const outputCol = this.outputColList?.getValue()[0] ?? "";
+    this.sourceColList?.destroy();
+    this.outputColList?.destroy();
     return {
-      sourceCol: this.sourceColList?.getValue() ?? "",
-      outputCol: this.outputColList?.getValue() ?? "",
+      sourceCol,
+      outputCol,
       startRow: range?.start ?? 2,
       endRow: range?.end ?? 2,
     };
@@ -99,13 +108,13 @@ export class ExtractTextPanel implements Panel<undefined, SavedState> {
   }
 
   private assembleConfig(): ExtractTextConfig | null {
-    const sourceCol = this.sourceColList?.getValue() ?? "";
+    const sourceCol = this.sourceColList?.getValue()[0] ?? "";
     if (!sourceCol) {
       globalThis.alert("Please select a source column.");
       return null;
     }
 
-    const outputCol = this.outputColList?.getValue() ?? "";
+    const outputCol = this.outputColList?.getValue()[0] ?? "";
     if (!outputCol) {
       globalThis.alert("Please select an output column.");
       return null;

--- a/src/client/panels/import-drive-links.ts
+++ b/src/client/panels/import-drive-links.ts
@@ -1,6 +1,6 @@
 import type { NavigationContext, Panel } from "../types";
 import type { ImportDriveLinksConfig } from "../../shared/types";
-import { SingleTagList } from "../components/single-tag-list";
+import { TokenInput } from "../components/token-input";
 import { TagList } from "../components/tag-list";
 import { PanelLoader } from "../components/panel-loader";
 import { getSheetHeaders, importDriveLinks } from "../services";
@@ -23,7 +23,7 @@ const MIME_TYPE_OPTIONS = [
 
 export class ImportDriveLinksPanel implements Panel<undefined, SavedState> {
   private folderUrlInput: HTMLInputElement | null = null;
-  private outputColList: SingleTagList | null = null;
+  private outputColList: TokenInput | null = null;
   private mimeTypeList: TagList | null = null;
   private nav: NavigationContext | null = null;
 
@@ -51,14 +51,15 @@ export class ImportDriveLinksPanel implements Panel<undefined, SavedState> {
     const loader = new PanelLoader(container);
 
     const loadHeaders = (selected?: string): Promise<void> => {
+      this.outputColList?.destroy();
       loader.setState({ status: "loading", message: "Loading columns..." });
       return getSheetHeaders().then(
         (headers) => {
-          this.outputColList = new SingleTagList(container.querySelector("#output-col")!, headers, {
+          this.outputColList = new TokenInput(container.querySelector("#output-col")!, headers, {
+            multi: false,
             includeNew: true,
-            selected,
-            newPlaceholder: "drive_links",
-            newDefault: "",
+            newDefault: "drive_links",
+            selected: selected ? [selected] : [],
           });
           container.querySelector<HTMLElement>("#config-form")!.style.display = "block";
           loader.setState({ status: "idle" });
@@ -78,7 +79,7 @@ export class ImportDriveLinksPanel implements Panel<undefined, SavedState> {
       const btn = container.querySelector<HTMLButtonElement>("#refresh-btn")!;
       btn.classList.add("spinning");
       btn.disabled = true;
-      loadHeaders(this.outputColList?.getValue()).finally(() => {
+      loadHeaders(this.outputColList?.getValue()[0]).finally(() => {
         btn.classList.remove("spinning");
         btn.disabled = false;
       });
@@ -88,9 +89,11 @@ export class ImportDriveLinksPanel implements Panel<undefined, SavedState> {
   }
 
   unmount(): SavedState {
+    const outputCol = this.outputColList?.getValue()[0] ?? "";
+    this.outputColList?.destroy();
     return {
       folderUrl: this.folderUrlInput?.value ?? "",
-      outputCol: this.outputColList?.getValue() ?? "",
+      outputCol,
       mimeTypes: this.mimeTypeList?.getValue() ?? [],
     };
   }
@@ -112,7 +115,7 @@ export class ImportDriveLinksPanel implements Panel<undefined, SavedState> {
       return null;
     }
 
-    const outputCol = this.outputColList?.getValue() ?? "";
+    const outputCol = this.outputColList?.getValue()[0] ?? "";
     if (!outputCol) {
       globalThis.alert("Please select an output column.");
       return null;

--- a/src/client/panels/recipe.ts
+++ b/src/client/panels/recipe.ts
@@ -1,6 +1,7 @@
-import type { NavigationContext, Panel, RecipeDefinition } from "../types";
-import type { RecipeParams } from "../types";
+import type { NavigationContext, Panel, RecipeDefinition, ColumnDef } from "../types";
 import type {
+  ColStrategy,
+  PrepColSpec,
   PrepRecipeParams,
   PrepRecipeResult,
   RunConfig,
@@ -10,13 +11,22 @@ import { LockableField } from "../components/lockable-field";
 import { RecipePrepCook } from "../components/recipe-prep-cook";
 import { prepRecipe } from "../services";
 
+type ColFieldRefs = {
+  colTitle?: LockableField;
+  prompt?: LockableField;
+  urlInput?: HTMLInputElement;
+  appendInputs?: Record<string, HTMLInputElement>;
+};
+
+type ColSavedValues = {
+  colTitle?: string;
+  prompt?: string;
+  url?: string;
+  appendValues?: Record<string, string>;
+};
+
 type SavedState = {
-  driveFolderValue?: string;
-  systemPromptTitle?: string;
-  systemPromptValue?: string;
-  userPromptTitles?: string[];
-  userPromptValues?: string[];
-  outputColTitle?: string;
+  colValues: ColSavedValues[];
   prepComplete: boolean;
   preppedRunConfig?: Partial<RunConfig>;
 };
@@ -24,18 +34,9 @@ type SavedState = {
 export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
   private nav: NavigationContext | null = null;
   private definition: RecipeDefinition | null = null;
-  private params: RecipeParams | null = null;
   private prepCook: RecipePrepCook | null = null;
   private preppedRunConfig: Partial<RunConfig> | null = null;
-  private driveFolderInput: HTMLInputElement | null = null;
-
-  private fields: {
-    systemPromptTitle?: LockableField;
-    systemPromptValue?: LockableField;
-    userPromptTitles: LockableField[];
-    userPromptValues: LockableField[];
-    outputColTitle?: LockableField;
-  } = { userPromptTitles: [], userPromptValues: [] };
+  private fields: ColFieldRefs[] = [];
 
   mount(
     container: HTMLElement,
@@ -45,111 +46,85 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
   ): void {
     this.nav = nav;
     this.definition = definition ?? null;
-    this.params = definition?.params ?? {};
-    this.fields = { userPromptTitles: [], userPromptValues: [] };
+    this.fields = [];
     this.preppedRunConfig = savedState?.preppedRunConfig ?? null;
 
-    container.innerHTML = this.template(this.definition);
-
+    container.innerHTML = this.template(definition);
     container.querySelector("#back-btn")?.addEventListener("click", () => nav.back());
 
-    this.mountFields(container, this.params, savedState);
-    this.mountPrepCook(container, savedState?.prepComplete ?? false, container);
+    this.mountFields(container, definition?.params?.columns ?? [], savedState);
+    this.mountPrepCook(container, savedState?.prepComplete ?? false);
   }
 
   unmount(): SavedState {
+    const colValues: ColSavedValues[] = this.fields.map((f) => ({
+      colTitle: f.colTitle?.getValue(),
+      prompt: f.prompt?.getValue(),
+      url: f.urlInput?.value,
+      appendValues: f.appendInputs
+        ? Object.fromEntries(Object.entries(f.appendInputs).map(([id, el]) => [id, el.value]))
+        : undefined,
+    }));
     return {
-      driveFolderValue: this.driveFolderInput?.value,
-      systemPromptTitle: this.fields.systemPromptTitle?.getValue(),
-      systemPromptValue: this.fields.systemPromptValue?.getValue(),
-      userPromptTitles: this.fields.userPromptTitles.map((f) => f.getValue()),
-      userPromptValues: this.fields.userPromptValues.map((f) => f.getValue()),
-      outputColTitle: this.fields.outputColTitle?.getValue(),
+      colValues,
       prepComplete: this.prepCook?.isPrepComplete() ?? false,
       preppedRunConfig: this.preppedRunConfig ?? undefined,
     };
   }
 
-  private mountFields(container: HTMLElement, params: RecipeParams, savedState?: SavedState): void {
+  private mountFields(container: HTMLElement, columns: ColumnDef[], savedState?: SavedState): void {
     const reset = (): void => this.prepCook?.reset();
 
-    if (params.driveFolder) {
-      this.driveFolderInput = container.querySelector<HTMLInputElement>("#drive-folder-input");
-      if (savedState?.driveFolderValue && this.driveFolderInput) {
-        this.driveFolderInput.value = savedState.driveFolderValue;
-      }
-      this.driveFolderInput?.addEventListener("input", reset);
-    }
+    columns.forEach((col, i) => {
+      const saved = savedState?.colValues?.[i];
+      const refs: ColFieldRefs = {};
 
-    if (params.systemPrompt) {
-      this.fields.systemPromptTitle = new LockableField(
-        container.querySelector("#system-prompt-title-container")!,
-        {
-          label: "Column",
-          defaultValue: savedState?.systemPromptTitle ?? params.systemPrompt.colTitle.value,
-          locked: params.systemPrompt.colTitle.locked,
-          onUnlock: reset,
-        },
-      );
-      this.fields.systemPromptValue = new LockableField(
-        container.querySelector("#system-prompt-value-container")!,
-        {
+      refs.colTitle = new LockableField(container.querySelector(`#col-${i}-title-container`)!, {
+        label: "Column",
+        defaultValue: saved?.colTitle ?? col.colTitle.value,
+        locked: col.colTitle.locked,
+        onUnlock: reset,
+      });
+
+      if (col.prompt !== undefined) {
+        refs.prompt = new LockableField(container.querySelector(`#col-${i}-prompt-container`)!, {
           label: "Prompt",
-          defaultValue: savedState?.systemPromptValue ?? params.systemPrompt.prompt.value,
-          locked: params.systemPrompt.prompt.locked,
+          defaultValue: saved?.prompt ?? col.prompt.value,
+          locked: col.prompt.locked,
           multiline: true,
           onUnlock: reset,
-        },
-      );
-    }
+        });
+      }
 
-    if (params.userPrompts) {
-      params.userPrompts.forEach((up, i) => {
-        this.fields.userPromptTitles[i] = new LockableField(
-          container.querySelector(`#user-prompt-title-${i}-container`)!,
-          {
-            label: "Column",
-            defaultValue: savedState?.userPromptTitles?.[i] ?? up.colTitle.value,
-            locked: up.colTitle.locked,
-            onUnlock: reset,
-          },
-        );
-        this.fields.userPromptValues[i] = new LockableField(
-          container.querySelector(`#user-prompt-value-${i}-container`)!,
-          {
-            label: "Prompt",
-            defaultValue: savedState?.userPromptValues?.[i] ?? up.prompt.value,
-            locked: up.prompt.locked,
-            multiline: true,
-            onUnlock: reset,
-          },
-        );
-      });
-    }
+      if (col.url !== undefined) {
+        const urlEl = container.querySelector<HTMLInputElement>(`#col-${i}-url-input`);
+        if (urlEl) {
+          if (saved?.url) urlEl.value = saved.url;
+          urlEl.addEventListener("input", reset);
+          refs.urlInput = urlEl;
+        }
+      }
 
-    if (params.outputCol) {
-      this.fields.outputColTitle = new LockableField(
-        container.querySelector("#output-col-title-container")!,
-        {
-          label: "Column",
-          defaultValue: savedState?.outputColTitle ?? params.outputCol.colTitle.value,
-          locked: params.outputCol.colTitle.locked,
-          onUnlock: reset,
-        },
-      );
-    }
+      if (col.appendFields?.length) {
+        refs.appendInputs = {};
+        for (const af of col.appendFields) {
+          const el = container.querySelector<HTMLInputElement>(`#col-${i}-append-${af.id}`);
+          if (el) {
+            if (saved?.appendValues?.[af.id]) el.value = saved.appendValues[af.id];
+            refs.appendInputs[af.id] = el;
+          }
+        }
+      }
+
+      this.fields[i] = refs;
+    });
   }
 
-  private mountPrepCook(
-    container: HTMLElement,
-    prepComplete: boolean,
-    _panelContainer: HTMLElement,
-  ): void {
+  private mountPrepCook(container: HTMLElement, prepComplete: boolean): void {
     this.prepCook = new RecipePrepCook(container.querySelector("#prep-cook-container")!, {
       onPrep: async (): Promise<void> => {
         const params = this.buildPrepParams();
-        if (!params) throw null; // validation alert already shown; bail silently
-
+        if (!params) throw null;
         const result = await prepRecipe(params);
         this.preppedRunConfig = this.buildRunConfig(result);
       },
@@ -163,107 +138,123 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
   }
 
   private buildPrepParams(): PrepRecipeParams | null {
-    const params = this.params!;
-    const result: PrepRecipeParams = {};
+    const columns = this.definition?.params?.columns ?? [];
+    const cols: PrepColSpec[] = [];
 
-    if (params.driveFolder) {
-      const url = this.driveFolderInput?.value.trim() ?? "";
-      if (!url) {
-        globalThis.alert("Please enter a Google Drive folder link.");
-        return null;
+    for (let i = 0; i < columns.length; i++) {
+      const col = columns[i];
+      const colTitle = this.fields[i]?.colTitle?.getValue() ?? col.colTitle.value;
+
+      let strategy: ColStrategy;
+      switch (col.strategyKind) {
+        case "list-drive-folder": {
+          const url = this.fields[i]?.urlInput?.value.trim() ?? "";
+          if (!url) {
+            globalThis.alert(`Please enter a URL for "${col.label}".`);
+            return null;
+          }
+          strategy = { kind: "list-drive-folder", url };
+          break;
+        }
+        case "fill-value": {
+          const base = this.fields[i]?.prompt?.getValue() ?? col.prompt?.value ?? "";
+          const appended = (col.appendFields ?? [])
+            .map((af) => {
+              const v = this.fields[i]?.appendInputs?.[af.id]?.value.trim() ?? "";
+              return v ? (af.prefix ?? "") + v : "";
+            })
+            .join("");
+          strategy = { kind: "fill-value", value: base + appended };
+          break;
+        }
+        case "create-empty":
+          strategy = { kind: "create-empty" };
+          break;
       }
-      result.driveFolder = { url, colTitle: params.driveFolder.colTitle };
+
+      cols.push({ colTitle, strategy });
     }
 
-    if (params.systemPrompt) {
-      result.systemPrompt = {
-        colTitle: this.fields.systemPromptTitle?.getValue() ?? params.systemPrompt.colTitle.value,
-        value: this.fields.systemPromptValue?.getValue() ?? params.systemPrompt.prompt.value,
-      };
-    }
-
-    if (params.userPrompts) {
-      result.userPrompts = params.userPrompts.map((up, i) => ({
-        colTitle: this.fields.userPromptTitles[i]?.getValue() ?? up.colTitle.value,
-        value: this.fields.userPromptValues[i]?.getValue() ?? up.prompt.value,
-      }));
-    }
-
-    if (params.outputCol) {
-      result.outputCol = {
-        colTitle: this.fields.outputColTitle?.getValue() ?? params.outputCol.colTitle.value,
-      };
-    }
-
-    return result;
+    return { cols };
   }
 
   private buildRunConfig(result: PrepRecipeResult): Partial<RunConfig> {
-    const promptCols: PromptColumnSpec[] = [
-      ...(result.colNames.userPrompts ?? []).map((col) => ({ col, kind: "text" as const })),
-      ...(result.colNames.driveLink
-        ? [{ col: result.colNames.driveLink, kind: "file" as const }]
-        : []),
-    ];
-    return {
-      promptCols,
-      systemPromptCol: result.colNames.systemPrompt,
-      outputCol: result.colNames.outputCol ?? "",
-      rowRange: result.rowRange,
-      tools: result.tools,
-    };
+    const columns = this.definition?.params?.columns ?? [];
+    const settings = this.definition?.params?.settings ?? {};
+    const promptCols: PromptColumnSpec[] = [];
+    let systemPromptCol: string | undefined;
+    let outputCol = "";
+
+    for (let i = 0; i < columns.length; i++) {
+      const col = columns[i];
+      const resolvedTitle = this.fields[i]?.colTitle?.getValue() ?? col.colTitle.value;
+
+      switch (col.role) {
+        case "userPrompt":
+          promptCols.push({ col: resolvedTitle, kind: "text" });
+          break;
+        case "driveLink":
+          promptCols.push({ col: resolvedTitle, kind: "file" });
+          break;
+        case "systemPrompt":
+          systemPromptCol = resolvedTitle;
+          break;
+        case "output":
+          outputCol = resolvedTitle;
+          break;
+      }
+    }
+
+    return { promptCols, systemPromptCol, outputCol, rowRange: result.rowRange, ...settings };
   }
 
-  private template(definition: RecipeDefinition | null): string {
-    const params = definition?.params ?? {};
+  private template(definition: RecipeDefinition | undefined | null): string {
+    const columns = definition?.params?.columns ?? [];
     const title = definition ? `${definition.icon} ${definition.name}` : "Recipe";
-    const numUserPrompts = params.userPrompts?.length ?? 0;
+
+    const columnSections = columns
+      .map((col, i) => {
+        const requiredMark = col.required ? ` <span class="required">*</span>` : "";
+        const helperHtml = col.helperText ? `<p class="field-helper">${col.helperText}</p>` : "";
+
+        const urlInputHtml =
+          col.url !== undefined
+            ? `<input id="col-${i}-url-input" type="text" class="text-input"
+                placeholder="${col.url.placeholder ?? "Paste Google Drive URL"}" />`
+            : "";
+
+        const promptContainerHtml =
+          col.prompt !== undefined ? `<div id="col-${i}-prompt-container"></div>` : "";
+
+        const appendFieldsHtml = (col.appendFields ?? [])
+          .map(
+            (af) =>
+              `<div class="append-field">
+                <label class="field-label">${af.label}</label>
+                <input id="col-${i}-append-${af.id}" type="text" class="text-input"
+                  placeholder="${af.placeholder ?? ""}" />
+              </div>`,
+          )
+          .join("");
+
+        return `
+          <div class="recipe-section-card">
+            <div class="recipe-section-card-title">${col.label}${requiredMark}</div>
+            ${helperHtml}
+            <div id="col-${i}-title-container"></div>
+            ${urlInputHtml}
+            ${promptContainerHtml}
+            ${appendFieldsHtml}
+          </div>`;
+      })
+      .join("");
 
     return `
       <div class="panel-header">
         <button id="back-btn" class="back-btn">← Back</button>
         <span class="panel-title">${title}</span>
       </div>
-      ${
-        params.driveFolder
-          ? `
-      <div class="recipe-section-card">
-        <div class="recipe-section-card-title">Drive Folder <span class="required">*</span></div>
-        ${params.driveFolder.helperText ? `<p class="field-helper">${params.driveFolder.helperText}</p>` : ""}
-        <input id="drive-folder-input" type="text" class="text-input"
-          placeholder="Paste Google Drive folder URL or ID" />
-      </div>`
-          : ""
-      }
-      ${
-        params.systemPrompt
-          ? `
-      <div class="recipe-section-card">
-        <div class="recipe-section-card-title">System Prompt</div>
-        <div id="system-prompt-title-container"></div>
-        <div id="system-prompt-value-container"></div>
-      </div>`
-          : ""
-      }
-      ${(params.userPrompts ?? [])
-        .map(
-          (_, i) => `
-      <div class="recipe-section-card">
-        <div class="recipe-section-card-title">User Prompt${numUserPrompts > 1 ? ` ${i + 1}` : ""}</div>
-        <div id="user-prompt-title-${i}-container"></div>
-        <div id="user-prompt-value-${i}-container"></div>
-      </div>`,
-        )
-        .join("")}
-      ${
-        params.outputCol
-          ? `
-      <div class="recipe-section-card">
-        <div class="recipe-section-card-title">Output Column</div>
-        <div id="output-col-title-container"></div>
-      </div>`
-          : ""
-      }
+      ${columnSections}
       <div id="prep-cook-container"></div>
     `;
   }

--- a/src/client/recipes.ts
+++ b/src/client/recipes.ts
@@ -1,5 +1,4 @@
-import type { RecipeDefinition } from "./types";
-import type { RecipeParams } from "./types";
+import type { RecipeDefinition, RecipeParams } from "./types";
 
 export const RECIPES: RecipeDefinition[] = [
   {
@@ -9,21 +8,32 @@ export const RECIPES: RecipeDefinition[] = [
     description: "Summarize each file in a Google Drive folder",
     panelId: "recipe",
     params: {
-      driveFolder: {
-        colTitle: "Drive Link",
-        helperText: "Make sure you have access to this folder",
-      },
-      systemPrompt: {
-        colTitle: { value: "System Prompt", locked: true },
-        prompt: {
-          value:
-            "You are an expert document analyst. Produce clear, structured summaries " +
-            "focusing on key themes, main arguments, important data points, and actionable conclusions.",
-          locked: true,
-        },
-      },
-      userPrompts: [
+      columns: [
         {
+          label: "Drive Folder",
+          role: "driveLink",
+          strategyKind: "list-drive-folder",
+          colTitle: { value: "Drive Link", locked: true },
+          url: { value: "", locked: false, placeholder: "Paste Google Drive folder URL" },
+          helperText: "Make sure you have access to this folder",
+          required: true,
+        },
+        {
+          label: "System Prompt",
+          role: "systemPrompt",
+          strategyKind: "fill-value",
+          colTitle: { value: "System Prompt", locked: true },
+          prompt: {
+            value:
+              "You are an expert document analyst. Produce clear, structured summaries " +
+              "focusing on key themes, main arguments, important data points, and actionable conclusions.",
+            locked: true,
+          },
+        },
+        {
+          label: "User Prompt",
+          role: "userPrompt",
+          strategyKind: "fill-value",
           colTitle: { value: "User Prompt", locked: true },
           prompt: {
             value:
@@ -32,10 +42,13 @@ export const RECIPES: RecipeDefinition[] = [
             locked: true,
           },
         },
+        {
+          label: "Output Column",
+          role: "output",
+          strategyKind: "create-empty",
+          colTitle: { value: "AI_Summarization", locked: true },
+        },
       ],
-      outputCol: {
-        colTitle: { value: "AI_Summarization", locked: true },
-      },
     } satisfies RecipeParams,
   },
 ];

--- a/src/client/sidebar.css
+++ b/src/client/sidebar.css
@@ -523,3 +523,24 @@
           overflow: hidden;
           text-overflow: ellipsis;
         }
+
+.job-strip__cancel {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 11px;
+  line-height: 1;
+  opacity: 0.6;
+  padding: 0 2px;
+}
+
+.job-strip__cancel:hover {
+  opacity: 1;
+}
+
+.job-strip__cancelling {
+  font-size: 11px;
+  font-style: italic;
+  opacity: 0.6;
+}

--- a/src/client/sidebar.css
+++ b/src/client/sidebar.css
@@ -544,3 +544,100 @@
   font-style: italic;
   opacity: 0.6;
 }
+
+        /* ── Token Input ─────────────────────────────────────────────────────────── */
+
+        .token-field {
+            position: relative;
+            width: 100%;
+        }
+
+        .token-chips {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            align-items: center;
+        }
+
+        .token-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 2px;
+        }
+
+        .token-chip-remove {
+            background: none;
+            border: none;
+            cursor: pointer;
+            color: #1a73e8;
+            font-size: 13px;
+            line-height: 1;
+            padding: 0 0 0 2px;
+            opacity: 0.7;
+        }
+
+        .token-chip-remove:hover {
+            opacity: 1;
+        }
+
+        .token-chip-input {
+            border: none;
+            outline: none;
+            font-size: 12px;
+            color: #1a73e8;
+            width: 120px;
+            background: transparent;
+        }
+
+        .token-add-btn {
+            color: var(--text-secondary) !important;
+        }
+
+        .token-search {
+            display: block;
+            width: 100%;
+            border: none;
+            outline: none;
+            border-bottom: 1px solid #dadce0;
+            padding: 6px 10px;
+            font-size: 13px;
+            color: #202124;
+            background: transparent;
+            box-sizing: border-box;
+        }
+
+        .token-search::placeholder {
+            color: #9aa0a6;
+        }
+
+        .token-dropdown {
+            position: absolute;
+            top: calc(100% + 4px);
+            left: 0;
+            right: 0;
+            background: #fff;
+            border: 1px solid #dadce0;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+            max-height: 220px;
+            overflow-y: auto;
+            z-index: 100;
+        }
+
+        .token-option {
+            padding: 7px 12px;
+            font-size: 13px;
+            cursor: pointer;
+            color: #202124;
+        }
+
+        .token-option:hover {
+            background: #f1f3f4;
+        }
+
+        .token-no-match {
+            padding: 7px 12px;
+            font-size: 13px;
+            color: #9aa0a6;
+            font-style: italic;
+        }

--- a/src/client/sidebar.css
+++ b/src/client/sidebar.css
@@ -641,3 +641,55 @@
             color: #9aa0a6;
             font-style: italic;
         }
+
+        /* ── Prompt Column List ──────────────────────────────────────────────────── */
+
+        .pcol-list { display: flex; flex-direction: column; gap: 8px; }
+
+        .pcol-row { display: flex; flex-direction: column; gap: 4px; }
+
+        .pcol-row-line1 { width: 100%; }
+
+        .pcol-row-line2 {
+          display: flex;
+          align-items: center;
+          gap: 4px;
+        }
+
+        .pcol-kind-pills { display: flex; gap: 4px; }
+
+        .pcol-spacer { flex: 1; }
+
+        .pcol-btn-up,
+        .pcol-btn-down,
+        .pcol-btn-remove {
+          background: none;
+          border: none;
+          cursor: pointer;
+          color: var(--text-secondary);
+          font-size: 13px;
+          padding: 2px 4px;
+          line-height: 1;
+        }
+
+        .pcol-btn-up:hover,
+        .pcol-btn-down:hover { color: var(--primary-blue); }
+        .pcol-btn-remove:hover { color: #d93025; }
+        .pcol-btn-up:disabled,
+        .pcol-btn-down:disabled { opacity: 0.25; cursor: default; }
+
+        .pcol-add-btn {
+          width: 100%;
+          margin-top: 4px;
+          background: none;
+          border: 1px solid var(--border-color);
+          border-radius: 4px;
+          color: var(--text-secondary);
+          font-size: 12px;
+          padding: 5px 8px;
+          cursor: pointer;
+          font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+          box-sizing: border-box;
+        }
+
+        .pcol-add-btn:hover { border-color: var(--primary-blue); color: var(--primary-blue); }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -2,7 +2,7 @@ import type { ToolId } from "../shared/types";
 
 // ── Loading / Progress types ─────────────────────────────────────────────────
 
-export type LoadingStatus = "idle" | "loading" | "progress" | "complete" | "error";
+export type LoadingStatus = "idle" | "loading" | "progress" | "cancelling" | "complete" | "error";
 
 export interface LoadingState {
   status: LoadingStatus;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,3 +1,5 @@
+import type { ToolId } from "../shared/types";
+
 // ── Loading / Progress types ─────────────────────────────────────────────────
 
 export type LoadingStatus = "idle" | "loading" | "progress" | "complete" | "error";
@@ -26,22 +28,46 @@ export interface RecipeFieldConfig {
   placeholder?: string;
 }
 
+export type ColStrategyKind = "list-drive-folder" | "fill-value" | "create-empty";
+export type ColRole = "userPrompt" | "systemPrompt" | "driveLink" | "output";
+
+export interface AppendField {
+  id: string;
+  label: string;
+  placeholder?: string;
+  /** Text injected before the reporter's value, e.g. "\n\nYou are looking for:\n\n" */
+  prefix?: string;
+}
+
+export interface RecipeSettings {
+  tools?: ToolId[];
+  applyMarkdown?: boolean;
+  includeGrounding?: boolean;
+}
+
+export interface ColumnDef {
+  /** UI section heading shown in the recipe panel */
+  label: string;
+  /** How this column maps into RunConfig after prep */
+  role: ColRole;
+  /** What PrepColSpec.strategy type to generate during prep */
+  strategyKind: ColStrategyKind;
+  /** Lockable column header field */
+  colTitle: RecipeFieldConfig;
+  /** Lockable prompt text — present for fill-value columns */
+  prompt?: RecipeFieldConfig;
+  /** Lockable URL input — present for drive columns */
+  url?: RecipeFieldConfig;
+  /** Extra reporter inputs composed into the prompt before prep */
+  appendFields?: AppendField[];
+  helperText?: string;
+  /** Show * in section heading */
+  required?: boolean;
+}
+
 export interface RecipeParams {
-  driveFolder?: {
-    colTitle: string;
-    helperText?: string;
-  };
-  systemPrompt?: {
-    colTitle: RecipeFieldConfig;
-    prompt: RecipeFieldConfig;
-  };
-  userPrompts?: Array<{
-    colTitle: RecipeFieldConfig;
-    prompt: RecipeFieldConfig;
-  }>;
-  outputCol?: {
-    colTitle: RecipeFieldConfig;
-  };
+  columns: ColumnDef[];
+  settings?: RecipeSettings;
 }
 
 /**

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -397,70 +397,50 @@ export function runTool(functionName: string, jobId?: string): void {
 
 export function prepRecipe(params: PrepRecipeParams): PrepRecipeResult {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
-  const colNames: PrepRecipeResult["colNames"] = {};
   let numRows = 1;
 
-  if (params.driveFolder) {
-    const folderId = extractId(params.driveFolder.url);
-    const folder = DriveApp.getFolderById(folderId);
-    const files: { url: string }[] = [];
-    getAllFilesRecursive(folder, files);
-    numRows = files.length || 1;
-    const col = findOrCreateColumn(
-      sheet,
-      params.driveFolder.colTitle,
-      SpreadsheetApp.WrapStrategy.CLIP,
-    );
-    writeColumn(
-      sheet,
-      col,
-      files.map((f) => f.url),
-      SpreadsheetApp.WrapStrategy.CLIP,
-    );
-    colNames.driveLink = params.driveFolder.colTitle;
-  }
-
-  if (params.systemPrompt) {
-    const col = findOrCreateColumn(
-      sheet,
-      params.systemPrompt.colTitle,
-      SpreadsheetApp.WrapStrategy.CLIP,
-    );
-    writeColumn(
-      sheet,
-      col,
-      Array(numRows).fill(params.systemPrompt.value) as string[],
-      SpreadsheetApp.WrapStrategy.CLIP,
-    );
-    colNames.systemPrompt = params.systemPrompt.colTitle;
-  }
-
-  if (params.userPrompts) {
-    colNames.userPrompts = [];
-    for (const up of params.userPrompts) {
-      const col = findOrCreateColumn(sheet, up.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
-      writeColumn(
-        sheet,
-        col,
-        Array(numRows).fill(up.value) as string[],
-        SpreadsheetApp.WrapStrategy.CLIP,
-      );
-      colNames.userPrompts.push(up.colTitle);
+  // Pass 1: scan Drive folders, cache results, determine numRows
+  const folderCache = new Map<string, string[]>();
+  for (const col of params.cols) {
+    if (col.strategy.kind === "list-drive-folder") {
+      const url = col.strategy.url;
+      if (!folderCache.has(url)) {
+        const folder = DriveApp.getFolderById(extractId(url));
+        const files: { url: string }[] = [];
+        getAllFilesRecursive(folder, files);
+        folderCache.set(
+          url,
+          files.map((f) => f.url),
+        );
+      }
+      numRows = Math.max(numRows, folderCache.get(url)!.length || 1);
     }
   }
 
-  if (params.outputCol) {
-    findOrCreateColumn(sheet, params.outputCol.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
-    colNames.outputCol = params.outputCol.colTitle;
+  // Pass 2: write all columns
+  for (const col of params.cols) {
+    const colIdx = findOrCreateColumn(sheet, col.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
+    switch (col.strategy.kind) {
+      case "list-drive-folder": {
+        const urls = folderCache.get(col.strategy.url) ?? [];
+        writeColumn(sheet, colIdx, urls, SpreadsheetApp.WrapStrategy.CLIP);
+        break;
+      }
+      case "fill-value":
+        writeColumn(
+          sheet,
+          colIdx,
+          Array(numRows).fill(col.strategy.value) as string[],
+          SpreadsheetApp.WrapStrategy.CLIP,
+        );
+        break;
+      case "create-empty":
+        break;
+    }
   }
 
   SpreadsheetApp.flush();
-
-  return {
-    rowRange: { start: 2, end: 2 + numRows - 1 },
-    colNames,
-    tools: params.tools,
-  };
+  return { rowRange: { start: 2, end: 2 + numRows - 1 } };
 }
 
 // ==========================================

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -21,8 +21,7 @@ export type ToolId = "google_search" | "url_context" | "code_execution";
 
 /**
  * A reference to a spreadsheet column together with its prompt kind.
- * Crosses the RPC boundary in RunConfig.promptCols (Phase 2) and is
- * echoed through PrepRecipeResult so the client never needs to infer kinds.
+ * Crosses the RPC boundary in RunConfig.promptCols.
  */
 export interface PromptColumnSpec {
   col: string;
@@ -45,37 +44,30 @@ export interface RunConfig {
    * column. When false (default), result.text is written directly via setValue.
    * The grounding column is unaffected by this setting.
    *
-   * Future: recipes could pre-set this via PrepRecipeParams/PrepRecipeResult —
-   * follow the tools echo pattern if needed.
+   * Recipes pre-set this via RecipeSettings (client-only) — it flows into RunConfig
+   * through buildRunConfig() without any server echo.
    */
   applyMarkdown?: boolean;
 }
 
 // ── Recipes ─────────────────────────────────────────────────────
 
+export type ColStrategy =
+  | { kind: "list-drive-folder"; url: string }
+  | { kind: "fill-value"; value: string }
+  | { kind: "create-empty" };
+
+export interface PrepColSpec {
+  colTitle: string;
+  strategy: ColStrategy;
+}
+
 export interface PrepRecipeParams {
-  driveFolder?: { url: string; colTitle: string };
-  systemPrompt?: { colTitle: string; value: string };
-  userPrompts?: Array<{ colTitle: string; value: string }>;
-  outputCol?: { colTitle: string };
-  /**
-   * Tool IDs to pass through to PrepRecipeResult.
-   * The server does not process these during prep — they are echoed back
-   * to preserve the single-source-of-truth invariant for preppedRunConfig.
-   */
-  tools?: ToolId[];
+  cols: PrepColSpec[];
 }
 
 export interface PrepRecipeResult {
   rowRange: { start: number; end: number };
-  colNames: {
-    driveLink?: string;
-    systemPrompt?: string;
-    userPrompts?: string[];
-    outputCol?: string;
-  };
-  /** Echoed from PrepRecipeParams — no server-side processing. */
-  tools?: ToolId[];
 }
 
 // ── Import Drive Links ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Reordered panel sections to follow AI inference narrative: System Prompt → User Prompt → Output → Rows → Tools
- Added plain-English helper text beneath each section label explaining its role in the request
- Condensed PromptColList rows from two stacked lines to a single inline flex row
- Added collapsible Tools section with summary text and expand/collapse toggle; state persists across navigation

## Test Plan
- [ ] All 419 tests pass
- [ ] Panel section order matches design: System Prompt first, Tools collapsed by default
- [ ] Helper text appears below each label in light gray
- [ ] Prompt column rows render on a single line with column picker, kind pills, and controls inline
- [ ] Tools toggle expands/collapses; summary shows selected tool names or No tools selected
- [ ] Tools expand state survives Back + re-enter navigation
