### PR TITLE
docs: update architecture.md and CLAUDE.md to reflect recipe redesign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,13 @@ src/client/sidebar-entry.ts  (thin init — instantiates all panels, creates Rou
     ├── lockable-field.ts        (LockableField — value + lock/unlock toggle; optional onUnlock callback)
     ├── recipe-prep-cook.ts      (RecipePrepCook — 4-state machine: idle/prepping/prep-complete/cooking)
     ├── panel-loader.ts          (PanelLoader — drives panel loading skeleton: progress bar, spinner, message)
-    └── job-indicator.ts         (JobIndicator — renders active/failed jobs to #job-strip; persists across navigation)
+    ├── job-indicator.ts         (JobIndicator — renders active/failed jobs to #job-strip; persists across navigation)
+    ├── token-input.ts           (TokenInput — searchable chip field for column selection; multi or single-select;
+    │                             supports includeNew for new column creation; use when item count is 8+ or items are
+    │                             dynamic headers. Prefer TagList when count is small and all options benefit from
+    │                             simultaneous display, e.g. the Tools section with ~5 fixed entries.)
+    └── prompt-col-list.ts       (PromptColList — ordered list of PromptColumnSpec rows; each row pairs a
+                                  TokenInput column picker with a text/file kind toggle and reorder controls)
     └── src/shared/types.ts
 
 src/client/google.d.ts       (compile-time type stub for google.script.run — uses declare global{} pattern)
@@ -155,11 +161,34 @@ The Gemini tool system spans three layers. `ToolId` (a string union in `shared/t
 
 `buildGeminiPayload` in `api.ts` resolves `ToolId[]` via `TOOL_REGISTRY`, splits by `kind`, and assembles both shapes into the `tools` array of the REST request.
 
-**Propagation path:** `ConfigureAIRunPanel` (UI TagList) → `RunConfig.tools` → `runBatchAI` → `runInference(tools?)` → `invokeGemini` → `callGeminiAPI` → `buildGeminiPayload`. For recipes: `RecipePanel` → `PrepRecipeParams.tools` → server echoes back as `PrepRecipeResult.tools` → assembled into `preppedRunConfig`.
+**Propagation path:** `ConfigureAIRunPanel` (UI TagList) → `RunConfig.tools` → `runBatchAI` → `runInference(tools?)` → `invokeGemini` → `callGeminiAPI` → `buildGeminiPayload`. For recipes: `RecipePanel` → `PrepRecipeParams.cols + inputValues` → server resolves `inputId` references and writes columns → `PrepRecipeResult.rowRange` → client calls `buildRunTemplate(prepTemplate)` (derives `promptCols`/`systemPromptCol`/`outputCol` from `RecipeColumn.role`) merged with `definition.settings` and `rowRange` → `preppedRunConfig`.
 
 Source files use relative imports (e.g. `../shared/types`). The `@server/*` and `@shared/*` aliases are **Jest-only** (mapped in `jest.config.cjs`) and are not available in TypeScript source.
 
 Only `index.ts` should reference Google Apps Script UI services (SpreadsheetApp, HtmlService, PropertiesService). On the client side, only `services.ts` calls `google.script.run` (wrapping each call as a Promise); `sidebar-entry.ts` is a thin init file that creates the Router and calls `router.start()`.
+
+### Recipe System
+
+Recipes are journalist-facing presets that automate column setup and launch a Run AI. Each `RecipeDefinition` in `src/client/recipes.ts` has four parts:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `inputs` | `RecipeInput[]` | Journalist-facing form fields rendered by `RecipePanel` |
+| `prepTemplate` | `RecipeColumn[]` | Column definitions sent to `prepRecipe()` on the server |
+| `settings` | `RecipeSettings?` | Non-column `RunConfig` fields (tools, markdown, grounding, etc.) |
+| Discovery fields | `id`, `name`, `icon`, `description`, `intro?` | Rendered in the recipes list and recipe header |
+
+**`RecipeColumn`** (`src/client/types.ts`) = `PrepColSpec` + optional `role?: ColumnRole`. The `role` is client-only — `buildRunTemplate()` in `recipe.ts` maps roles to `promptCols`, `systemPromptCol`, and `outputCol` at cook time. Roles: `"file-prompt"` | `"text-prompt"` | `"system-prompt"` | `"output"`.
+
+**`FillStrategy`** (`src/shared/types.ts`) controls how `prepRecipe()` populates each column:
+- `{ kind: "fill-value"; value: string }` — writes a static string to every row
+- `{ kind: "list-drive-folder"; inputId: string }` — lists files from the folder URL in `inputValues[inputId]`
+- `{ kind: "create-empty" }` — creates the column with no content
+- `{ kind: "template"; template: string }` — interpolates `{{inputId}}` placeholders; supports Mustache-style conditionals `{{#inputId}}...{{/inputId}}` (block is omitted when the input is empty)
+
+**`RecipeInput.id`** must be camelCase or underscore_separated — no hyphens. The template interpolation regex uses `\w+` which does not match `-`.
+
+**To add a new recipe:** add an entry to `RECIPES` in `src/client/recipes.ts`. No other files need changing unless you need a new `FillStrategy` kind.
 
 ### TypeScript Configuration
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ HtmlService can only serve `.html` files. A custom Rollup plugin inlines all JS 
 
 ## `google.d.ts` — Hand-Maintained
 
-`src/client/google.d.ts` is the TypeScript declaration for `google.script.run`. It is **not auto-generated** — it must be manually updated whenever a server function is added or removed. If you skip this, the client will typecheck against stale declarations and only fail at runtime.
+`src/client/google.d.ts` is the TypeScript declaration for `google.script.run`. It is **not auto-generated** — it must be manually updated whenever a server function that is callable from the client is added or removed. Not every server function belongs here: only functions invoked via `google.script.run` from the sidebar need a declaration. If you skip this for a client-callable function, the client will typecheck against stale declarations and only fail at runtime.
 
 ## Tool System
 
@@ -49,11 +49,21 @@ The Gemini tool system spans three layers, linked by `ToolId` (a string union in
 
 `GeminiTool` is a discriminated union: `{ kind: "grounding" }` produces `{ [id]: {} }` in the Gemini REST payload; `{ kind: "function" }` produces `{ function_declarations: [...] }`.
 
+## `RunConfig` — The AI Run Descriptor
+
+`RunConfig` (in `src/shared/types.ts`) is the central data type for an AI run. It crosses the `google.script.run` boundary when the client calls `runBatchAI`, and it's the output both `ConfigureAIRunPanel` and `RecipePanel` produce.
+
+The key field is `promptCols: PromptColumnSpec[]` — an **ordered** list of `{ col: string; kind: "text" | "file" }` entries. Order matters: parts are assembled into the Gemini request in the sequence they appear, allowing a recipe or user to interleave text and file columns arbitrarily (e.g. file first, then a text instruction column). Each entry's `kind` determines whether the column value is sent as inline text or fetched and base64-encoded as a Drive file.
+
+Other fields: `systemPromptCol` (optional system instruction column), `outputCol` (where results are written), `tools?: ToolId[]`, `includeGrounding`, `applyMarkdown`, `prefixWithColName` (prepends `"<col>: "` to each text part), and `rowRange`.
+
 ## Panel / Router System
 
 The client uses a lightweight navigation system: `Router` (`src/client/router.ts`) manages a push/pop navigation stack, and each `Panel` implementation handles its own render and state.
 
-**Recipes** are a workflow layer built on top of Run AI. Each `RecipeDefinition` in `src/client/recipes.ts` describes display metadata, the form fields shown during prep, and how those fields map to a `RunConfig`. The generic `RecipePanel` drives a four-state prep/cook machine: the user fills in parameters (prep), the server writes any required columns and returns a fully assembled `RunConfig` (prep-complete), and the user launches the AI run (cooking). The `preppedRunConfig` comes entirely from the server response — not from client form state — making it the single source of truth for what gets executed.
+**Recipes** are a workflow layer built on top of Run AI. Each `RecipeDefinition` in `src/client/recipes.ts` has four parts: journalist-facing `inputs` (form fields), a `prepTemplate` of `RecipeColumn` entries (column definitions with fill strategies and AI roles), optional `settings` (non-column `RunConfig` fields like tools or markdown), and display metadata. The generic `RecipePanel` drives a four-state prep/cook machine: the user fills in inputs (prep), the server writes the required columns and returns a `rowRange` (prep-complete), and the user launches the AI run (cooking).
+
+The `preppedRunConfig` is assembled client-side at prep-complete time from three sources: `buildRunTemplate(prepTemplate)` derives `promptCols`, `systemPromptCol`, and `outputCol` from each `RecipeColumn.role`; `definition.settings` contributes non-column options; and `result.rowRange` comes from the server. The server never constructs or returns a `RunConfig` — it only writes spreadsheet columns and reports back the populated row range.
 
 ## TypeScript Configuration
 


### PR DESCRIPTION
- Add TokenInput and PromptColList to CLAUDE.md component graph
- Add Recipe System section to CLAUDE.md (RecipeDefinition shape, RecipeColumn.role, FillStrategy kinds including template syntax, RecipeInput.id naming constraint)
- Fix stale recipe propagation path in Tool System section (server no longer echoes back RunConfig; preppedRunConfig is assembled client-side)
- Add RunConfig / PromptColumnSpec section to architecture.md
- Fix google.d.ts description to clarify only client-callable functions need declarations, not every server function
- Update architecture.md recipes description to match new RecipeDefinition shape and correct preppedRunConfig assembly flow

## Summary

-
-

## Manual QA

> Complete for PRs targeting `main`. Mark N/A with reason for PRs targeting `develop`.

- [ ] Add-on menu appears after opening a Sheet
- [ ] Sidebar opens without errors
- [ ] Import Drive Links — imports files from a folder
- [ ] Extract Text — extracts text from a Doc/PDF/image
- [ ] Sample Rows — samples rows reproducibly with a seed
- [ ] Run AI — batch inference completes and writes output column
- [ ] Tested on a Sheet the tester does not own (shared access)

## Notes

<!-- Anything reviewers or QA testers should know -->
