### PR TITLE
feat: document summarization recipe redesign for journalism use

### DIFF
--- a/__tests__/panels/recipe.test.ts
+++ b/__tests__/panels/recipe.test.ts
@@ -65,7 +65,7 @@ async function flush() {
 describe("rendering", () => {
   it("renders one input field per RecipeInput", () => {
     const { container } = mount();
-    expect(container.querySelectorAll(".recipe-input-field")).toHaveLength(2);
+    expect(container.querySelectorAll(".field-group")).toHaveLength(2);
   });
 
   it("renders the label for each input", () => {

--- a/__tests__/panels/recipe.test.ts
+++ b/__tests__/panels/recipe.test.ts
@@ -70,11 +70,11 @@ describe("rendering", () => {
 
   it("renders the label for each input", () => {
     const { container } = mount();
-    const labels = Array.from(container.querySelectorAll(".recipe-input-label")).map(
+    const labels = Array.from(container.querySelectorAll(".field-label")).map(
       (el) => el.textContent,
     );
-    expect(labels).toContain("Drive Folder");
-    expect(labels).toContain("What are you looking for?");
+    expect(labels).toContain("Drive Folder *");
+    expect(labels).toContain("What are you looking for? (optional)");
   });
 
   it("renders placeholder on the input element", () => {

--- a/__tests__/recipes.test.ts
+++ b/__tests__/recipes.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Integration tests for src/client/recipes.ts
+ *
+ * Exercises each recipe's template strings through interpolateTemplate to catch
+ * typos in placeholder/block syntax (e.g. mismatched closing tags) that would
+ * silently pass unit tests on either module in isolation.
+ */
+
+import { RECIPES } from "../src/client/recipes";
+import { interpolateTemplate } from "../src/server/utils";
+import type { RecipeColumn } from "../src/client/types";
+
+function getTemplateCol(cols: RecipeColumn[], role: RecipeColumn["role"]): string | null {
+  const col = cols.find((c) => c.role === role);
+  if (!col || col.fillStrategy.kind !== "template") return null;
+  return col.fillStrategy.template;
+}
+
+describe("document-summarization recipe", () => {
+  const recipe = RECIPES.find((r) => r.id === "document-summarization");
+
+  it("is registered in RECIPES", () => {
+    expect(recipe).toBeDefined();
+  });
+
+  describe("system-prompt template", () => {
+    const template = recipe ? getTemplateCol(recipe.prepTemplate, "system-prompt") : null;
+
+    it("uses a template fill strategy", () => {
+      expect(template).not.toBeNull();
+    });
+
+    it("renders cleanly with no optional inputs", () => {
+      const result = interpolateTemplate(template!, { folder: "", docType: "", focus: "" });
+      expect(result).not.toContain("{{");
+      expect(result).toContain("Briefing Assistant");
+      expect(result).not.toContain("Document type");
+      expect(result).not.toContain("Area of interest");
+    });
+
+    it("renders docType when provided", () => {
+      const result = interpolateTemplate(template!, {
+        folder: "",
+        docType: "court filing",
+        focus: "",
+      });
+      expect(result).toContain("Document type: court filing");
+      expect(result).not.toContain("Area of interest");
+      expect(result).not.toContain("{{");
+    });
+
+    it("renders focus when provided", () => {
+      const result = interpolateTemplate(template!, {
+        folder: "",
+        docType: "",
+        focus: "financial fraud",
+      });
+      expect(result).not.toContain("Document type");
+      expect(result).toContain("Area of interest: financial fraud");
+      expect(result).not.toContain("{{");
+    });
+
+    it("renders both optional inputs when provided", () => {
+      const result = interpolateTemplate(template!, {
+        folder: "",
+        docType: "FOIA response",
+        focus: "conflicts of interest",
+      });
+      expect(result).toContain("Document type: FOIA response");
+      expect(result).toContain("Area of interest: conflicts of interest");
+      expect(result).not.toContain("{{");
+    });
+  });
+});

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -437,9 +437,7 @@ describe("interpolateTemplate", () => {
   });
 
   it("replaces multiple placeholders in one string", () => {
-    expect(
-      interpolateTemplate("{{a}} and {{b}}", { a: "foo", b: "bar" }),
-    ).toBe("foo and bar");
+    expect(interpolateTemplate("{{a}} and {{b}}", { a: "foo", b: "bar" })).toBe("foo and bar");
   });
 
   it("replaces the same placeholder multiple times", () => {
@@ -452,5 +450,43 @@ describe("interpolateTemplate", () => {
 
   it("returns the string unchanged when no placeholders present", () => {
     expect(interpolateTemplate("no placeholders", { x: "y" })).toBe("no placeholders");
+  });
+
+  it("includes block content when the key has a non-empty value", () => {
+    expect(interpolateTemplate("{{#focus}}Focus: {{focus}}{{/focus}}", { focus: "fraud" })).toBe(
+      "Focus: fraud",
+    );
+  });
+
+  it("omits block content when the key is empty string", () => {
+    expect(interpolateTemplate("{{#focus}}Focus: {{focus}}{{/focus}}", { focus: "" })).toBe("");
+  });
+
+  it("omits block content when the key is missing from inputValues", () => {
+    expect(interpolateTemplate("{{#focus}}Focus: {{focus}}{{/focus}}", {})).toBe("");
+  });
+
+  it("handles multiple conditional blocks independently", () => {
+    expect(
+      interpolateTemplate(
+        "{{#docType}}Type: {{docType}}{{/docType}}\n{{#focus}}Focus: {{focus}}{{/focus}}",
+        { docType: "filing", focus: "" },
+      ),
+    ).toBe("Type: filing\n");
+  });
+
+  it("handles conditional blocks alongside simple placeholders", () => {
+    expect(
+      interpolateTemplate("Hello {{name}}{{#extra}} ({{extra}}){{/extra}}", {
+        name: "world",
+        extra: "detail",
+      }),
+    ).toBe("Hello world (detail)");
+  });
+
+  it("handles conditional blocks with multiline content", () => {
+    expect(interpolateTemplate("before\n{{#key}}line1\nline2\n{{/key}}after", { key: "yes" })).toBe(
+      "before\nline1\nline2\nafter",
+    );
   });
 });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -489,4 +489,12 @@ describe("interpolateTemplate", () => {
       "before\nline1\nline2\nafter",
     );
   });
+
+  it("handles two conditional blocks with the same key", () => {
+    expect(interpolateTemplate("{{#x}}first{{/x}}{{#x}}second{{/x}}", { x: "yes" })).toBe(
+      "firstsecond",
+    );
+
+    expect(interpolateTemplate("{{#x}}first{{/x}}{{#x}}second{{/x}}", { x: "" })).toBe("");
+  });
 });

--- a/docs/plans/2026-04-15-document-summarization-recipe-implementation.md
+++ b/docs/plans/2026-04-15-document-summarization-recipe-implementation.md
@@ -1,0 +1,223 @@
+# Document Summarization Recipe Redesign — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Update the document-summarization recipe for journalism use — two new optional inputs (document type, area of interest), a journalist-oriented BLUF system prompt using conditional template blocks, and the infrastructure to support those blocks.
+
+**Architecture:** Add a two-pass conditional block syntax (`{{#key}}...{{/key}}`) to `interpolateTemplate`, then update the recipe definition to use the new inputs and template. No new files; three existing files modified.
+
+**Tech Stack:** TypeScript, Jest, Rollup (no new dependencies)
+
+---
+
+### Task 1: Extend `interpolateTemplate` with conditional block support
+
+**Files:**
+- Modify: `src/server/utils.ts:145-151`
+- Test: `__tests__/utils.test.ts:434-456`
+
+**Step 1: Write the failing tests**
+
+Add the following cases to the `describe("interpolateTemplate", ...)` block in `__tests__/utils.test.ts`, just before the closing `});` on line 456:
+
+```typescript
+  it("includes block content when the key has a non-empty value", () => {
+    expect(
+      interpolateTemplate("{{#focus}}Focus: {{focus}}{{/focus}}", { focus: "fraud" }),
+    ).toBe("Focus: fraud");
+  });
+
+  it("omits block content when the key is empty string", () => {
+    expect(
+      interpolateTemplate("{{#focus}}Focus: {{focus}}{{/focus}}", { focus: "" }),
+    ).toBe("");
+  });
+
+  it("omits block content when the key is missing from inputValues", () => {
+    expect(
+      interpolateTemplate("{{#focus}}Focus: {{focus}}{{/focus}}", {}),
+    ).toBe("");
+  });
+
+  it("handles multiple conditional blocks independently", () => {
+    expect(
+      interpolateTemplate(
+        "{{#docType}}Type: {{docType}}{{/docType}}\n{{#focus}}Focus: {{focus}}{{/focus}}",
+        { docType: "filing", focus: "" },
+      ),
+    ).toBe("Type: filing\n");
+  });
+
+  it("handles conditional blocks alongside simple placeholders", () => {
+    expect(
+      interpolateTemplate("Hello {{name}}{{#extra}} ({{extra}}){{/extra}}", {
+        name: "world",
+        extra: "detail",
+      }),
+    ).toBe("Hello world (detail)");
+  });
+
+  it("handles conditional blocks with multiline content", () => {
+    expect(
+      interpolateTemplate("before\n{{#key}}line1\nline2\n{{/key}}after", { key: "yes" }),
+    ).toBe("before\nline1\nline2\nafter");
+  });
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+npx jest __tests__/utils.test.ts -t "interpolateTemplate" --no-coverage
+```
+
+Expected: 6 new tests FAIL with errors like `"Focus: fraud" !== ""`
+
+**Step 3: Implement two-pass interpolation**
+
+Replace the body of `interpolateTemplate` in `src/server/utils.ts` (lines 145–151):
+
+```typescript
+/**
+ * Replace {{inputId}} placeholders and {{#key}}...{{/key}} conditional blocks
+ * in a template string with values from a map.
+ *
+ * Conditional blocks: content is included only when the named key has a non-empty value.
+ * Simple placeholders: unknown keys are replaced with an empty string.
+ */
+export function interpolateTemplate(template: string, inputValues: Record<string, string>): string {
+  // Pass 1: conditional blocks — include content only if value is non-empty
+  const withBlocks = template.replace(
+    /\{\{#(\w+)\}\}([\s\S]*?)\{\{\/\1\}\}/g,
+    (_, id: string, content: string) => ((inputValues[id] ?? "") ? content : ""),
+  );
+  // Pass 2: simple interpolations
+  return withBlocks.replace(/\{\{(\w+)\}\}/g, (_, id: string) => inputValues[id] ?? "");
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+```bash
+npx jest __tests__/utils.test.ts -t "interpolateTemplate" --no-coverage
+```
+
+Expected: all 11 tests PASS (5 existing + 6 new)
+
+**Step 5: Run the full test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests PASS
+
+**Step 6: Commit**
+
+```bash
+git add src/server/utils.ts __tests__/utils.test.ts
+git commit -m "feat: add conditional block syntax to interpolateTemplate"
+```
+
+---
+
+### Task 2: Update the document-summarization recipe
+
+**Files:**
+- Modify: `src/client/recipes.ts`
+
+**Step 1: Replace the recipe definition**
+
+Replace the entire contents of `src/client/recipes.ts` with:
+
+```typescript
+import type { RecipeDefinition } from "./types";
+
+export const RECIPES: RecipeDefinition[] = [
+  {
+    id: "document-summarization",
+    name: "Document Summarization",
+    icon: "📄",
+    description: "Summarize files in a Google Drive folder",
+    inputs: [
+      {
+        id: "folder",
+        label: "Drive Folder",
+        required: true,
+        helperText: "Make sure you have access to this folder",
+        placeholder: "Paste Google Drive folder URL",
+      },
+      {
+        id: "docType",
+        label: "Document Type",
+        required: false,
+        placeholder: "e.g. court filing, FOIA response, annual report",
+      },
+      {
+        id: "focus",
+        label: "Area of Interest",
+        required: false,
+        placeholder: "e.g. financial fraud, conflicts of interest",
+      },
+    ],
+    prepTemplate: [
+      {
+        colTitle: "Drive Link",
+        fillStrategy: { kind: "list-drive-folder", inputId: "folder" },
+        role: "file-prompt",
+      },
+      {
+        colTitle: "System Prompt",
+        fillStrategy: {
+          kind: "template",
+          template:
+            "Role: You are a specialized Briefing Assistant. Your goal is to distill complex documents into ultra-concise, scannable summaries.\n\n" +
+            "Tone: Objective, professional, and dense with information but sparse with \"fluff\" words.\n\n" +
+            "Guidelines:\n" +
+            "  - Prioritize Utility: Focus on information that helps a user decide: \"Do I need to open the full file?\"\n" +
+            "  - Structure: Always start with a 1-sentence \"Bottom Line Up Front\" (BLUF). Follow with 3-5 high-impact bullet points.\n" +
+            "  - Constraint: Keep the entire output under 150 words.\n" +
+            "{{#docType}}  - Document type: {{docType}}\n{{/docType}}" +
+            "{{#focus}}  - Area of interest: {{focus}} — prioritize this above all else.\n{{/focus}}",
+        },
+        role: "system-prompt",
+      },
+      {
+        colTitle: "User Prompt",
+        fillStrategy: {
+          kind: "fill-value",
+          value: "Summarize the attached document.",
+        },
+        role: "text-prompt",
+      },
+      {
+        colTitle: "AI_Summarization",
+        fillStrategy: { kind: "create-empty" },
+        role: "output",
+      },
+    ],
+  },
+];
+```
+
+**Step 2: Type-check**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors
+
+**Step 3: Build**
+
+```bash
+npm run build
+```
+
+Expected: clean build, no errors
+
+**Step 4: Commit**
+
+```bash
+git add src/client/recipes.ts
+git commit -m "feat: update document-summarization recipe for journalism use"
+```

--- a/docs/plans/2026-04-15-document-summarization-recipe-redesign.md
+++ b/docs/plans/2026-04-15-document-summarization-recipe-redesign.md
@@ -1,0 +1,88 @@
+# Document Summarization Recipe Redesign
+
+**Date:** 2026-04-15
+**Status:** Ready for implementation
+
+## Goal
+
+Improve the document summarization recipe for a journalism use case: journalists doing first-pass review of source documents (court filings, FOIA responses, government reports, corporate records, etc.) from a Google Drive folder.
+
+## Recipe Metadata
+
+| Field | Value |
+|---|---|
+| `id` | `document-summarization` (unchanged) |
+| `name` | `Document Summarization` (unchanged) |
+| `icon` | `📄` (unchanged) |
+| `description` | `"Summarize files in a Google Drive folder"` (unchanged) |
+
+## Inputs
+
+| `id` | Label | Required | Placeholder |
+|---|---|---|---|
+| `folder` | Drive Folder | Yes | `"Paste Google Drive folder URL"` |
+| `docType` | Document Type | No | `"e.g. court filing, FOIA response, annual report"` |
+| `focus` | Area of Interest | No | `"e.g. financial fraud, conflicts of interest"` |
+
+Both `docType` and `focus` are optional. The recipe runs usefully with only the folder URL; the new fields narrow the model's lens when provided.
+
+## prepTemplate Columns
+
+| `colTitle` | `fillStrategy` | `role` |
+|---|---|---|
+| `Drive Link` | `list-drive-folder` from `folder` | `file-prompt` |
+| `System Prompt` | `template` (see below) | `system-prompt` |
+| `User Prompt` | `fill-value`: `"Summarize the attached document."` | `text-prompt` |
+| `AI_Summarization` | `create-empty` | `output` |
+
+The System Prompt column changes from `fill-value` to `template` to support interpolation of `docType` and `focus`. The User Prompt simplifies to a single static instruction.
+
+## Prompts
+
+### System Prompt (template strategy)
+
+```
+Role: You are a specialized Briefing Assistant. Your goal is to distill complex documents into ultra-concise, scannable summaries.
+
+Tone: Objective, professional, and dense with information but sparse with "fluff" words.
+
+Guidelines:
+  - Prioritize Utility: Focus on information that helps a user decide: "Do I need to open the full file?"
+  - Structure: Always start with a 1-sentence "Bottom Line Up Front" (BLUF). Follow with 3-5 high-impact bullet points.
+  - Constraint: Keep the entire output under 150 words.
+{{#docType}}  - Document type: {{docType}}{{/docType}}
+{{#focus}}  - Area of interest: {{focus}} — prioritize this above all else.{{/focus}}
+```
+
+**Design rationale:** `docType` and `focus` are batch-level context (same for every row), so they belong in the system prompt rather than the user prompt. Conditional blocks (`{{#key}}...{{/key}}`) ensure nothing leaks through when fields are left empty.
+
+### User Prompt (fill-value strategy)
+
+```
+Summarize the attached document.
+```
+
+## Required Infrastructure: Conditional Template Blocks
+
+The system prompt template requires extending `interpolateTemplate` in `src/server/utils.ts` to support `{{#key}}...{{/key}}` conditional blocks — content is included only when the named input is non-empty.
+
+### Implementation
+
+```typescript
+// src/server/utils.ts
+export function interpolateTemplate(template: string, inputValues: Record<string, string>): string {
+  // Pass 1: conditional blocks — include content only if value is non-empty
+  const withBlocks = template.replace(
+    /\{\{#(\w+)\}\}([\s\S]*?)\{\{\/\1\}\}/g,
+    (_, id: string, content: string) => (inputValues[id] ?? "") ? content : ""
+  );
+  // Pass 2: simple interpolations
+  return withBlocks.replace(/\{\{(\w+)\}\}/g, (_, id: string) => inputValues[id] ?? "");
+}
+```
+
+### Files to touch
+
+1. **`src/server/utils.ts`** — extend `interpolateTemplate` (two-pass regex)
+2. **`__tests__/utils.test.ts`** — add test cases for conditional block syntax
+3. **`src/client/recipes.ts`** — update the document-summarization recipe definition

--- a/src/client/panels/recipe.ts
+++ b/src/client/panels/recipe.ts
@@ -146,13 +146,15 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
 
     const inputsHtml = inputs
       .map((input) => {
-        const requiredMark = input.required ? `<span class="required"> *</span>` : "";
+        const optionalityMark = input.required
+          ? `<span class="required"> *</span>`
+          : `<span class="optional"> (optional)</span>`;
         const helperHtml = input.helperText
           ? `<p class="field-helper">${input.helperText}</p>`
           : "";
         return `
           <div class="recipe-input-field">
-            <label class="recipe-input-label">${input.label}</label>${requiredMark}
+            <span class="field-label">${input.label}${optionalityMark}</span>
             ${helperHtml}
             <input
               data-input-id="${input.id}"

--- a/src/client/panels/recipe.ts
+++ b/src/client/panels/recipe.ts
@@ -166,11 +166,14 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
       })
       .join("");
 
+    const introHtml = definition?.intro ? `<p class="recipe-intro">${definition.intro}</p>` : "";
+
     return `
       <div class="panel-header">
         <button id="back-btn" class="back-btn">← Back</button>
         <span class="panel-title">${title}</span>
       </div>
+      ${introHtml}
       ${inputsHtml}
       <div id="prep-cook-container"></div>
     `;

--- a/src/client/panels/recipe.ts
+++ b/src/client/panels/recipe.ts
@@ -153,7 +153,7 @@ export class RecipePanel implements Panel<RecipeDefinition, SavedState> {
           ? `<p class="field-helper">${input.helperText}</p>`
           : "";
         return `
-          <div class="recipe-input-field">
+          <div class="field-group">
             <span class="field-label">${input.label}${optionalityMark}</span>
             ${helperHtml}
             <input

--- a/src/client/recipes.ts
+++ b/src/client/recipes.ts
@@ -23,14 +23,14 @@ export const RECIPES: RecipeDefinition[] = [
         required: false,
         helperText:
           "Helps the AI read the document — legal language reads differently than a financial disclosure",
-        placeholder: "e.g. court docket, FOIA response, annual report",
+        placeholder: "e.g. court docket, email",
       },
       {
         id: "focus",
         label: "Area of Interest",
         required: false,
         helperText: "The AI will prioritize this above all else in the summary",
-        placeholder: "e.g. relationships between people, financial fraud",
+        placeholder: "e.g. specific people, financial fraud",
       },
     ],
     prepTemplate: [

--- a/src/client/recipes.ts
+++ b/src/client/recipes.ts
@@ -43,7 +43,7 @@ export const RECIPES: RecipeDefinition[] = [
             'Tone: Objective, professional, and dense with information but sparse with "fluff" words.\n\n' +
             "Guidelines:\n" +
             '  - Prioritize Utility: Focus on information that helps a user decide: "Do I need to open the full file?"\n' +
-            '  - Structure: Always start with a 1-sentence "Bottom Line Up Front" (BLUF). Follow with 3-5 high-impact bullet points.\n' +
+            "  - Structure: Always start with a 1-sentence bottom line (no label or prefix — just the sentence). Follow with 3-5 high-impact bullet points.\n" +
             "  - Constraint: Keep the entire output under 150 words.\n" +
             "{{#docType}}  - Document type: {{docType}}\n{{/docType}}" +
             "{{#focus}}  - Area of interest: {{focus}} — prioritize this above all else.\n{{/focus}}",

--- a/src/client/recipes.ts
+++ b/src/client/recipes.ts
@@ -6,12 +6,16 @@ export const RECIPES: RecipeDefinition[] = [
     name: "Document Summarization",
     icon: "📄",
     description: "Summarize files in a Google Drive folder",
+    intro:
+      "This recipe reads every file in a Drive folder and generates a tight, scannable summary for each one — designed to help you triage a large document set quickly. " +
+      "For best results, point it at a folder of similar documents (e.g. all court filings from one case, or a set of FOIA responses). " +
+      "Specifying a document type helps the AI parse the format correctly; specifying an area of interest focuses the summary on what matters for your story.",
     inputs: [
       {
         id: "folder",
         label: "Drive Folder",
         required: true,
-        helperText: "Make sure you have access to this folder",
+        helperText: "The folder of documents to summarize. Make sure you have access.",
         placeholder: "Paste Google Drive folder URL",
       },
       {
@@ -19,7 +23,7 @@ export const RECIPES: RecipeDefinition[] = [
         label: "Document Type",
         required: false,
         helperText:
-          "Helps the AI read the document correctly — legal language reads differently than a financial disclosure",
+          "Helps the AI read the document — legal language reads differently than a financial disclosure",
         placeholder: "e.g. court docket, FOIA response, annual report",
       },
       {

--- a/src/client/recipes.ts
+++ b/src/client/recipes.ts
@@ -5,7 +5,7 @@ export const RECIPES: RecipeDefinition[] = [
     id: "document-summarization",
     name: "Document Summarization",
     icon: "📄",
-    description: "Summarize each file in a Google Drive folder",
+    description: "Summarize files in a Google Drive folder",
     inputs: [
       {
         id: "folder",
@@ -13,6 +13,18 @@ export const RECIPES: RecipeDefinition[] = [
         required: true,
         helperText: "Make sure you have access to this folder",
         placeholder: "Paste Google Drive folder URL",
+      },
+      {
+        id: "docType",
+        label: "Document Type",
+        required: false,
+        placeholder: "e.g. court filing, FOIA response, annual report",
+      },
+      {
+        id: "focus",
+        label: "Area of Interest",
+        required: false,
+        placeholder: "e.g. financial fraud, conflicts of interest",
       },
     ],
     prepTemplate: [
@@ -24,10 +36,16 @@ export const RECIPES: RecipeDefinition[] = [
       {
         colTitle: "System Prompt",
         fillStrategy: {
-          kind: "fill-value",
-          value:
-            "You are an expert document analyst. Produce clear, structured summaries " +
-            "focusing on key themes, main arguments, important data points, and actionable conclusions.",
+          kind: "template",
+          template:
+            "Role: You are a specialized Briefing Assistant. Your goal is to distill complex documents into ultra-concise, scannable summaries.\n\n" +
+            'Tone: Objective, professional, and dense with information but sparse with "fluff" words.\n\n' +
+            "Guidelines:\n" +
+            '  - Prioritize Utility: Focus on information that helps a user decide: "Do I need to open the full file?"\n' +
+            '  - Structure: Always start with a 1-sentence "Bottom Line Up Front" (BLUF). Follow with 3-5 high-impact bullet points.\n' +
+            "  - Constraint: Keep the entire output under 150 words.\n" +
+            "{{#docType}}  - Document type: {{docType}}\n{{/docType}}" +
+            "{{#focus}}  - Area of interest: {{focus}} — prioritize this above all else.\n{{/focus}}",
         },
         role: "system-prompt",
       },
@@ -35,9 +53,7 @@ export const RECIPES: RecipeDefinition[] = [
         colTitle: "User Prompt",
         fillStrategy: {
           kind: "fill-value",
-          value:
-            "Please summarize the attached document. Include the main topics, key findings, " +
-            "and important conclusions. The document file will be attached as inline data.",
+          value: "Summarize the attached document.",
         },
         role: "text-prompt",
       },

--- a/src/client/recipes.ts
+++ b/src/client/recipes.ts
@@ -8,8 +8,7 @@ export const RECIPES: RecipeDefinition[] = [
     description: "Summarize files in a Google Drive folder",
     intro:
       "This recipe reads every file in a Drive folder and generates a tight, scannable summary for each one — designed to help you triage a large document set quickly. " +
-      "For best results, point it at a folder of similar documents (e.g. all court filings from one case, or a set of FOIA responses). " +
-      "Specifying a document type helps the AI parse the format correctly; specifying an area of interest focuses the summary on what matters for your story.",
+      "For best results, point it at a folder of similar documents (e.g. all court filings from one case, or a set of FOIA responses).",
     inputs: [
       {
         id: "folder",

--- a/src/client/recipes.ts
+++ b/src/client/recipes.ts
@@ -18,12 +18,15 @@ export const RECIPES: RecipeDefinition[] = [
         id: "docType",
         label: "Document Type",
         required: false,
+        helperText:
+          "Helps the AI read the document correctly — legal language reads differently than a financial disclosure",
         placeholder: "e.g. court docket, FOIA response, annual report",
       },
       {
         id: "focus",
         label: "Area of Interest",
         required: false,
+        helperText: "The AI will prioritize this above all else in the summary",
         placeholder: "e.g. relationships between people, financial fraud",
       },
     ],

--- a/src/client/recipes.ts
+++ b/src/client/recipes.ts
@@ -18,21 +18,16 @@ export const RECIPES: RecipeDefinition[] = [
         id: "docType",
         label: "Document Type",
         required: false,
-        placeholder: "e.g. court filing, FOIA response, annual report",
+        placeholder: "e.g. court docket, FOIA response, annual report",
       },
       {
         id: "focus",
         label: "Area of Interest",
         required: false,
-        placeholder: "e.g. financial fraud, conflicts of interest",
+        placeholder: "e.g. relationships between people, financial fraud",
       },
     ],
     prepTemplate: [
-      {
-        colTitle: "Drive Link",
-        fillStrategy: { kind: "list-drive-folder", inputId: "folder" },
-        role: "file-prompt",
-      },
       {
         colTitle: "System Prompt",
         fillStrategy: {
@@ -50,12 +45,9 @@ export const RECIPES: RecipeDefinition[] = [
         role: "system-prompt",
       },
       {
-        colTitle: "User Prompt",
-        fillStrategy: {
-          kind: "fill-value",
-          value: "Summarize the attached document.",
-        },
-        role: "text-prompt",
+        colTitle: "Drive Link",
+        fillStrategy: { kind: "list-drive-folder", inputId: "folder" },
+        role: "file-prompt",
       },
       {
         colTitle: "AI_Summarization",

--- a/src/client/sidebar.css
+++ b/src/client/sidebar.css
@@ -426,6 +426,13 @@
             line-height: 1.4;
         }
 
+        .recipe-intro {
+            font-size: 12px;
+            color: var(--text-secondary);
+            line-height: 1.5;
+            margin: 0 0 16px 0;
+        }
+
         /* ── LockableField layouts ── */
 
         .lockable-field-header {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -99,6 +99,8 @@ export interface RecipeDefinition {
   name: string;
   icon: string;
   description: string;
+  /** Optional longer description rendered at the top of the recipe panel. */
+  intro?: string;
   /** Journalist-facing form fields. Drives RecipePanel rendering. */
   inputs: RecipeInput[];
   /**

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -148,6 +148,7 @@ export function writeJobProgress(
  *
  * Conditional blocks: content is included only when the named key has a non-empty value.
  * Simple placeholders: unknown keys are replaced with an empty string.
+ * Nesting conditional blocks is not supported.
  */
 export function interpolateTemplate(template: string, inputValues: Record<string, string>): string {
   // Pass 1: conditional blocks — include content only if value is non-empty

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -143,11 +143,20 @@ export function writeJobProgress(
 }
 
 /**
- * Replace {{inputId}} placeholders in a template string with values from a map.
- * Unknown placeholders are replaced with an empty string.
+ * Replace {{inputId}} placeholders and {{#key}}...{{/key}} conditional blocks
+ * in a template string with values from a map.
+ *
+ * Conditional blocks: content is included only when the named key has a non-empty value.
+ * Simple placeholders: unknown keys are replaced with an empty string.
  */
 export function interpolateTemplate(template: string, inputValues: Record<string, string>): string {
-  return template.replace(/\{\{(\w+)\}\}/g, (_, id: string) => inputValues[id] ?? "");
+  // Pass 1: conditional blocks — include content only if value is non-empty
+  const withBlocks = template.replace(
+    /\{\{#(\w+)\}\}([\s\S]*?)\{\{\/\1\}\}/g,
+    (_, id: string, content: string) => ((inputValues[id] ?? "") ? content : ""),
+  );
+  // Pass 2: simple interpolations
+  return withBlocks.replace(/\{\{(\w+)\}\}/g, (_, id: string) => inputValues[id] ?? "");
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds two optional journalist inputs to the document-summarization recipe: **Document Type** and **Area of Interest**
- Rewrites system prompt to a journalist-oriented BLUF structure; optional inputs are conditionally injected via `{{#key}}...{{/key}}` template blocks
- Extends `interpolateTemplate` with conditional block syntax (content included only when key is non-empty) — infrastructure the recipe depends on
- Adds integration tests that exercise the recipe template string through interpolation, catching future typos in block syntax

## Test Plan

- [x] All 439 tests pass (`npm test`)
- [x] Typecheck clean (`npm run typecheck`)
- [x] Build clean (`npm run build`)
- [x] 12 unit tests cover `interpolateTemplate` conditional block behavior
- [x] 6 integration tests exercise the recipe template with all input combinations (no inputs / docType only / focus only / both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)