### PR TITLE
feat: recipe architecture redesign — UserInput + prepTemplate + runTemplate

### DIFF
--- a/__tests__/panels/recipe.test.ts
+++ b/__tests__/panels/recipe.test.ts
@@ -33,14 +33,14 @@ const baseDefinition: RecipeDefinition = {
     {
       colTitle: "Drive Link",
       fillStrategy: { kind: "list-drive-folder", inputId: "folder" },
-      role: { kind: "file-prompt" },
+      role: "file-prompt",
     },
     {
       colTitle: "User Prompt",
       fillStrategy: { kind: "template", template: "Summarize. Focus on: {{question}}" },
-      role: { kind: "text-prompt" },
+      role: "text-prompt",
     },
-    { colTitle: "Output", fillStrategy: { kind: "create-empty" }, role: { kind: "output" } },
+    { colTitle: "Output", fillStrategy: { kind: "create-empty" }, role: "output" },
   ],
   settings: { tools: ["google_search"] },
 };

--- a/__tests__/panels/recipe.test.ts
+++ b/__tests__/panels/recipe.test.ts
@@ -7,8 +7,8 @@ jest.mock("../../src/client/services", () => ({
 
 import { RecipePanel } from "../../src/client/panels/recipe";
 import * as services from "../../src/client/services";
-import type { PrepRecipeResult } from "../../src/shared/types";
-import type { ColumnDef, RecipeDefinition, RecipeParams, NavigationContext } from "../../src/client/types";
+import type { PrepRecipeResult, RunConfig } from "../../src/shared/types";
+import type { RecipeDefinition, NavigationContext } from "../../src/client/types";
 
 const mockPrepRecipe = services.prepRecipe as jest.Mock;
 
@@ -20,18 +20,36 @@ function makeNav(): jest.Mocked<NavigationContext> {
   };
 }
 
-function mount(params: RecipeParams, savedState?: unknown) {
+const baseDefinition: RecipeDefinition = {
+  id: "test-recipe",
+  name: "Test Recipe",
+  icon: "🧪",
+  description: "A test recipe",
+  inputs: [
+    { id: "folder", label: "Drive Folder", required: true, placeholder: "Paste folder URL" },
+    { id: "question", label: "What are you looking for?" },
+  ],
+  prepTemplate: [
+    { colTitle: "Drive Link",  strategy: { kind: "list-drive-folder", inputId: "folder" } },
+    { colTitle: "User Prompt", strategy: { kind: "template", template: "Summarize. Focus on: {{question}}" } },
+    { colTitle: "Output",      strategy: { kind: "create-empty" } },
+  ],
+  runTemplate: {
+    promptCols: [
+      { col: "Drive Link",  kind: "file" },
+      { col: "User Prompt", kind: "text" },
+    ],
+    outputCol: "Output",
+    tools: ["google_search"],
+  },
+};
+
+const mockResult: PrepRecipeResult = { rowRange: { start: 2, end: 11 } };
+
+function mount(definition = baseDefinition, savedState?: unknown) {
   const container = document.createElement("div");
   const nav = makeNav();
   const panel = new RecipePanel();
-  const definition: RecipeDefinition = {
-    id: "test",
-    name: "Test Recipe",
-    icon: "🧪",
-    description: "Test",
-    panelId: "recipe",
-    params,
-  };
   panel.mount(container, nav, definition, savedState as never);
   return { container, nav, panel };
 }
@@ -41,94 +59,32 @@ async function flush() {
   await Promise.resolve();
 }
 
-// helper: a minimal column set covering all roles
-const fullColumns: ColumnDef[] = [
-  {
-    label: "Drive Folder",
-    role: "driveLink",
-    strategyKind: "list-drive-folder",
-    colTitle: { value: "Drive Link", locked: true },
-    url: { value: "", locked: false, placeholder: "Paste folder URL" },
-    required: true,
-  },
-  {
-    label: "System Prompt",
-    role: "systemPrompt",
-    strategyKind: "fill-value",
-    colTitle: { value: "System Prompt", locked: true },
-    prompt: { value: "You are helpful.", locked: true },
-  },
-  {
-    label: "User Prompt",
-    role: "userPrompt",
-    strategyKind: "fill-value",
-    colTitle: { value: "User Prompt", locked: true },
-    prompt: { value: "Summarize.", locked: true },
-  },
-  {
-    label: "Output Column",
-    role: "output",
-    strategyKind: "create-empty",
-    colTitle: { value: "AI_Out", locked: true },
-  },
-];
-
-const mockResult: PrepRecipeResult = {
-  rowRange: { start: 2, end: 11 },
-};
-
-// ── rendering ───────────────────────────────────────────────────
+// ── rendering ──────────────────────────────────────────────────
 
 describe("rendering", () => {
-  it("renders a url input for list-drive-folder columns", () => {
-    const { container } = mount({ columns: [fullColumns[0]] });
-    expect(container.querySelector("#col-0-url-input")).not.toBeNull();
+  it("renders one input field per UserInput", () => {
+    const { container } = mount();
+    expect(container.querySelectorAll(".recipe-input-field")).toHaveLength(2);
   });
 
-  it("does not render url input for fill-value columns", () => {
-    const { container } = mount({ columns: [fullColumns[2]] });
-    expect(container.querySelector("#col-0-url-input")).toBeNull();
+  it("renders the label for each input", () => {
+    const { container } = mount();
+    const labels = Array.from(container.querySelectorAll(".recipe-input-label")).map(
+      (el) => el.textContent,
+    );
+    expect(labels).toContain("Drive Folder");
+    expect(labels).toContain("What are you looking for?");
   });
 
-  it("renders a prompt container for fill-value columns", () => {
-    const { container } = mount({ columns: [fullColumns[1]] });
-    expect(container.querySelector("#col-0-prompt-container")).not.toBeNull();
+  it("renders placeholder on the input element", () => {
+    const { container } = mount();
+    const input = container.querySelector<HTMLInputElement>('[data-input-id="folder"]')!;
+    expect(input.placeholder).toBe("Paste folder URL");
   });
 
-  it("does not render prompt container for create-empty columns", () => {
-    const { container } = mount({ columns: [fullColumns[3]] });
-    expect(container.querySelector("#col-0-prompt-container")).toBeNull();
-  });
-
-  it("renders one section per ColumnDef", () => {
-    const { container } = mount({ columns: fullColumns });
-    expect(container.querySelectorAll(".recipe-section-card")).toHaveLength(fullColumns.length);
-  });
-
-  it("renders append field inputs when appendFields present", () => {
-    const colWithAppend: ColumnDef = {
-      ...fullColumns[2],
-      appendFields: [{ id: "search", label: "What are you looking for?" }],
-    };
-    const { container } = mount({ columns: [colWithAppend] });
-    expect(container.querySelector("#col-0-append-search")).not.toBeNull();
-  });
-});
-
-// ── LockableField defaults ────────────────────────────────────────
-
-describe("LockableField defaults", () => {
-  it("initialises locked colTitle field as disabled", () => {
-    const { container } = mount({ columns: [fullColumns[3]] });
-    const input = container.querySelector<HTMLInputElement>("#col-0-title-container input")!;
-    expect(input.value).toBe("AI_Out");
-    expect(input.disabled).toBe(true);
-  });
-
-  it("initialises unlocked url field as enabled", () => {
-    const { container } = mount({ columns: [fullColumns[0]] });
-    const input = container.querySelector<HTMLInputElement>("#col-0-url-input")!;
-    expect(input.disabled).toBe(false);
+  it("does not render column section cards", () => {
+    const { container } = mount();
+    expect(container.querySelector(".recipe-section-card")).toBeNull();
   });
 });
 
@@ -137,62 +93,26 @@ describe("LockableField defaults", () => {
 describe("Prep flow", () => {
   beforeEach(() => mockPrepRecipe.mockClear());
 
-  it("calls services.prepRecipe with PrepColSpec[] built from resolved field values", async () => {
+  it("calls prepRecipe with prepTemplate and collected inputValues", async () => {
     mockPrepRecipe.mockResolvedValue(mockResult);
-    const { container } = mount({ columns: fullColumns });
-    container.querySelector<HTMLInputElement>("#col-0-url-input")!.value =
-      "https://drive.google.com/drive/folders/abc123";
+    const { container } = mount();
+    container.querySelector<HTMLInputElement>('[data-input-id="folder"]')!.value =
+      "https://drive.google.com/drive/folders/abc";
+    container.querySelector<HTMLInputElement>('[data-input-id="question"]')!.value =
+      "fraud patterns";
     container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
     await flush();
     expect(mockPrepRecipe).toHaveBeenCalledWith({
-      cols: [
-        { colTitle: "Drive Link", strategy: { kind: "list-drive-folder", url: "https://drive.google.com/drive/folders/abc123" } },
-        { colTitle: "System Prompt", strategy: { kind: "fill-value", value: "You are helpful." } },
-        { colTitle: "User Prompt", strategy: { kind: "fill-value", value: "Summarize." } },
-        { colTitle: "AI_Out", strategy: { kind: "create-empty" } },
-      ],
+      cols: baseDefinition.prepTemplate,
+      inputValues: { folder: "https://drive.google.com/drive/folders/abc", question: "fraud patterns" },
     });
   });
 
-  it("composes appendFields into the fill-value prompt string", async () => {
-    mockPrepRecipe.mockResolvedValue(mockResult);
-    const colWithAppend: ColumnDef = {
-      ...fullColumns[2],
-      appendFields: [{ id: "search", label: "What?", prefix: "\n\nLooking for:\n\n" }],
-    };
-    const { container } = mount({ columns: [colWithAppend] });
-    container.querySelector<HTMLInputElement>("#col-0-append-search")!.value = "a signature";
-    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
-    await flush();
-    expect(mockPrepRecipe).toHaveBeenCalledWith({
-      cols: [
-        {
-          colTitle: "User Prompt",
-          strategy: { kind: "fill-value", value: "Summarize.\n\nLooking for:\n\na signature" },
-        },
-      ],
-    });
-  });
-
-  it("does not append prefix when appendField input is empty", async () => {
-    mockPrepRecipe.mockResolvedValue(mockResult);
-    const colWithAppend: ColumnDef = {
-      ...fullColumns[2],
-      appendFields: [{ id: "search", label: "What?", prefix: "\n\nLooking for:\n\n" }],
-    };
-    const { container } = mount({ columns: [colWithAppend] });
-    // leave #col-0-append-search empty
-    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
-    await flush();
-    expect(mockPrepRecipe).toHaveBeenCalledWith({
-      cols: [{ colTitle: "User Prompt", strategy: { kind: "fill-value", value: "Summarize." } }],
-    });
-  });
-
-  it("shows alert and does not call prepRecipe when url input is empty for list-drive-folder", async () => {
+  it("shows alert and does not call prepRecipe when required input is empty", async () => {
     const alertMock = jest.fn();
     globalThis.alert = alertMock;
-    const { container } = mount({ columns: [fullColumns[0]] });
+    const { container } = mount();
+    // leave 'folder' empty
     container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
     await flush();
     expect(alertMock).toHaveBeenCalledTimes(1);
@@ -200,73 +120,55 @@ describe("Prep flow", () => {
   });
 });
 
-// ── Cook flow ──────────────────────────────────────────────────
+// ── cook flow ──────────────────────────────────────────────────
 
 describe("Cook flow", () => {
-  it("navigates to configure-ai-run with RunConfig assembled from ColumnDef roles + rowRange", async () => {
+  it("navigates to configure-ai-run with runTemplate merged with rowRange", async () => {
     mockPrepRecipe.mockResolvedValue({ rowRange: { start: 2, end: 5 } });
-    const { container, nav } = mount({ columns: fullColumns });
-    container.querySelector<HTMLInputElement>("#col-0-url-input")!.value =
-      "https://drive.google.com/abc";
+    const { container, nav } = mount();
+    container.querySelector<HTMLInputElement>('[data-input-id="folder"]')!.value =
+      "https://drive.google.com/drive/folders/abc";
     container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
     await flush();
     container.querySelector<HTMLButtonElement>("#cook-btn")!.click();
     expect(nav.navigate).toHaveBeenCalledWith("configure-ai-run", {
-      promptCols: [
-        { col: "Drive Link", kind: "file" },
-        { col: "User Prompt", kind: "text" },
-      ],
-      systemPromptCol: "System Prompt",
-      outputCol: "AI_Out",
+      ...baseDefinition.runTemplate,
       rowRange: { start: 2, end: 5 },
     });
-  });
-
-  it("spreads RecipeSettings into RunConfig", async () => {
-    mockPrepRecipe.mockResolvedValue({ rowRange: { start: 2, end: 3 } });
-    const outputOnly: ColumnDef = fullColumns[3];
-    const { container, nav } = mount({
-      columns: [outputOnly],
-      settings: { tools: ["google_search"], applyMarkdown: true },
-    });
-    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
-    await flush();
-    container.querySelector<HTMLButtonElement>("#cook-btn")!.click();
-    expect(nav.navigate).toHaveBeenCalledWith("configure-ai-run",
-      expect.objectContaining({ tools: ["google_search"], applyMarkdown: true }),
-    );
   });
 });
 
 // ── saved state ────────────────────────────────────────────────
 
 describe("unmount / saved state", () => {
-  it("unmount returns colValues array and prepComplete: false when not prepped", () => {
-    const { container, panel } = mount({ columns: [fullColumns[0]] });
-    container.querySelector<HTMLInputElement>("#col-0-url-input")!.value = "my-folder-url";
+  it("unmount returns inputValues and prepComplete: false when not prepped", () => {
+    const { container, panel } = mount();
+    container.querySelector<HTMLInputElement>('[data-input-id="folder"]')!.value = "my-url";
     const state = panel.unmount();
     expect(state).toMatchObject({
-      colValues: [expect.objectContaining({ url: "my-folder-url" })],
+      inputValues: { folder: "my-url", question: "" },
       prepComplete: false,
     });
   });
 
-  it("restores url value from savedState", () => {
+  it("restores input values from savedState", () => {
     const savedState = {
-      colValues: [{ url: "restored-url" }],
+      inputValues: { folder: "restored-url", question: "restored-question" },
       prepComplete: false,
     };
-    const { container } = mount({ columns: [fullColumns[0]] }, savedState);
-    expect(container.querySelector<HTMLInputElement>("#col-0-url-input")!.value).toBe("restored-url");
+    const { container } = mount(baseDefinition, savedState);
+    expect(
+      container.querySelector<HTMLInputElement>('[data-input-id="folder"]')!.value,
+    ).toBe("restored-url");
   });
 
   it("mounts with savedState prepComplete: true — Cook is enabled", () => {
     const savedState = {
-      colValues: [{}],
+      inputValues: {},
       prepComplete: true,
-      preppedRunConfig: { outputCol: "Out", promptCols: [] },
+      preppedRunConfig: { outputCol: "Output", promptCols: [] } as Partial<RunConfig>,
     };
-    const { container } = mount({ columns: [fullColumns[3]] }, savedState);
+    const { container } = mount(baseDefinition, savedState);
     expect(container.querySelector<HTMLButtonElement>("#cook-btn")!.disabled).toBe(false);
   });
 });

--- a/__tests__/panels/recipe.test.ts
+++ b/__tests__/panels/recipe.test.ts
@@ -7,7 +7,7 @@ jest.mock("../../src/client/services", () => ({
 
 import { RecipePanel } from "../../src/client/panels/recipe";
 import * as services from "../../src/client/services";
-import type { PrepRecipeResult, RunConfig } from "../../src/shared/types";
+import type { PrepRecipeResult } from "../../src/shared/types";
 import type { RecipeDefinition, NavigationContext } from "../../src/client/types";
 
 const mockPrepRecipe = services.prepRecipe as jest.Mock;
@@ -30,21 +30,19 @@ const baseDefinition: RecipeDefinition = {
     { id: "question", label: "What are you looking for?" },
   ],
   prepTemplate: [
-    { colTitle: "Drive Link", fillStrategy: { kind: "list-drive-folder", inputId: "folder" } },
+    {
+      colTitle: "Drive Link",
+      fillStrategy: { kind: "list-drive-folder", inputId: "folder" },
+      role: { kind: "file-prompt" },
+    },
     {
       colTitle: "User Prompt",
       fillStrategy: { kind: "template", template: "Summarize. Focus on: {{question}}" },
+      role: { kind: "text-prompt" },
     },
-    { colTitle: "Output", fillStrategy: { kind: "create-empty" } },
+    { colTitle: "Output", fillStrategy: { kind: "create-empty" }, role: { kind: "output" } },
   ],
-  runTemplate: {
-    promptCols: [
-      { col: "Drive Link", kind: "file" },
-      { col: "User Prompt", kind: "text" },
-    ],
-    outputCol: "Output",
-    tools: ["google_search"],
-  },
+  settings: { tools: ["google_search"] },
 };
 
 const mockResult: PrepRecipeResult = { rowRange: { start: 2, end: 11 } };
@@ -129,7 +127,7 @@ describe("Prep flow", () => {
 // ── cook flow ──────────────────────────────────────────────────
 
 describe("Cook flow", () => {
-  it("navigates to configure-ai-run with runTemplate merged with rowRange", async () => {
+  it("navigates to configure-ai-run with RunConfig derived from roles + settings + rowRange", async () => {
     mockPrepRecipe.mockResolvedValue({ rowRange: { start: 2, end: 5 } });
     const { container, nav } = mount();
     container.querySelector<HTMLInputElement>('[data-input-id="folder"]')!.value =
@@ -138,7 +136,13 @@ describe("Cook flow", () => {
     await flush();
     container.querySelector<HTMLButtonElement>("#cook-btn")!.click();
     expect(nav.navigate).toHaveBeenCalledWith("configure-ai-run", {
-      ...baseDefinition.runTemplate,
+      promptCols: [
+        { col: "Drive Link", kind: "file" },
+        { col: "User Prompt", kind: "text" },
+      ],
+      systemPromptCol: undefined,
+      outputCol: "Output",
+      tools: ["google_search"],
       rowRange: { start: 2, end: 5 },
     });
   });
@@ -172,7 +176,7 @@ describe("unmount / saved state", () => {
     const savedState = {
       inputValues: {},
       prepComplete: true,
-      preppedRunConfig: { outputCol: "Output", promptCols: [] } as Partial<RunConfig>,
+      preppedRunConfig: { outputCol: "Output", promptCols: [] },
     };
     const { container } = mount(baseDefinition, savedState);
     expect(container.querySelector<HTMLButtonElement>("#cook-btn")!.disabled).toBe(false);

--- a/__tests__/panels/recipe.test.ts
+++ b/__tests__/panels/recipe.test.ts
@@ -63,7 +63,7 @@ async function flush() {
 // ── rendering ──────────────────────────────────────────────────
 
 describe("rendering", () => {
-  it("renders one input field per UserInput", () => {
+  it("renders one input field per RecipeInput", () => {
     const { container } = mount();
     expect(container.querySelectorAll(".recipe-input-field")).toHaveLength(2);
   });

--- a/__tests__/panels/recipe.test.ts
+++ b/__tests__/panels/recipe.test.ts
@@ -30,13 +30,16 @@ const baseDefinition: RecipeDefinition = {
     { id: "question", label: "What are you looking for?" },
   ],
   prepTemplate: [
-    { colTitle: "Drive Link",  strategy: { kind: "list-drive-folder", inputId: "folder" } },
-    { colTitle: "User Prompt", strategy: { kind: "template", template: "Summarize. Focus on: {{question}}" } },
-    { colTitle: "Output",      strategy: { kind: "create-empty" } },
+    { colTitle: "Drive Link", fillStrategy: { kind: "list-drive-folder", inputId: "folder" } },
+    {
+      colTitle: "User Prompt",
+      fillStrategy: { kind: "template", template: "Summarize. Focus on: {{question}}" },
+    },
+    { colTitle: "Output", fillStrategy: { kind: "create-empty" } },
   ],
   runTemplate: {
     promptCols: [
-      { col: "Drive Link",  kind: "file" },
+      { col: "Drive Link", kind: "file" },
       { col: "User Prompt", kind: "text" },
     ],
     outputCol: "Output",
@@ -104,7 +107,10 @@ describe("Prep flow", () => {
     await flush();
     expect(mockPrepRecipe).toHaveBeenCalledWith({
       cols: baseDefinition.prepTemplate,
-      inputValues: { folder: "https://drive.google.com/drive/folders/abc", question: "fraud patterns" },
+      inputValues: {
+        folder: "https://drive.google.com/drive/folders/abc",
+        question: "fraud patterns",
+      },
     });
   });
 
@@ -157,9 +163,9 @@ describe("unmount / saved state", () => {
       prepComplete: false,
     };
     const { container } = mount(baseDefinition, savedState);
-    expect(
-      container.querySelector<HTMLInputElement>('[data-input-id="folder"]')!.value,
-    ).toBe("restored-url");
+    expect(container.querySelector<HTMLInputElement>('[data-input-id="folder"]')!.value).toBe(
+      "restored-url",
+    );
   });
 
   it("mounts with savedState prepComplete: true — Cook is enabled", () => {

--- a/__tests__/services.test.ts
+++ b/__tests__/services.test.ts
@@ -108,9 +108,10 @@ describe("prepRecipe", () => {
     const handlers = captureHandlers();
     const params: import("../src/shared/types").PrepRecipeParams = {
       cols: [
-        { colTitle: "Drive Link", strategy: { kind: "list-drive-folder", url: "https://drive.google.com/folder/abc" } },
+        { colTitle: "Drive Link", strategy: { kind: "list-drive-folder", inputId: "folder" } },
         { colTitle: "AI_Summarization", strategy: { kind: "create-empty" } },
       ],
+      inputValues: { folder: "https://drive.google.com/drive/folders/abc123" },
     };
     const result: import("../src/shared/types").PrepRecipeResult = {
       rowRange: { start: 2, end: 5 },
@@ -123,7 +124,7 @@ describe("prepRecipe", () => {
 
   it("rejects on failure", async () => {
     const handlers = captureHandlers();
-    const promise = services.prepRecipe({ cols: [] });
+    const promise = services.prepRecipe({ cols: [], inputValues: {} });
     handlers.reject(new Error("prep error"));
     await expect(promise).rejects.toThrow("prep error");
   });

--- a/__tests__/services.test.ts
+++ b/__tests__/services.test.ts
@@ -108,8 +108,8 @@ describe("prepRecipe", () => {
     const handlers = captureHandlers();
     const params: import("../src/shared/types").PrepRecipeParams = {
       cols: [
-        { colTitle: "Drive Link", strategy: { kind: "list-drive-folder", inputId: "folder" } },
-        { colTitle: "AI_Summarization", strategy: { kind: "create-empty" } },
+        { colTitle: "Drive Link", fillStrategy: { kind: "list-drive-folder", inputId: "folder" } },
+        { colTitle: "AI_Summarization", fillStrategy: { kind: "create-empty" } },
       ],
       inputValues: { folder: "https://drive.google.com/drive/folders/abc123" },
     };

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -18,6 +18,7 @@ import {
   findOrCreateColumn,
   writeColumn,
   writeJobProgress,
+  interpolateTemplate,
 } from "../src/server/utils";
 import type { DriveFileInfo } from "../src/server/types";
 
@@ -427,5 +428,29 @@ describe("writeColumn", () => {
     const wrapStrategy = "CLIP" as unknown as GoogleAppsScript.Spreadsheet.WrapStrategy;
     writeColumn(sheet, 3, ["a", "b"], wrapStrategy);
     expect(setWrapStrategyMock).toHaveBeenCalledWith(wrapStrategy);
+  });
+});
+
+describe("interpolateTemplate", () => {
+  it("replaces a single {{inputId}} with the corresponding value", () => {
+    expect(interpolateTemplate("Hello {{name}}", { name: "world" })).toBe("Hello world");
+  });
+
+  it("replaces multiple placeholders in one string", () => {
+    expect(
+      interpolateTemplate("{{a}} and {{b}}", { a: "foo", b: "bar" }),
+    ).toBe("foo and bar");
+  });
+
+  it("replaces the same placeholder multiple times", () => {
+    expect(interpolateTemplate("{{x}} {{x}}", { x: "hi" })).toBe("hi hi");
+  });
+
+  it("leaves unknown placeholders as empty string", () => {
+    expect(interpolateTemplate("{{missing}}", {})).toBe("");
+  });
+
+  it("returns the string unchanged when no placeholders present", () => {
+    expect(interpolateTemplate("no placeholders", { x: "y" })).toBe("no placeholders");
   });
 });

--- a/docs/plans/2026-04-14-recipe-architecture-redesign-impl.md
+++ b/docs/plans/2026-04-14-recipe-architecture-redesign-impl.md
@@ -1,0 +1,817 @@
+# Recipe Architecture Redesign Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the tri-purpose `ColumnDef` model with three focused structures — `UserInput[]` (journalist form), `prepTemplate: PrepColSpec[]` (spreadsheet prep), and `runTemplate: Partial<RunConfig>` (AI run config).
+
+**Architecture:** `RecipeDefinition` is split into independent sections: `inputs` drives `RecipePanel` rendering, `prepTemplate` drives `prepRecipe()` on the server, and `runTemplate` is passed directly to `ConfigureAIRunPanel` as presets after cook. Inputs bind to columns via `inputId` references in fill strategies. Template interpolation (`{{inputId}}`) is extracted to a pure `interpolateTemplate()` helper in `utils.ts` for testability.
+
+**Tech Stack:** TypeScript, Jest/ts-jest, Google Apps Script (server), vanilla DOM (client panel).
+
+**Worktree:** `.worktrees/recipe-architecture-redesign` on branch `feature/recipe-architecture-redesign`
+
+---
+
+### Task 1: Add `interpolateTemplate` to `utils.ts`
+
+This is the only genuinely new logic. Extract it first so it's testable in isolation before we wire it into `prepRecipe`.
+
+**Files:**
+- Modify: `src/server/utils.ts`
+- Modify: `__tests__/utils.test.ts`
+
+**Step 1: Write the failing tests**
+
+Add to the bottom of `__tests__/utils.test.ts`:
+
+```ts
+import { interpolateTemplate } from "../src/server/utils";
+
+describe("interpolateTemplate", () => {
+  it("replaces a single {{inputId}} with the corresponding value", () => {
+    expect(interpolateTemplate("Hello {{name}}", { name: "world" })).toBe("Hello world");
+  });
+
+  it("replaces multiple placeholders in one string", () => {
+    expect(
+      interpolateTemplate("{{a}} and {{b}}", { a: "foo", b: "bar" }),
+    ).toBe("foo and bar");
+  });
+
+  it("replaces the same placeholder multiple times", () => {
+    expect(interpolateTemplate("{{x}} {{x}}", { x: "hi" })).toBe("hi hi");
+  });
+
+  it("leaves unknown placeholders as empty string", () => {
+    expect(interpolateTemplate("{{missing}}", {})).toBe("");
+  });
+
+  it("returns the string unchanged when no placeholders present", () => {
+    expect(interpolateTemplate("no placeholders", { x: "y" })).toBe("no placeholders");
+  });
+});
+```
+
+**Step 2: Run to confirm failure**
+
+```bash
+npx jest __tests__/utils.test.ts -t "interpolateTemplate"
+```
+
+Expected: FAIL — `interpolateTemplate` is not exported.
+
+**Step 3: Implement in `src/server/utils.ts`**
+
+Add at the bottom of the file (before any closing braces):
+
+```ts
+export function interpolateTemplate(template: string, inputValues: Record<string, string>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, id: string) => inputValues[id] ?? "");
+}
+```
+
+**Step 4: Run to confirm passing**
+
+```bash
+npx jest __tests__/utils.test.ts -t "interpolateTemplate"
+```
+
+Expected: 5 tests passing.
+
+**Step 5: Run full suite to check for regressions**
+
+```bash
+npm test
+```
+
+Expected: 433 tests passing (428 + 5 new).
+
+**Step 6: Commit**
+
+```bash
+git add src/server/utils.ts __tests__/utils.test.ts
+git commit -m "feat: add interpolateTemplate utility for recipe template strategy"
+```
+
+---
+
+### Task 2: Update shared types
+
+This is the RPC boundary change. After this commit TypeScript will report errors in `server/index.ts` and `client/panels/recipe.ts` — that is expected and will be fixed in Tasks 3 and 4.
+
+**Files:**
+- Modify: `src/shared/types.ts`
+
+**Step 1: Update `ColStrategy`**
+
+Replace the existing `ColStrategy` type:
+
+```ts
+// Before
+export type ColStrategy =
+  | { kind: "list-drive-folder"; url: string }
+  | { kind: "fill-value"; value: string }
+  | { kind: "create-empty" };
+
+// After
+export type ColStrategy =
+  | { kind: "list-drive-folder"; inputId: string }
+  | { kind: "fill-value"; value: string }
+  | { kind: "template"; template: string }
+  | { kind: "create-empty" };
+```
+
+**Step 2: Update `PrepRecipeParams`**
+
+```ts
+// Before
+export interface PrepRecipeParams {
+  cols: PrepColSpec[];
+}
+
+// After
+export interface PrepRecipeParams {
+  cols: PrepColSpec[];
+  inputValues: Record<string, string>;
+}
+```
+
+**Step 3: Confirm expected typecheck errors**
+
+```bash
+npm run typecheck 2>&1 | grep "error TS"
+```
+
+Expected: errors in `src/server/index.ts` (reads `strategy.url`) and `src/client/panels/recipe.ts` (sends `{ url }` in payload). No errors elsewhere.
+
+**Step 4: Commit**
+
+```bash
+git add src/shared/types.ts
+git commit -m "feat: update ColStrategy and PrepRecipeParams for inputId-based binding"
+```
+
+---
+
+### Task 3: Update `prepRecipe()` in `server/index.ts`
+
+Fix the server-side breakage from Task 2. The key changes: resolve `inputId` from `inputValues` for `list-drive-folder`, and handle the new `template` strategy using `interpolateTemplate`.
+
+**Files:**
+- Modify: `src/server/index.ts`
+
+**Step 1: Update the function signature and `list-drive-folder` handling**
+
+In `prepRecipe`, the parameter is already `PrepRecipeParams`. Update the destructuring and Pass 1:
+
+```ts
+// Add inputValues to the destructured params:
+export function prepRecipe({ cols, inputValues }: PrepRecipeParams): PrepRecipeResult {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+  let numRows = 1;
+
+  // Pass 1: scan Drive folders, cache results, determine numRows
+  const folderCache = new Map<string, string[]>();
+  for (const col of cols) {
+    if (col.strategy.kind === "list-drive-folder") {
+      const url = inputValues[col.strategy.inputId] ?? "";  // ← resolve inputId
+      if (!folderCache.has(url)) {
+        const folder = DriveApp.getFolderById(extractId(url));
+        const files: { url: string }[] = [];
+        getAllFilesRecursive(folder, files);
+        folderCache.set(url, files.map((f) => f.url));
+      }
+      numRows = Math.max(numRows, folderCache.get(url)!.length || 1);
+    }
+  }
+```
+
+**Step 2: Update Pass 2 to handle `template` and the updated `list-drive-folder`**
+
+```ts
+  // Pass 2: write all columns
+  for (const col of cols) {
+    const colIdx = findOrCreateColumn(sheet, col.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
+    switch (col.strategy.kind) {
+      case "list-drive-folder": {
+        const url = inputValues[col.strategy.inputId] ?? "";  // ← resolve inputId
+        const urls = folderCache.get(url) ?? [];
+        writeColumn(sheet, colIdx, urls, SpreadsheetApp.WrapStrategy.CLIP);
+        break;
+      }
+      case "fill-value":
+        writeColumn(
+          sheet,
+          colIdx,
+          Array(numRows).fill(col.strategy.value) as string[],
+          SpreadsheetApp.WrapStrategy.CLIP,
+        );
+        break;
+      case "template": {                                       // ← new
+        const resolved = interpolateTemplate(col.strategy.template, inputValues);
+        writeColumn(
+          sheet,
+          colIdx,
+          Array(numRows).fill(resolved) as string[],
+          SpreadsheetApp.WrapStrategy.CLIP,
+        );
+        break;
+      }
+      case "create-empty":
+        // column created above; nothing to write
+        break;
+    }
+  }
+```
+
+Make sure `interpolateTemplate` is imported at the top of `index.ts`:
+
+```ts
+import { /* existing imports */, interpolateTemplate } from "./utils";
+```
+
+**Step 3: Confirm server typecheck passes**
+
+```bash
+tsc --noEmit 2>&1 | grep "error TS"
+```
+
+Expected: no errors in server files. Client errors may still exist (fixed in Task 4).
+
+**Step 4: Commit**
+
+```bash
+git add src/server/index.ts
+git commit -m "feat: update prepRecipe to resolve inputId refs and handle template strategy"
+```
+
+---
+
+### Task 4: Update client types and `RecipeDefinition`
+
+Replace the `ColumnDef` cluster with `UserInput` and update `RecipeDefinition` to use `inputs`, `prepTemplate`, `runTemplate`.
+
+**Files:**
+- Modify: `src/client/types.ts`
+
+**Step 1: Remove the old recipe UI types**
+
+Delete these interfaces/types entirely from `src/client/types.ts`:
+- `RecipeFieldConfig`
+- `ColStrategyKind`
+- `ColRole`
+- `AppendField`
+- `RecipeSettings`
+- `ColumnDef`
+- `RecipeParams`
+
+**Step 2: Add `UserInput` and update `RecipeDefinition`**
+
+Add after the loading/progress types block:
+
+```ts
+// ── Recipe UI types ─────────────────────────────────────────────
+// These are client-only — they define the journalist-facing form, not RPC payloads.
+
+export interface UserInput {
+  id: string;
+  label: string;
+  required?: boolean;
+  helperText?: string;
+  placeholder?: string;
+}
+
+export interface RecipeDefinition {
+  id: string;
+  name: string;
+  icon: string;
+  description: string;
+  inputs: UserInput[];
+  prepTemplate: PrepColSpec[];
+  runTemplate: Partial<RunConfig>;
+}
+```
+
+Add the necessary imports at the top of the file (if not already present):
+
+```ts
+import type { PrepColSpec, RunConfig } from "../shared/types";
+```
+
+**Step 3: Run typecheck — expect client panel errors**
+
+```bash
+tsc -p tsconfig.client.json --noEmit 2>&1 | grep "error TS"
+```
+
+Expected: errors in `src/client/panels/recipe.ts` and `src/client/recipes.ts` (reference removed types). Fixed in Tasks 5 and 6.
+
+**Step 4: Commit**
+
+```bash
+git add src/client/types.ts
+git commit -m "feat: replace ColumnDef cluster with UserInput; update RecipeDefinition"
+```
+
+---
+
+### Task 5: Rewrite `RecipePanel` and its tests
+
+This is the largest task. The panel now renders `inputs[]` only — no column cards, no lockable fields per column. `buildPrepParams` collects `inputValues` from the form and forwards `prepTemplate`. `buildRunConfig` spreads `runTemplate` + `rowRange`.
+
+**Files:**
+- Rewrite: `src/client/panels/recipe.ts`
+- Rewrite: `__tests__/panels/recipe.test.ts`
+
+**Step 1: Rewrite the tests first**
+
+Replace the entire contents of `__tests__/panels/recipe.test.ts`:
+
+```ts
+/**
+ * @jest-environment jsdom
+ */
+jest.mock("../../src/client/services", () => ({
+  prepRecipe: jest.fn(),
+}));
+
+import { RecipePanel } from "../../src/client/panels/recipe";
+import * as services from "../../src/client/services";
+import type { PrepRecipeResult, RunConfig } from "../../src/shared/types";
+import type { RecipeDefinition, NavigationContext } from "../../src/client/types";
+
+const mockPrepRecipe = services.prepRecipe as jest.Mock;
+
+function makeNav(): jest.Mocked<NavigationContext> {
+  return {
+    navigate: jest.fn(),
+    back: jest.fn(),
+    canGoBack: jest.fn().mockReturnValue(true),
+  };
+}
+
+const baseDefinition: RecipeDefinition = {
+  id: "test-recipe",
+  name: "Test Recipe",
+  icon: "🧪",
+  description: "A test recipe",
+  inputs: [
+    { id: "folder", label: "Drive Folder", required: true, placeholder: "Paste folder URL" },
+    { id: "question", label: "What are you looking for?" },
+  ],
+  prepTemplate: [
+    { colTitle: "Drive Link",  strategy: { kind: "list-drive-folder", inputId: "folder" } },
+    { colTitle: "User Prompt", strategy: { kind: "template", template: "Summarize. Focus on: {{question}}" } },
+    { colTitle: "Output",      strategy: { kind: "create-empty" } },
+  ],
+  runTemplate: {
+    promptCols: [
+      { col: "Drive Link",  kind: "file" },
+      { col: "User Prompt", kind: "text" },
+    ],
+    outputCol: "Output",
+    tools: ["google_search"],
+  },
+};
+
+const mockResult: PrepRecipeResult = { rowRange: { start: 2, end: 11 } };
+
+function mount(definition = baseDefinition, savedState?: unknown) {
+  const container = document.createElement("div");
+  const nav = makeNav();
+  const panel = new RecipePanel();
+  panel.mount(container, nav, definition, savedState as never);
+  return { container, nav, panel };
+}
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+// ── rendering ──────────────────────────────────────────────────
+
+describe("rendering", () => {
+  it("renders one input field per UserInput", () => {
+    const { container } = mount();
+    expect(container.querySelectorAll(".recipe-input-field")).toHaveLength(2);
+  });
+
+  it("renders the label for each input", () => {
+    const { container } = mount();
+    const labels = Array.from(container.querySelectorAll(".recipe-input-label")).map(
+      (el) => el.textContent,
+    );
+    expect(labels).toContain("Drive Folder");
+    expect(labels).toContain("What are you looking for?");
+  });
+
+  it("renders placeholder on the input element", () => {
+    const { container } = mount();
+    const input = container.querySelector<HTMLInputElement>('[data-input-id="folder"]')!;
+    expect(input.placeholder).toBe("Paste folder URL");
+  });
+
+  it("does not render column section cards", () => {
+    const { container } = mount();
+    expect(container.querySelector(".recipe-section-card")).toBeNull();
+  });
+});
+
+// ── prep flow ──────────────────────────────────────────────────
+
+describe("Prep flow", () => {
+  beforeEach(() => mockPrepRecipe.mockClear());
+
+  it("calls prepRecipe with prepTemplate and collected inputValues", async () => {
+    mockPrepRecipe.mockResolvedValue(mockResult);
+    const { container } = mount();
+    container.querySelector<HTMLInputElement>('[data-input-id="folder"]')!.value =
+      "https://drive.google.com/drive/folders/abc";
+    container.querySelector<HTMLInputElement>('[data-input-id="question"]')!.value =
+      "fraud patterns";
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    expect(mockPrepRecipe).toHaveBeenCalledWith({
+      cols: baseDefinition.prepTemplate,
+      inputValues: { folder: "https://drive.google.com/drive/folders/abc", question: "fraud patterns" },
+    });
+  });
+
+  it("shows alert and does not call prepRecipe when required input is empty", async () => {
+    const alertMock = jest.fn();
+    globalThis.alert = alertMock;
+    const { container } = mount();
+    // leave 'folder' empty
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    expect(alertMock).toHaveBeenCalledTimes(1);
+    expect(mockPrepRecipe).not.toHaveBeenCalled();
+  });
+});
+
+// ── cook flow ──────────────────────────────────────────────────
+
+describe("Cook flow", () => {
+  it("navigates to configure-ai-run with runTemplate merged with rowRange", async () => {
+    mockPrepRecipe.mockResolvedValue({ rowRange: { start: 2, end: 5 } });
+    const { container, nav } = mount();
+    container.querySelector<HTMLInputElement>('[data-input-id="folder"]')!.value =
+      "https://drive.google.com/drive/folders/abc";
+    container.querySelector<HTMLButtonElement>("#prep-btn")!.click();
+    await flush();
+    container.querySelector<HTMLButtonElement>("#cook-btn")!.click();
+    expect(nav.navigate).toHaveBeenCalledWith("configure-ai-run", {
+      ...baseDefinition.runTemplate,
+      rowRange: { start: 2, end: 5 },
+    });
+  });
+});
+
+// ── saved state ────────────────────────────────────────────────
+
+describe("unmount / saved state", () => {
+  it("unmount returns inputValues and prepComplete: false when not prepped", () => {
+    const { container, panel } = mount();
+    container.querySelector<HTMLInputElement>('[data-input-id="folder"]')!.value = "my-url";
+    const state = panel.unmount();
+    expect(state).toMatchObject({
+      inputValues: { folder: "my-url", question: "" },
+      prepComplete: false,
+    });
+  });
+
+  it("restores input values from savedState", () => {
+    const savedState = {
+      inputValues: { folder: "restored-url", question: "restored-question" },
+      prepComplete: false,
+    };
+    const { container } = mount(baseDefinition, savedState);
+    expect(
+      container.querySelector<HTMLInputElement>('[data-input-id="folder"]')!.value,
+    ).toBe("restored-url");
+  });
+
+  it("mounts with savedState prepComplete: true — Cook is enabled", () => {
+    const savedState = {
+      inputValues: {},
+      prepComplete: true,
+      preppedRunConfig: { outputCol: "Output", promptCols: [] } as Partial<RunConfig>,
+    };
+    const { container } = mount(baseDefinition, savedState);
+    expect(container.querySelector<HTMLButtonElement>("#cook-btn")!.disabled).toBe(false);
+  });
+});
+```
+
+**Step 2: Run tests to confirm they all fail**
+
+```bash
+npx jest __tests__/panels/recipe.test.ts
+```
+
+Expected: FAIL — tests reference new API that doesn't exist yet.
+
+**Step 3: Rewrite `src/client/panels/recipe.ts`**
+
+Replace the entire file:
+
+```ts
+import type { NavigationContext, Panel, RecipeDefinition, UserInput } from "../types";
+import type { PrepRecipeParams, PrepRecipeResult, RunConfig } from "../../shared/types";
+import { RecipePrepCook } from "../components/recipe-prep-cook";
+import { prepRecipe } from "../services";
+
+type SavedState = {
+  inputValues: Record<string, string>;
+  prepComplete: boolean;
+  preppedRunConfig?: Partial<RunConfig>;
+};
+
+export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
+  private nav: NavigationContext | null = null;
+  private definition: RecipeDefinition | null = null;
+  private prepCook: RecipePrepCook | null = null;
+  private preppedRunConfig: Partial<RunConfig> | null = null;
+
+  mount(
+    container: HTMLElement,
+    nav: NavigationContext,
+    definition?: RecipeDefinition,
+    savedState?: SavedState,
+  ): void {
+    this.nav = nav;
+    this.definition = definition ?? null;
+    this.preppedRunConfig = savedState?.preppedRunConfig ?? null;
+
+    container.innerHTML = this.template(definition);
+    container.querySelector("#back-btn")?.addEventListener("click", () => nav.back());
+
+    this.restoreInputValues(container, definition?.inputs ?? [], savedState?.inputValues ?? {});
+    this.mountPrepCook(container, savedState?.prepComplete ?? false);
+  }
+
+  unmount(): SavedState {
+    const inputs = this.definition?.inputs ?? [];
+    const inputValues: Record<string, string> = {};
+    for (const input of inputs) {
+      const el = document.querySelector<HTMLInputElement>(`[data-input-id="${input.id}"]`);
+      inputValues[input.id] = el?.value ?? "";
+    }
+    return {
+      inputValues,
+      prepComplete: this.prepCook?.isPrepComplete() ?? false,
+      preppedRunConfig: this.preppedRunConfig ?? undefined,
+    };
+  }
+
+  private restoreInputValues(
+    container: HTMLElement,
+    inputs: UserInput[],
+    savedValues: Record<string, string>,
+  ): void {
+    for (const input of inputs) {
+      const el = container.querySelector<HTMLInputElement>(`[data-input-id="${input.id}"]`);
+      if (el && savedValues[input.id]) el.value = savedValues[input.id];
+      el?.addEventListener("input", () => this.prepCook?.reset());
+    }
+  }
+
+  private mountPrepCook(container: HTMLElement, prepComplete: boolean): void {
+    this.prepCook = new RecipePrepCook(container.querySelector("#prep-cook-container")!, {
+      onPrep: async (): Promise<void> => {
+        const params = this.buildPrepParams();
+        if (!params) throw null;
+        const result = await prepRecipe(params);
+        this.preppedRunConfig = this.buildRunConfig(result);
+      },
+      onCook: (): void => {
+        if (this.preppedRunConfig) {
+          this.nav?.navigate("configure-ai-run", this.preppedRunConfig);
+        }
+      },
+      prepComplete,
+    });
+  }
+
+  private buildPrepParams(): PrepRecipeParams | null {
+    const inputs = this.definition?.inputs ?? [];
+    const inputValues: Record<string, string> = {};
+
+    for (const input of inputs) {
+      const el = document.querySelector<HTMLInputElement>(`[data-input-id="${input.id}"]`);
+      const value = el?.value.trim() ?? "";
+      if (input.required && !value) {
+        globalThis.alert(`Please fill in "${input.label}".`);
+        return null;
+      }
+      inputValues[input.id] = value;
+    }
+
+    return {
+      cols: this.definition?.prepTemplate ?? [],
+      inputValues,
+    };
+  }
+
+  private buildRunConfig(result: PrepRecipeResult): Partial<RunConfig> {
+    return {
+      ...this.definition?.runTemplate,
+      rowRange: result.rowRange,
+    };
+  }
+
+  private template(definition: RecipeDefinition | undefined | null): string {
+    const inputs = definition?.inputs ?? [];
+    const title = definition ? `${definition.icon} ${definition.name}` : "Recipe";
+
+    const inputsHtml = inputs
+      .map((input) => {
+        const requiredMark = input.required ? ` <span class="required">*</span>` : "";
+        const helperHtml = input.helperText
+          ? `<p class="field-helper">${input.helperText}</p>`
+          : "";
+        return `
+          <div class="recipe-input-field">
+            <label class="recipe-input-label">${input.label}${requiredMark}</label>
+            ${helperHtml}
+            <input
+              data-input-id="${input.id}"
+              type="text"
+              class="text-input"
+              placeholder="${input.placeholder ?? ""}"
+            />
+          </div>`;
+      })
+      .join("");
+
+    return `
+      <div class="panel-header">
+        <button id="back-btn" class="back-btn">← Back</button>
+        <span class="panel-title">${title}</span>
+      </div>
+      ${inputsHtml}
+      <div id="prep-cook-container"></div>
+    `;
+  }
+}
+```
+
+**Step 4: Run the recipe panel tests**
+
+```bash
+npx jest __tests__/panels/recipe.test.ts
+```
+
+Expected: all tests passing.
+
+**Step 5: Run full suite**
+
+```bash
+npm test
+```
+
+Expected: all tests passing (count will differ from baseline due to removed + added tests).
+
+**Step 6: Commit**
+
+```bash
+git add src/client/panels/recipe.ts __tests__/panels/recipe.test.ts
+git commit -m "feat: rewrite RecipePanel to render UserInput[] and use prepTemplate/runTemplate"
+```
+
+---
+
+### Task 6: Rewrite `RECIPES` registry
+
+Update the document-summarization recipe to use the new `RecipeDefinition` shape.
+
+**Files:**
+- Rewrite: `src/client/recipes.ts`
+
+**Step 1: Rewrite the file**
+
+```ts
+import type { RecipeDefinition } from "./types";
+
+export const RECIPES: RecipeDefinition[] = [
+  {
+    id: "document-summarization",
+    name: "Document Summarization",
+    icon: "📄",
+    description: "Summarize each file in a Google Drive folder",
+    inputs: [
+      {
+        id: "folder",
+        label: "Drive Folder",
+        required: true,
+        helperText: "Make sure you have access to this folder",
+        placeholder: "Paste Google Drive folder URL",
+      },
+    ],
+    prepTemplate: [
+      {
+        colTitle: "Drive Link",
+        strategy: { kind: "list-drive-folder", inputId: "folder" },
+      },
+      {
+        colTitle: "System Prompt",
+        strategy: {
+          kind: "fill-value",
+          value:
+            "You are an expert document analyst. Produce clear, structured summaries " +
+            "focusing on key themes, main arguments, important data points, and actionable conclusions.",
+        },
+      },
+      {
+        colTitle: "User Prompt",
+        strategy: {
+          kind: "fill-value",
+          value:
+            "Please summarize the attached document. Include the main topics, key findings, " +
+            "and important conclusions. The document file will be attached as inline data.",
+        },
+      },
+      {
+        colTitle: "AI_Summarization",
+        strategy: { kind: "create-empty" },
+      },
+    ],
+    runTemplate: {
+      promptCols: [
+        { col: "Drive Link", kind: "file" },
+        { col: "User Prompt", kind: "text" },
+      ],
+      systemPromptCol: "System Prompt",
+      outputCol: "AI_Summarization",
+    },
+  },
+];
+```
+
+**Step 2: Run full typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors.
+
+**Step 3: Run full suite**
+
+```bash
+npm test
+```
+
+Expected: all tests passing.
+
+**Step 4: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: no errors.
+
+**Step 5: Commit**
+
+```bash
+git add src/client/recipes.ts
+git commit -m "feat: rewrite RECIPES registry under new RecipeDefinition shape"
+```
+
+---
+
+### Task 7: Final verification
+
+**Step 1: Full typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: clean.
+
+**Step 2: Full test suite with coverage**
+
+```bash
+npm run test:coverage
+```
+
+Expected: all thresholds met, all tests passing.
+
+**Step 3: Build**
+
+```bash
+npm run build
+```
+
+Expected: clean build, no rollup errors.
+
+**Step 4: Lint + format check**
+
+```bash
+npm run lint && npm run format:check
+```
+
+Expected: clean.

--- a/docs/plans/2026-04-14-recipe-architecture-redesign.md
+++ b/docs/plans/2026-04-14-recipe-architecture-redesign.md
@@ -1,0 +1,154 @@
+# Recipe Architecture Redesign
+
+**Date:** 2026-04-14
+**Status:** Approved
+
+## Goals
+
+1. Break `ColumnDef` out of its tri-purpose role (UI rendering + spreadsheet prep + RunConfig assembly) into focused, independent structures.
+2. Make recipes feel like a single action to the journalist — a small number of discrete inputs, then run.
+3. Allow recipe authors to work with types already familiar from the rest of the system (`PrepColSpec`, `RunConfig`) rather than recipe-specific abstractions.
+
+## Out of Scope
+
+- Collapsing prep and cook into a single server action (future iteration).
+- User-authored or saved recipes. Recipes remain code-defined presets.
+- `generationConfig` / `modelName` overrides at the recipe level.
+
+---
+
+## Core Insight
+
+A recipe has four distinct jobs, each now handled by a focused structure:
+
+| Job | Structure | Lives in |
+|-----|-----------|----------|
+| Discovery (recipes list) | `id`, `name`, `icon`, `description` on `RecipeDefinition` | `client/types.ts` |
+| Input collection (journalist form) | `UserInput[]` | `client/types.ts` |
+| Spreadsheet prep | `prepTemplate: PrepColSpec[]` | `shared/types.ts` (existing type) |
+| AI run configuration | `runTemplate: Partial<RunConfig>` | `shared/types.ts` (existing type) |
+
+`prepTemplate` and `runTemplate` are linked only by matching column title strings — the same convention used by `RunConfig` everywhere else in the system. Neither needs to know about the other's structure.
+
+---
+
+## New Interfaces
+
+### `src/client/types.ts`
+
+Remove: `RecipeFieldConfig`, `ColStrategyKind`, `ColRole`, `AppendField`, `RecipeSettings`, `ColumnDef`, `RecipeParams`.
+
+Add:
+
+```ts
+export interface UserInput {
+  id: string;
+  label: string;
+  required?: boolean;
+  helperText?: string;
+  placeholder?: string;
+}
+
+export interface RecipeDefinition {
+  id: string;
+  name: string;
+  icon: string;
+  description: string;
+  inputs: UserInput[];
+  prepTemplate: PrepColSpec[];
+  runTemplate: Partial<RunConfig>;
+}
+```
+
+### `src/shared/types.ts`
+
+`ColStrategy` gains a `template` variant and `list-drive-folder` switches from a static `url` to an `inputId` reference:
+
+```ts
+export type ColStrategy =
+  | { kind: "list-drive-folder"; inputId: string }
+  | { kind: "fill-value"; value: string }
+  | { kind: "template"; template: string }  // {{inputId}} placeholders resolved at prep time
+  | { kind: "create-empty" };
+```
+
+`PrepRecipeParams` gains `inputValues` so the server can resolve `inputId` references:
+
+```ts
+export interface PrepRecipeParams {
+  cols: PrepColSpec[];
+  inputValues: Record<string, string>;
+}
+```
+
+`PrepRecipeResult` is unchanged.
+
+---
+
+## Binding: How Inputs Connect to Columns and Settings
+
+`UserInput.id` is the universal binding key. It appears in:
+
+- **`ColStrategy`** — `list-drive-folder` and `template` variants reference `inputId` to pull journalist-provided values into column fill strategies at prep time.
+- **`RunConfig` settings (future)** — any setting can optionally reference an `inputId` using the same pattern when a journalist-editable setting is needed.
+
+The `RecipePanel` collects `inputValues: Record<string, string>` from the form and sends them alongside `prepTemplate` in `PrepRecipeParams`. The server resolves all `inputId` references server-side before writing columns.
+
+---
+
+## Example: Document Summarization Recipe
+
+```ts
+{
+  id: "document-summarization",
+  name: "Document Summarization",
+  icon: "📄",
+  description: "Summarize each file in a Google Drive folder",
+  inputs: [
+    {
+      id: "folder",
+      label: "Drive Folder",
+      required: true,
+      helperText: "Make sure you have access to this folder",
+      placeholder: "Paste Google Drive folder URL",
+    },
+  ],
+  prepTemplate: [
+    { colTitle: "Drive Link",       strategy: { kind: "list-drive-folder", inputId: "folder" } },
+    { colTitle: "System Prompt",    strategy: { kind: "fill-value", value: "You are an expert document analyst. Produce clear, structured summaries focusing on key themes, main arguments, important data points, and actionable conclusions." } },
+    { colTitle: "User Prompt",      strategy: { kind: "fill-value", value: "Please summarize the attached document. Include the main topics, key findings, and important conclusions." } },
+    { colTitle: "AI_Summarization", strategy: { kind: "create-empty" } },
+  ],
+  runTemplate: {
+    promptCols: [
+      { col: "Drive Link",    kind: "file" },
+      { col: "User Prompt",  kind: "text" },
+    ],
+    systemPromptCol: "System Prompt",
+    outputCol: "AI_Summarization",
+  },
+}
+```
+
+---
+
+## Files to Modify
+
+```
+src/client/types.ts        ← remove ColumnDef cluster, add UserInput + updated RecipeDefinition
+src/shared/types.ts        ← update ColStrategy, update PrepRecipeParams
+src/client/recipes.ts      ← rewrite RECIPES array under new RecipeDefinition shape
+src/client/panels/recipe.ts ← rewrite RecipePanel: render inputs[], collect inputValues,
+                              pass prepTemplate + inputValues on prep,
+                              assemble preppedRunConfig from runTemplate + result.rowRange on cook
+src/server/index.ts        ← update prepRecipe() to accept inputValues, resolve inputId refs
+                              in list-drive-folder and template strategies
+```
+
+---
+
+## What Gets Simpler
+
+- `RecipePanel` only needs to know about `inputs` to render the form. No column cards, no lockable fields per column, no tri-purpose ColumnDef loop.
+- Recipe authors read `prepTemplate` and `runTemplate` independently. Prep strategy and AI role are no longer entangled on the same object.
+- Adding a new recipe is: define `inputs`, define columns with fill strategies, define a partial `RunConfig`. All familiar types.

--- a/src/client/panels/recipe.ts
+++ b/src/client/panels/recipe.ts
@@ -1,32 +1,10 @@
-import type { NavigationContext, Panel, RecipeDefinition, ColumnDef } from "../types";
-import type {
-  ColStrategy,
-  PrepColSpec,
-  PrepRecipeParams,
-  PrepRecipeResult,
-  RunConfig,
-  PromptColumnSpec,
-} from "../../shared/types";
-import { LockableField } from "../components/lockable-field";
+import type { NavigationContext, Panel, RecipeDefinition, UserInput } from "../types";
+import type { PrepRecipeParams, PrepRecipeResult, RunConfig } from "../../shared/types";
 import { RecipePrepCook } from "../components/recipe-prep-cook";
 import { prepRecipe } from "../services";
 
-type ColFieldRefs = {
-  colTitle?: LockableField;
-  prompt?: LockableField;
-  urlInput?: HTMLInputElement;
-  appendInputs?: Record<string, HTMLInputElement>;
-};
-
-type ColSavedValues = {
-  colTitle?: string;
-  prompt?: string;
-  url?: string;
-  appendValues?: Record<string, string>;
-};
-
 type SavedState = {
-  colValues: ColSavedValues[];
+  inputValues: Record<string, string>;
   prepComplete: boolean;
   preppedRunConfig?: Partial<RunConfig>;
 };
@@ -36,7 +14,7 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
   private definition: RecipeDefinition | null = null;
   private prepCook: RecipePrepCook | null = null;
   private preppedRunConfig: Partial<RunConfig> | null = null;
-  private fields: ColFieldRefs[] = [];
+  private container: HTMLElement | null = null;
 
   mount(
     container: HTMLElement,
@@ -46,78 +24,40 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
   ): void {
     this.nav = nav;
     this.definition = definition ?? null;
-    this.fields = [];
+    this.container = container;
     this.preppedRunConfig = savedState?.preppedRunConfig ?? null;
 
     container.innerHTML = this.template(definition);
     container.querySelector("#back-btn")?.addEventListener("click", () => nav.back());
 
-    this.mountFields(container, definition?.params?.columns ?? [], savedState);
+    this.restoreInputValues(container, definition?.inputs ?? [], savedState?.inputValues ?? {});
     this.mountPrepCook(container, savedState?.prepComplete ?? false);
   }
 
   unmount(): SavedState {
-    const colValues: ColSavedValues[] = this.fields.map((f) => ({
-      colTitle: f.colTitle?.getValue(),
-      prompt: f.prompt?.getValue(),
-      url: f.urlInput?.value,
-      appendValues: f.appendInputs
-        ? Object.fromEntries(Object.entries(f.appendInputs).map(([id, el]) => [id, el.value]))
-        : undefined,
-    }));
+    const inputs = this.definition?.inputs ?? [];
+    const inputValues: Record<string, string> = {};
+    for (const input of inputs) {
+      const el = this.container?.querySelector<HTMLInputElement>(`[data-input-id="${input.id}"]`);
+      inputValues[input.id] = el?.value ?? "";
+    }
     return {
-      colValues,
+      inputValues,
       prepComplete: this.prepCook?.isPrepComplete() ?? false,
       preppedRunConfig: this.preppedRunConfig ?? undefined,
     };
   }
 
-  private mountFields(container: HTMLElement, columns: ColumnDef[], savedState?: SavedState): void {
-    const reset = (): void => this.prepCook?.reset();
-
-    columns.forEach((col, i) => {
-      const saved = savedState?.colValues?.[i];
-      const refs: ColFieldRefs = {};
-
-      refs.colTitle = new LockableField(container.querySelector(`#col-${i}-title-container`)!, {
-        label: "Column",
-        defaultValue: saved?.colTitle ?? col.colTitle.value,
-        locked: col.colTitle.locked,
-        onUnlock: reset,
-      });
-
-      if (col.prompt !== undefined) {
-        refs.prompt = new LockableField(container.querySelector(`#col-${i}-prompt-container`)!, {
-          label: "Prompt",
-          defaultValue: saved?.prompt ?? col.prompt.value,
-          locked: col.prompt.locked,
-          multiline: true,
-          onUnlock: reset,
-        });
-      }
-
-      if (col.url !== undefined) {
-        const urlEl = container.querySelector<HTMLInputElement>(`#col-${i}-url-input`);
-        if (urlEl) {
-          if (saved?.url) urlEl.value = saved.url;
-          urlEl.addEventListener("input", reset);
-          refs.urlInput = urlEl;
-        }
-      }
-
-      if (col.appendFields?.length) {
-        refs.appendInputs = {};
-        for (const af of col.appendFields) {
-          const el = container.querySelector<HTMLInputElement>(`#col-${i}-append-${af.id}`);
-          if (el) {
-            if (saved?.appendValues?.[af.id]) el.value = saved.appendValues[af.id];
-            refs.appendInputs[af.id] = el;
-          }
-        }
-      }
-
-      this.fields[i] = refs;
-    });
+  private restoreInputValues(
+    container: HTMLElement,
+    inputs: UserInput[],
+    savedValues: Record<string, string>,
+  ): void {
+    for (const input of inputs) {
+      const el = container.querySelector<HTMLInputElement>(`[data-input-id="${input.id}"]`);
+      if (el && savedValues[input.id]) el.value = savedValues[input.id];
+      el?.addEventListener("input", () => this.prepCook?.reset());
+    }
   }
 
   private mountPrepCook(container: HTMLElement, prepComplete: boolean): void {
@@ -138,113 +78,52 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
   }
 
   private buildPrepParams(): PrepRecipeParams | null {
-    const columns = this.definition?.params?.columns ?? [];
-    const cols: PrepColSpec[] = [];
+    const inputs = this.definition?.inputs ?? [];
+    const inputValues: Record<string, string> = {};
 
-    for (let i = 0; i < columns.length; i++) {
-      const col = columns[i];
-      const colTitle = this.fields[i]?.colTitle?.getValue() ?? col.colTitle.value;
-
-      let strategy: ColStrategy;
-      switch (col.strategyKind) {
-        case "list-drive-folder": {
-          const url = this.fields[i]?.urlInput?.value.trim() ?? "";
-          if (!url) {
-            globalThis.alert(`Please enter a URL for "${col.label}".`);
-            return null;
-          }
-          strategy = { kind: "list-drive-folder", url };
-          break;
-        }
-        case "fill-value": {
-          const base = this.fields[i]?.prompt?.getValue() ?? col.prompt?.value ?? "";
-          const appended = (col.appendFields ?? [])
-            .map((af) => {
-              const v = this.fields[i]?.appendInputs?.[af.id]?.value.trim() ?? "";
-              return v ? (af.prefix ?? "") + v : "";
-            })
-            .join("");
-          strategy = { kind: "fill-value", value: base + appended };
-          break;
-        }
-        case "create-empty":
-          strategy = { kind: "create-empty" };
-          break;
+    for (const input of inputs) {
+      const el = this.container?.querySelector<HTMLInputElement>(`[data-input-id="${input.id}"]`);
+      const value = el?.value.trim() ?? "";
+      if (input.required && !value) {
+        globalThis.alert(`Please fill in "${input.label}".`);
+        return null;
       }
-
-      cols.push({ colTitle, strategy });
+      inputValues[input.id] = value;
     }
 
-    return { cols };
+    return {
+      cols: this.definition?.prepTemplate ?? [],
+      inputValues,
+    };
   }
 
   private buildRunConfig(result: PrepRecipeResult): Partial<RunConfig> {
-    const columns = this.definition?.params?.columns ?? [];
-    const settings = this.definition?.params?.settings ?? {};
-    const promptCols: PromptColumnSpec[] = [];
-    let systemPromptCol: string | undefined;
-    let outputCol = "";
-
-    for (let i = 0; i < columns.length; i++) {
-      const col = columns[i];
-      const resolvedTitle = this.fields[i]?.colTitle?.getValue() ?? col.colTitle.value;
-
-      switch (col.role) {
-        case "userPrompt":
-          promptCols.push({ col: resolvedTitle, kind: "text" });
-          break;
-        case "driveLink":
-          promptCols.push({ col: resolvedTitle, kind: "file" });
-          break;
-        case "systemPrompt":
-          systemPromptCol = resolvedTitle;
-          break;
-        case "output":
-          outputCol = resolvedTitle;
-          break;
-      }
-    }
-
-    return { promptCols, systemPromptCol, outputCol, rowRange: result.rowRange, ...settings };
+    return {
+      ...this.definition?.runTemplate,
+      rowRange: result.rowRange,
+    };
   }
 
   private template(definition: RecipeDefinition | undefined | null): string {
-    const columns = definition?.params?.columns ?? [];
+    const inputs = definition?.inputs ?? [];
     const title = definition ? `${definition.icon} ${definition.name}` : "Recipe";
 
-    const columnSections = columns
-      .map((col, i) => {
-        const requiredMark = col.required ? ` <span class="required">*</span>` : "";
-        const helperHtml = col.helperText ? `<p class="field-helper">${col.helperText}</p>` : "";
-
-        const urlInputHtml =
-          col.url !== undefined
-            ? `<input id="col-${i}-url-input" type="text" class="text-input"
-                placeholder="${col.url.placeholder ?? "Paste Google Drive URL"}" />`
-            : "";
-
-        const promptContainerHtml =
-          col.prompt !== undefined ? `<div id="col-${i}-prompt-container"></div>` : "";
-
-        const appendFieldsHtml = (col.appendFields ?? [])
-          .map(
-            (af) =>
-              `<div class="append-field">
-                <label class="field-label">${af.label}</label>
-                <input id="col-${i}-append-${af.id}" type="text" class="text-input"
-                  placeholder="${af.placeholder ?? ""}" />
-              </div>`,
-          )
-          .join("");
-
+    const inputsHtml = inputs
+      .map((input) => {
+        const requiredMark = input.required ? `<span class="required"> *</span>` : "";
+        const helperHtml = input.helperText
+          ? `<p class="field-helper">${input.helperText}</p>`
+          : "";
         return `
-          <div class="recipe-section-card">
-            <div class="recipe-section-card-title">${col.label}${requiredMark}</div>
+          <div class="recipe-input-field">
+            <label class="recipe-input-label">${input.label}</label>${requiredMark}
             ${helperHtml}
-            <div id="col-${i}-title-container"></div>
-            ${urlInputHtml}
-            ${promptContainerHtml}
-            ${appendFieldsHtml}
+            <input
+              data-input-id="${input.id}"
+              type="text"
+              class="text-input"
+              placeholder="${input.placeholder ?? ""}"
+            />
           </div>`;
       })
       .join("");
@@ -254,7 +133,7 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
         <button id="back-btn" class="back-btn">← Back</button>
         <span class="panel-title">${title}</span>
       </div>
-      ${columnSections}
+      ${inputsHtml}
       <div id="prep-cook-container"></div>
     `;
   }

--- a/src/client/panels/recipe.ts
+++ b/src/client/panels/recipe.ts
@@ -1,6 +1,11 @@
-import type { NavigationContext, Panel, RecipeDefinition, UserInput } from "../types";
 import type {
-  PrepColSpec,
+  NavigationContext,
+  Panel,
+  RecipeColumn,
+  RecipeDefinition,
+  RecipeInput,
+} from "../types";
+import type {
   PrepRecipeParams,
   PrepRecipeResult,
   PromptColumnSpec,
@@ -9,7 +14,7 @@ import type {
 import { RecipePrepCook } from "../components/recipe-prep-cook";
 import { prepRecipe } from "../services";
 
-function buildRunTemplate(cols: PrepColSpec[]): Partial<RunConfig> {
+function buildRunTemplate(cols: RecipeColumn[]): Partial<RunConfig> {
   const promptCols: PromptColumnSpec[] = [];
   let systemPromptCol: string | undefined;
   let outputCol: string | undefined;
@@ -80,7 +85,7 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
 
   private restoreInputValues(
     container: HTMLElement,
-    inputs: UserInput[],
+    inputs: RecipeInput[],
     savedValues: Record<string, string>,
   ): void {
     for (const input of inputs) {

--- a/src/client/panels/recipe.ts
+++ b/src/client/panels/recipe.ts
@@ -15,7 +15,7 @@ function buildRunTemplate(cols: PrepColSpec[]): Partial<RunConfig> {
   let outputCol: string | undefined;
 
   for (const col of cols) {
-    switch (col.role?.kind) {
+    switch (col.role) {
       case "file-prompt":
         promptCols.push({ col: col.colTitle, kind: "file" });
         break;

--- a/src/client/panels/recipe.ts
+++ b/src/client/panels/recipe.ts
@@ -1,7 +1,37 @@
 import type { NavigationContext, Panel, RecipeDefinition, UserInput } from "../types";
-import type { PrepRecipeParams, PrepRecipeResult, RunConfig } from "../../shared/types";
+import type {
+  PrepColSpec,
+  PrepRecipeParams,
+  PrepRecipeResult,
+  PromptColumnSpec,
+  RunConfig,
+} from "../../shared/types";
 import { RecipePrepCook } from "../components/recipe-prep-cook";
 import { prepRecipe } from "../services";
+
+function buildRunTemplate(cols: PrepColSpec[]): Partial<RunConfig> {
+  const promptCols: PromptColumnSpec[] = [];
+  let systemPromptCol: string | undefined;
+  let outputCol: string | undefined;
+
+  for (const col of cols) {
+    switch (col.role?.kind) {
+      case "file-prompt":
+        promptCols.push({ col: col.colTitle, kind: "file" });
+        break;
+      case "text-prompt":
+        promptCols.push({ col: col.colTitle, kind: "text" });
+        break;
+      case "system-prompt":
+        systemPromptCol = col.colTitle;
+        break;
+      case "output":
+        outputCol = col.colTitle;
+        break;
+    }
+  }
+  return { promptCols, systemPromptCol, outputCol };
+}
 
 type SavedState = {
   inputValues: Record<string, string>;
@@ -99,7 +129,8 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
 
   private buildRunConfig(result: PrepRecipeResult): Partial<RunConfig> {
     return {
-      ...this.definition?.runTemplate,
+      ...buildRunTemplate(this.definition?.prepTemplate ?? []),
+      ...this.definition?.settings,
       rowRange: result.rowRange,
     };
   }

--- a/src/client/panels/recipes-list.ts
+++ b/src/client/panels/recipes-list.ts
@@ -8,7 +8,7 @@ export class RecipesListPanel implements Panel {
     RECIPES.forEach((recipe) => {
       container
         .querySelector(`#btn-${recipe.id}`)
-        ?.addEventListener("click", () => nav.navigate(recipe.panelId, recipe));
+        ?.addEventListener("click", () => nav.navigate("recipe", recipe));
     });
   }
 

--- a/src/client/recipes.ts
+++ b/src/client/recipes.ts
@@ -1,4 +1,4 @@
-import type { RecipeDefinition, RecipeParams } from "./types";
+import type { RecipeDefinition } from "./types";
 
 export const RECIPES: RecipeDefinition[] = [
   {
@@ -6,49 +6,50 @@ export const RECIPES: RecipeDefinition[] = [
     name: "Document Summarization",
     icon: "📄",
     description: "Summarize each file in a Google Drive folder",
-    panelId: "recipe",
-    params: {
-      columns: [
-        {
-          label: "Drive Folder",
-          role: "driveLink",
-          strategyKind: "list-drive-folder",
-          colTitle: { value: "Drive Link", locked: true },
-          url: { value: "", locked: false, placeholder: "Paste Google Drive folder URL" },
-          helperText: "Make sure you have access to this folder",
-          required: true,
+    inputs: [
+      {
+        id: "folder",
+        label: "Drive Folder",
+        required: true,
+        helperText: "Make sure you have access to this folder",
+        placeholder: "Paste Google Drive folder URL",
+      },
+    ],
+    prepTemplate: [
+      {
+        colTitle: "Drive Link",
+        strategy: { kind: "list-drive-folder", inputId: "folder" },
+      },
+      {
+        colTitle: "System Prompt",
+        strategy: {
+          kind: "fill-value",
+          value:
+            "You are an expert document analyst. Produce clear, structured summaries " +
+            "focusing on key themes, main arguments, important data points, and actionable conclusions.",
         },
-        {
-          label: "System Prompt",
-          role: "systemPrompt",
-          strategyKind: "fill-value",
-          colTitle: { value: "System Prompt", locked: true },
-          prompt: {
-            value:
-              "You are an expert document analyst. Produce clear, structured summaries " +
-              "focusing on key themes, main arguments, important data points, and actionable conclusions.",
-            locked: true,
-          },
+      },
+      {
+        colTitle: "User Prompt",
+        strategy: {
+          kind: "fill-value",
+          value:
+            "Please summarize the attached document. Include the main topics, key findings, " +
+            "and important conclusions. The document file will be attached as inline data.",
         },
-        {
-          label: "User Prompt",
-          role: "userPrompt",
-          strategyKind: "fill-value",
-          colTitle: { value: "User Prompt", locked: true },
-          prompt: {
-            value:
-              "Please summarize the attached document. Include the main topics, key findings, " +
-              "and important conclusions. The document file will be attached as inline data.",
-            locked: true,
-          },
-        },
-        {
-          label: "Output Column",
-          role: "output",
-          strategyKind: "create-empty",
-          colTitle: { value: "AI_Summarization", locked: true },
-        },
+      },
+      {
+        colTitle: "AI_Summarization",
+        strategy: { kind: "create-empty" },
+      },
+    ],
+    runTemplate: {
+      promptCols: [
+        { col: "Drive Link", kind: "file" },
+        { col: "User Prompt", kind: "text" },
       ],
-    } satisfies RecipeParams,
+      systemPromptCol: "System Prompt",
+      outputCol: "AI_Summarization",
+    },
   },
 ];

--- a/src/client/recipes.ts
+++ b/src/client/recipes.ts
@@ -19,6 +19,7 @@ export const RECIPES: RecipeDefinition[] = [
       {
         colTitle: "Drive Link",
         fillStrategy: { kind: "list-drive-folder", inputId: "folder" },
+        role: { kind: "file-prompt" },
       },
       {
         colTitle: "System Prompt",
@@ -28,6 +29,7 @@ export const RECIPES: RecipeDefinition[] = [
             "You are an expert document analyst. Produce clear, structured summaries " +
             "focusing on key themes, main arguments, important data points, and actionable conclusions.",
         },
+        role: { kind: "system-prompt" },
       },
       {
         colTitle: "User Prompt",
@@ -37,19 +39,13 @@ export const RECIPES: RecipeDefinition[] = [
             "Please summarize the attached document. Include the main topics, key findings, " +
             "and important conclusions. The document file will be attached as inline data.",
         },
+        role: { kind: "text-prompt" },
       },
       {
         colTitle: "AI_Summarization",
         fillStrategy: { kind: "create-empty" },
+        role: { kind: "output" },
       },
     ],
-    runTemplate: {
-      promptCols: [
-        { col: "Drive Link", kind: "file" },
-        { col: "User Prompt", kind: "text" },
-      ],
-      systemPromptCol: "System Prompt",
-      outputCol: "AI_Summarization",
-    },
   },
 ];

--- a/src/client/recipes.ts
+++ b/src/client/recipes.ts
@@ -19,7 +19,7 @@ export const RECIPES: RecipeDefinition[] = [
       {
         colTitle: "Drive Link",
         fillStrategy: { kind: "list-drive-folder", inputId: "folder" },
-        role: { kind: "file-prompt" },
+        role: "file-prompt",
       },
       {
         colTitle: "System Prompt",
@@ -29,7 +29,7 @@ export const RECIPES: RecipeDefinition[] = [
             "You are an expert document analyst. Produce clear, structured summaries " +
             "focusing on key themes, main arguments, important data points, and actionable conclusions.",
         },
-        role: { kind: "system-prompt" },
+        role: "system-prompt",
       },
       {
         colTitle: "User Prompt",
@@ -39,12 +39,12 @@ export const RECIPES: RecipeDefinition[] = [
             "Please summarize the attached document. Include the main topics, key findings, " +
             "and important conclusions. The document file will be attached as inline data.",
         },
-        role: { kind: "text-prompt" },
+        role: "text-prompt",
       },
       {
         colTitle: "AI_Summarization",
         fillStrategy: { kind: "create-empty" },
-        role: { kind: "output" },
+        role: "output",
       },
     ],
   },

--- a/src/client/recipes.ts
+++ b/src/client/recipes.ts
@@ -18,11 +18,11 @@ export const RECIPES: RecipeDefinition[] = [
     prepTemplate: [
       {
         colTitle: "Drive Link",
-        strategy: { kind: "list-drive-folder", inputId: "folder" },
+        fillStrategy: { kind: "list-drive-folder", inputId: "folder" },
       },
       {
         colTitle: "System Prompt",
-        strategy: {
+        fillStrategy: {
           kind: "fill-value",
           value:
             "You are an expert document analyst. Produce clear, structured summaries " +
@@ -31,7 +31,7 @@ export const RECIPES: RecipeDefinition[] = [
       },
       {
         colTitle: "User Prompt",
-        strategy: {
+        fillStrategy: {
           kind: "fill-value",
           value:
             "Please summarize the attached document. Include the main topics, key findings, " +
@@ -40,7 +40,7 @@ export const RECIPES: RecipeDefinition[] = [
       },
       {
         colTitle: "AI_Summarization",
-        strategy: { kind: "create-empty" },
+        fillStrategy: { kind: "create-empty" },
       },
     ],
     runTemplate: {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,4 +1,4 @@
-import type { PrepColSpec, ToolId } from "../shared/types";
+import type { PrepColSpec, RunConfig } from "../shared/types";
 
 // ── Loading / Progress types ─────────────────────────────────────────────────
 
@@ -25,13 +25,12 @@ export interface Job {
 /**
  * Non-column AI settings a recipe can pre-configure.
  * These flow into RunConfig at cook time alongside the derived column references.
+ * Typed as a Pick so it stays in sync with RunConfig automatically.
  */
-export interface RecipeSettings {
-  tools?: ToolId[];
-  applyMarkdown?: boolean;
-  includeGrounding?: boolean;
-  prefixWithColName?: boolean;
-}
+export type RecipeSettings = Pick<
+  RunConfig,
+  "tools" | "applyMarkdown" | "includeGrounding" | "prefixWithColName"
+>;
 
 export interface UserInput {
   /**

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,4 +1,4 @@
-import type { PrepColSpec, RunConfig } from "../shared/types";
+import type { PrepColSpec, ToolId } from "../shared/types";
 
 // ── Loading / Progress types ─────────────────────────────────────────────────
 
@@ -21,6 +21,17 @@ export interface Job {
 
 // ── Recipe UI types ─────────────────────────────────────────────
 // These are client-only — they define the journalist-facing form, not RPC payloads.
+
+/**
+ * Non-column AI settings a recipe can pre-configure.
+ * These flow into RunConfig at cook time alongside the derived column references.
+ */
+export interface RecipeSettings {
+  tools?: ToolId[];
+  applyMarkdown?: boolean;
+  includeGrounding?: boolean;
+  prefixWithColName?: boolean;
+}
 
 export interface UserInput {
   /**
@@ -75,8 +86,12 @@ export interface RecipeDefinition {
   description: string;
   /** Journalist-facing form fields. Drives RecipePanel rendering. */
   inputs: UserInput[];
-  /** Column template passed to prepRecipe(). Strategies may reference input IDs. */
+  /**
+   * Column template passed to prepRecipe(). Each column's role field determines
+   * its place in the AI call — promptCols, systemPromptCol, outputCol are derived
+   * from these roles at cook time via buildRunTemplate().
+   */
   prepTemplate: PrepColSpec[];
-  /** Partial RunConfig passed to ConfigureAIRunPanel after cook. rowRange is filled in by prep result. */
-  runTemplate: Partial<RunConfig>;
+  /** Non-column AI settings (tools, markdown, grounding, etc.). */
+  settings?: RecipeSettings;
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,4 +1,4 @@
-import type { ToolId } from "../shared/types";
+import type { PrepColSpec, RunConfig } from "../shared/types";
 
 // ── Loading / Progress types ─────────────────────────────────────────────────
 
@@ -20,54 +20,21 @@ export interface Job {
 }
 
 // ── Recipe UI types ─────────────────────────────────────────────
-// These are client-only — they define sidebar form structure, not RPC payloads.
+// These are client-only — they define the journalist-facing form, not RPC payloads.
 
-export interface RecipeFieldConfig {
-  value: string;
-  locked?: boolean; // defaults to true
-  placeholder?: string;
-}
-
-export type ColStrategyKind = "list-drive-folder" | "fill-value" | "create-empty";
-export type ColRole = "userPrompt" | "systemPrompt" | "driveLink" | "output";
-
-export interface AppendField {
+export interface UserInput {
+  /**
+   * Unique identifier for this input. Used as the key in template interpolation
+   * (e.g. a fill strategy of `{{folder}}` resolves from `inputValues["folder"]`).
+   *
+   * Must be camelCase or underscore_separated — no hyphens. The interpolation
+   * regex uses `\w+` which does not match `-`.
+   */
   id: string;
   label: string;
-  placeholder?: string;
-  /** Text injected before the reporter's value, e.g. "\n\nYou are looking for:\n\n" */
-  prefix?: string;
-}
-
-export interface RecipeSettings {
-  tools?: ToolId[];
-  applyMarkdown?: boolean;
-  includeGrounding?: boolean;
-}
-
-export interface ColumnDef {
-  /** UI section heading shown in the recipe panel */
-  label: string;
-  /** How this column maps into RunConfig after prep */
-  role: ColRole;
-  /** What PrepColSpec.strategy type to generate during prep */
-  strategyKind: ColStrategyKind;
-  /** Lockable column header field */
-  colTitle: RecipeFieldConfig;
-  /** Lockable prompt text — present for fill-value columns */
-  prompt?: RecipeFieldConfig;
-  /** Lockable URL input — present for drive columns */
-  url?: RecipeFieldConfig;
-  /** Extra reporter inputs composed into the prompt before prep */
-  appendFields?: AppendField[];
-  helperText?: string;
-  /** Show * in section heading */
   required?: boolean;
-}
-
-export interface RecipeParams {
-  columns: ColumnDef[];
-  settings?: RecipeSettings;
+  helperText?: string;
+  placeholder?: string;
 }
 
 /**
@@ -106,6 +73,10 @@ export interface RecipeDefinition {
   name: string;
   icon: string;
   description: string;
-  panelId: PanelId;
-  params?: RecipeParams;
+  /** Journalist-facing form fields. Drives RecipePanel rendering. */
+  inputs: UserInput[];
+  /** Column template passed to prepRecipe(). Strategies may reference input IDs. */
+  prepTemplate: PrepColSpec[];
+  /** Partial RunConfig passed to ConfigureAIRunPanel after cook. rowRange is filled in by prep result. */
+  runTemplate: Partial<RunConfig>;
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,5 +1,21 @@
 import type { PrepColSpec, RunConfig } from "../shared/types";
 
+// ── Recipe column types ──────────────────────────────────────────
+
+/**
+ * The AI inference role this column plays at run time.
+ * Lives client-side only — the server never reads it.
+ */
+export type ColumnRole = "file-prompt" | "text-prompt" | "system-prompt" | "output";
+
+/**
+ * What recipe authors write: the RPC-crossing PrepColSpec plus the
+ * client-only role that determines the column's place in the AI call.
+ */
+export interface RecipeColumn extends PrepColSpec {
+  role?: ColumnRole;
+}
+
 // ── Loading / Progress types ─────────────────────────────────────────────────
 
 export type LoadingStatus = "idle" | "loading" | "progress" | "cancelling" | "complete" | "error";
@@ -32,7 +48,7 @@ export type RecipeSettings = Pick<
   "tools" | "applyMarkdown" | "includeGrounding" | "prefixWithColName"
 >;
 
-export interface UserInput {
+export interface RecipeInput {
   /**
    * Unique identifier for this input. Used as the key in template interpolation
    * (e.g. a fill strategy of `{{folder}}` resolves from `inputValues["folder"]`).
@@ -84,13 +100,13 @@ export interface RecipeDefinition {
   icon: string;
   description: string;
   /** Journalist-facing form fields. Drives RecipePanel rendering. */
-  inputs: UserInput[];
+  inputs: RecipeInput[];
   /**
    * Column template passed to prepRecipe(). Each column's role field determines
    * its place in the AI call — promptCols, systemPromptCol, outputCol are derived
    * from these roles at cook time via buildRunTemplate().
    */
-  prepTemplate: PrepColSpec[];
+  prepTemplate: RecipeColumn[];
   /** Non-column AI settings (tools, markdown, grounding, etc.). */
   settings?: RecipeSettings;
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -404,8 +404,8 @@ export function prepRecipe({ cols, inputValues }: PrepRecipeParams): PrepRecipeR
   // Pass 1: scan Drive folders, cache results, determine numRows
   const folderCache = new Map<string, string[]>();
   for (const col of cols) {
-    if (col.strategy.kind === "list-drive-folder") {
-      const url = inputValues[col.strategy.inputId] ?? "";
+    if (col.fillStrategy.kind === "list-drive-folder") {
+      const url = inputValues[col.fillStrategy.inputId] ?? "";
       if (!folderCache.has(url)) {
         const folder = DriveApp.getFolderById(extractId(url));
         const files: { url: string }[] = [];
@@ -422,9 +422,9 @@ export function prepRecipe({ cols, inputValues }: PrepRecipeParams): PrepRecipeR
   // Pass 2: write all columns
   for (const col of cols) {
     const colIdx = findOrCreateColumn(sheet, col.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
-    switch (col.strategy.kind) {
+    switch (col.fillStrategy.kind) {
       case "list-drive-folder": {
-        const urls = folderCache.get(inputValues[col.strategy.inputId] ?? "") ?? [];
+        const urls = folderCache.get(inputValues[col.fillStrategy.inputId] ?? "") ?? [];
         writeColumn(sheet, colIdx, urls, SpreadsheetApp.WrapStrategy.CLIP);
         break;
       }
@@ -432,12 +432,12 @@ export function prepRecipe({ cols, inputValues }: PrepRecipeParams): PrepRecipeR
         writeColumn(
           sheet,
           colIdx,
-          Array(numRows).fill(col.strategy.value) as string[],
+          Array(numRows).fill(col.fillStrategy.value) as string[],
           SpreadsheetApp.WrapStrategy.CLIP,
         );
         break;
       case "template": {
-        const resolved = interpolateTemplate(col.strategy.template, inputValues);
+        const resolved = interpolateTemplate(col.fillStrategy.template, inputValues);
         writeColumn(
           sheet,
           colIdx,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -26,6 +26,7 @@ import {
   findOrCreateColumn,
   writeColumn,
   writeJobProgress,
+  interpolateTemplate,
 } from "./utils";
 import type {
   RunConfig,
@@ -396,15 +397,15 @@ export function runTool(functionName: string, jobId?: string): void {
 // RECIPE PREP
 // ==========================================
 
-export function prepRecipe(params: PrepRecipeParams): PrepRecipeResult {
+export function prepRecipe({ cols, inputValues }: PrepRecipeParams): PrepRecipeResult {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
   let numRows = 1;
 
   // Pass 1: scan Drive folders, cache results, determine numRows
   const folderCache = new Map<string, string[]>();
-  for (const col of params.cols) {
+  for (const col of cols) {
     if (col.strategy.kind === "list-drive-folder") {
-      const url = col.strategy.url;
+      const url = inputValues[col.strategy.inputId] ?? "";
       if (!folderCache.has(url)) {
         const folder = DriveApp.getFolderById(extractId(url));
         const files: { url: string }[] = [];
@@ -419,11 +420,11 @@ export function prepRecipe(params: PrepRecipeParams): PrepRecipeResult {
   }
 
   // Pass 2: write all columns
-  for (const col of params.cols) {
+  for (const col of cols) {
     const colIdx = findOrCreateColumn(sheet, col.colTitle, SpreadsheetApp.WrapStrategy.CLIP);
     switch (col.strategy.kind) {
       case "list-drive-folder": {
-        const urls = folderCache.get(col.strategy.url) ?? [];
+        const urls = folderCache.get(inputValues[col.strategy.inputId] ?? "") ?? [];
         writeColumn(sheet, colIdx, urls, SpreadsheetApp.WrapStrategy.CLIP);
         break;
       }
@@ -435,6 +436,16 @@ export function prepRecipe(params: PrepRecipeParams): PrepRecipeResult {
           SpreadsheetApp.WrapStrategy.CLIP,
         );
         break;
+      case "template": {
+        const resolved = interpolateTemplate(col.strategy.template, inputValues);
+        writeColumn(
+          sheet,
+          colIdx,
+          Array(numRows).fill(resolved) as string[],
+          SpreadsheetApp.WrapStrategy.CLIP,
+        );
+        break;
+      }
       case "create-empty":
         break;
     }

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -143,6 +143,17 @@ export function writeJobProgress(
 }
 
 /**
+ * Replace {{inputId}} placeholders in a template string with values from a map.
+ * Unknown placeholders are replaced with an empty string.
+ */
+export function interpolateTemplate(
+  template: string,
+  inputValues: Record<string, string>,
+): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, id: string) => inputValues[id] ?? "");
+}
+
+/**
  * Write an array of string values to a column starting at row 2.
  * Uses a single setValues() call for efficiency.
  * Pass wrapStrategy to apply a wrap format to the written range.

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -146,10 +146,7 @@ export function writeJobProgress(
  * Replace {{inputId}} placeholders in a template string with values from a map.
  * Unknown placeholders are replaced with an empty string.
  */
-export function interpolateTemplate(
-  template: string,
-  inputValues: Record<string, string>,
-): string {
+export function interpolateTemplate(template: string, inputValues: Record<string, string>): string {
   return template.replace(/\{\{(\w+)\}\}/g, (_, id: string) => inputValues[id] ?? "");
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -55,8 +55,9 @@ export interface RunConfig {
 // ── Recipes ─────────────────────────────────────────────────────
 
 export type ColStrategy =
-  | { kind: "list-drive-folder"; url: string }
+  | { kind: "list-drive-folder"; inputId: string }
   | { kind: "fill-value"; value: string }
+  | { kind: "template"; template: string }
   | { kind: "create-empty" };
 
 export interface PrepColSpec {
@@ -66,6 +67,7 @@ export interface PrepColSpec {
 
 export interface PrepRecipeParams {
   cols: PrepColSpec[];
+  inputValues: Record<string, string>;
 }
 
 export interface PrepRecipeResult {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -54,7 +54,7 @@ export interface RunConfig {
 
 // ── Recipes ─────────────────────────────────────────────────────
 
-export type ColStrategy =
+export type FillStrategy =
   | { kind: "list-drive-folder"; inputId: string }
   | { kind: "fill-value"; value: string }
   | { kind: "template"; template: string }
@@ -62,7 +62,7 @@ export type ColStrategy =
 
 export interface PrepColSpec {
   colTitle: string;
-  strategy: ColStrategy;
+  fillStrategy: FillStrategy;
 }
 
 export interface PrepRecipeParams {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -60,9 +60,20 @@ export type FillStrategy =
   | { kind: "template"; template: string }
   | { kind: "create-empty" };
 
+/**
+ * The AI inference role this column plays at run time.
+ * Absent = prep-only column (no role in the AI call).
+ */
+export type ColumnRole =
+  | { kind: "file-prompt" }
+  | { kind: "text-prompt" }
+  | { kind: "system-prompt" }
+  | { kind: "output" };
+
 export interface PrepColSpec {
   colTitle: string;
   fillStrategy: FillStrategy;
+  role?: ColumnRole;
 }
 
 export interface PrepRecipeParams {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -64,11 +64,7 @@ export type FillStrategy =
  * The AI inference role this column plays at run time.
  * Absent = prep-only column (no role in the AI call).
  */
-export type ColumnRole =
-  | { kind: "file-prompt" }
-  | { kind: "text-prompt" }
-  | { kind: "system-prompt" }
-  | { kind: "output" };
+export type ColumnRole = "file-prompt" | "text-prompt" | "system-prompt" | "output";
 
 export interface PrepColSpec {
   colTitle: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -60,16 +60,9 @@ export type FillStrategy =
   | { kind: "template"; template: string }
   | { kind: "create-empty" };
 
-/**
- * The AI inference role this column plays at run time.
- * Absent = prep-only column (no role in the AI call).
- */
-export type ColumnRole = "file-prompt" | "text-prompt" | "system-prompt" | "output";
-
 export interface PrepColSpec {
   colTitle: string;
   fillStrategy: FillStrategy;
-  role?: ColumnRole;
 }
 
 export interface PrepRecipeParams {


### PR DESCRIPTION
## Summary

- Replaces the tri-purpose `ColumnDef` model with three focused structures: `UserInput[]` (journalist-facing form), `prepTemplate: PrepColSpec[]` (spreadsheet prep), and `runTemplate: Partial<RunConfig>` (AI run config)
- `RecipePanel` now renders only `inputs[]` — no column section cards, no lockable fields per column — and collects `inputValues` by id before calling `prepRecipe`
- Adds `interpolateTemplate()` utility to `utils.ts` for `{{inputId}}` placeholder substitution in the new `template` ColStrategy variant; server `prepRecipe()` resolves `list-drive-folder` via `inputId` and handles the new `template` strategy
- `UserInput.id` must be camelCase/underscore (no hyphens) — documented in JSDoc; `runTemplate` is a plain `Partial<RunConfig>` so recipe authors work with types already familiar from the rest of the system

## Test Plan
- [ ] 426 tests passing, all per-file coverage thresholds met (`npm run test:coverage`)
- [ ] Typecheck clean on both server + client tsconfigs (`npm run typecheck`)
- [ ] Build clean (`npm run build`)
- [ ] Manually: open sidebar, navigate to Recipes, open Document Summarization, paste a Drive folder URL, click Prep, verify columns are written to sheet, click Cook, verify ConfigureAIRunPanel is pre-populated with correct columns and row range

## Design doc

`docs/plans/2026-04-14-recipe-architecture-redesign.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)