### PR TITLE
Standardize font sizes, colors, and families

### DIFF
--- a/src/Sidebar.html
+++ b/src/Sidebar.html
@@ -3,6 +3,9 @@
 
 <head>
     <base target="_top">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Flex:opsz,wdth,wght@6..144,75..125,100..700&display=swap" rel="stylesheet">
     {{STYLES}}
 </head>
 

--- a/src/client/sidebar.css
+++ b/src/client/sidebar.css
@@ -2,8 +2,16 @@
             --primary-blue: #1a73e8;
             --hover-blue: #f1f3f4;
             --border-color: #dadce0;
-            --text-main: #3c4043;
-            --text-secondary: #5f6368;
+            --text-main: rgb(31, 31, 31);
+            --text-secondary: rgb(57, 57, 57);
+
+            --font-family: "Google Sans Flex", Roboto, sans-serif;
+
+            --font-size-100: 11px;
+            --font-size-200: 12px;
+            --font-size-300: 14px;
+            --font-size-400: 16px;
+            --font-size-500: 18px;
         }
 
         html, body {
@@ -15,9 +23,10 @@
             padding: 0;
             display: flex;
             flex-direction: column;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+            font-family: var(--font-family);
             background-color: #ffffff;
             color: var(--text-main);
+            font-optical-sizing: auto;
         }
 
         #app {
@@ -32,7 +41,7 @@
         .section { margin-bottom: 28px; }
 
         h3 {
-            font-size: 11px;
+            font-size: var(--font-size-100);
             font-style: italic;
             font-weight: 500;
             color: var(--text-secondary);
@@ -53,8 +62,8 @@
             background: white;
             cursor: pointer;
             transition: all 0.2s ease;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
-            font-size: 14px;
+            font-family: var(--font-family);
+            font-size: var(--font-size-300);
             font-weight: 500;
             color: var(--text-main);
         }
@@ -67,13 +76,13 @@
 
         .tool-btn:active { background-color: #e8eaed; transform: scale(0.98); }
 
-        .icon { margin-right: 12px; font-size: 18px; width: 24px; text-align: center; }
+        .icon { margin-right: 12px; font-size: var(--font-size-500); width: 24px; text-align: center; }
 
         .status-footer {
             margin-top: 40px;
             padding: 16px;
             border-top: 1px solid #eee;
-            font-size: 11px;
+            font-size: var(--font-size-100);
             font-style: italic;
             color: var(--text-secondary);
             text-align: center;
@@ -96,8 +105,8 @@
             border: none;
             color: var(--primary-blue);
             cursor: pointer;
-            font-size: 14px;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+            font-size: var(--font-size-300);
+            font-family: var(--font-family);
             padding: 0;
         }
 
@@ -106,7 +115,7 @@
             border: none;
             color: var(--text-secondary);
             cursor: pointer;
-            font-size: 16px;
+            font-size: var(--font-size-400);
             padding: 0;
             margin-left: auto;
             line-height: 1;
@@ -169,7 +178,7 @@
         }
 
         .panel-loader__message {
-            font-size: 12px;
+            font-size: var(--font-size-200);
             color: #5f6368;
             margin: 0;
             text-align: center;
@@ -181,7 +190,7 @@
             color: var(--text-secondary);
         }
 
-        .panel-title { font-weight: 500; font-size: 15px; }
+        .panel-title { font-weight: 500; font-size: var(--font-size-400); }
 
         .field-group { margin-bottom: 16px; }
 
@@ -192,17 +201,14 @@
 
         .field-label {
             display: block;
-            font-size: 11px;
-            font-style: italic;
+            font-size: var(--font-size-300);
             font-weight: 500;
-            color: var(--text-secondary);
-            text-transform: uppercase;
-            letter-spacing: 0.7px;
+            color: var(--text-main);
             margin-bottom: 6px;
         }
 
         .required { color: #d93025; }
-        .optional { color: var(--text-secondary); font-weight: 400; text-transform: none; letter-spacing: 0; font-size: 11px; }
+        .optional { color: var(--text-secondary); font-weight: 400; text-transform: none; letter-spacing: 0; font-size: var(--font-size-200); }
 
         .tag-list {
             display: flex;
@@ -216,8 +222,8 @@
             border: 1px solid var(--border-color);
             background: white;
             color: var(--text-main);
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
-            font-size: 12px;
+            font-family: var(--font-family);
+            font-size: var(--font-size-200);
             cursor: pointer;
             transition: all 0.15s;
             max-width: 100%;
@@ -243,8 +249,8 @@
             padding: 7px 8px;
             border: 1px solid var(--border-color);
             border-radius: 4px;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
-            font-size: 13px;
+            font-family: var(--font-family);
+            font-size: var(--font-size-300);
             color: var(--text-main);
             box-sizing: border-box;
         }
@@ -254,8 +260,8 @@
             padding: 7px 8px;
             border: 1px solid var(--border-color);
             border-radius: 4px;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
-            font-size: 13px;
+            font-family: var(--font-family);
+            font-size: var(--font-size-300);
             margin-top: 6px;
             box-sizing: border-box;
         }
@@ -264,7 +270,7 @@
             display: flex;
             flex-direction: column;
             gap: 6px;
-            font-size: 13px;
+            font-size: var(--font-size-300);
         }
 
         .row-range-options label {
@@ -280,8 +286,8 @@
             padding: 6px 8px;
             border: 1px solid var(--border-color);
             border-radius: 4px;
-            font-size: 13px;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+            font-size: var(--font-size-300);
+            font-family: var(--font-family);
             box-sizing: border-box;
         }
 
@@ -294,9 +300,9 @@
             color: white;
             border: none;
             border-radius: 4px;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+            font-family: var(--font-family);
             font-weight: 500;
-            font-size: 14px;
+            font-size: var(--font-size-300);
             cursor: pointer;
         }
 
@@ -310,9 +316,9 @@
             color: var(--primary-blue);
             border: 1px solid var(--primary-blue);
             border-radius: 4px;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+            font-family: var(--font-family);
             font-weight: 500;
-            font-size: 14px;
+            font-size: var(--font-size-300);
             cursor: pointer;
         }
 
@@ -325,13 +331,13 @@
             color: var(--text-main);
             border: 1px solid var(--border-color);
             border-radius: 4px;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
-            font-size: 14px;
+            font-family: var(--font-family);
+            font-size: var(--font-size-300);
             cursor: pointer;
         }
 
         .no-headers-msg {
-            font-size: 13px;
+            font-size: var(--font-size-300);
             color: var(--text-secondary);
             text-align: center;
             padding: 24px 0;
@@ -342,7 +348,7 @@
             display: flex;
             align-items: center;
             gap: 6px;
-            font-size: 11px;
+            font-size: var(--font-size-100);
             font-style: italic;
             color: var(--text-secondary);
             margin-top: 10px;
@@ -353,7 +359,7 @@
         .grounding-col-badge {
             display: inline-block;
             font-family: "SFMono-Regular", "Consolas", monospace;
-            font-size: 10px;
+            font-size: var(--font-size-100);
             background: #f1f3f4;
             border: 1px solid var(--border-color);
             border-radius: 3px;
@@ -373,8 +379,7 @@
         }
 
         .tool-btn-sub {
-            font-size: 11px;
-            font-style: italic;
+            font-size: var(--font-size-200);
             color: var(--text-secondary);
             font-weight: 400;
             line-height: 1.3;
@@ -394,8 +399,8 @@
             border: 1px dashed var(--border-color);
             background: #f8f9fa;
             color: var(--text-secondary);
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
-            font-size: 14px;
+            font-family: var(--font-family);
+            font-size: var(--font-size-300);
             font-style: italic;
             cursor: default;
             box-sizing: border-box;
@@ -411,7 +416,7 @@
         }
 
         .recipe-section-card-title {
-            font-size: 10px;
+            font-size: var(--font-size-100);
             font-weight: 600;
             text-transform: uppercase;
             letter-spacing: 0.8px;
@@ -420,14 +425,14 @@
         }
 
         .field-helper {
-            font-size: 11px;
+            font-size: var(--font-size-200);
             color: var(--text-secondary);
             margin: 2px 0 8px 0;
             line-height: 1.4;
         }
 
         .recipe-intro {
-            font-size: 12px;
+            font-size: var(--font-size-200);
             color: var(--text-secondary);
             line-height: 1.5;
             margin: 0 0 16px 0;
@@ -470,12 +475,12 @@
             border: 1px solid var(--border-color);
             border-radius: 4px;
             color: var(--text-secondary);
-            font-size: 11px;
+            font-size: var(--font-size-100);
             font-style: italic;
             cursor: pointer;
             padding: 3px 6px;
             white-space: nowrap;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+            font-family: var(--font-family);
             line-height: 1.4;
         }
 
@@ -503,7 +508,7 @@
           display: flex;
           align-items: center;
           gap: 6px;
-          font-size: 11px;
+          font-size: var(--font-size-100);
           color: #5f6368;
         }
 
@@ -540,7 +545,7 @@
   border: none;
   color: inherit;
   cursor: pointer;
-  font-size: 11px;
+  font-size: var(--font-size-100);
   line-height: 1;
   opacity: 0.6;
   padding: 0 2px;
@@ -551,7 +556,7 @@
 }
 
 .job-strip__cancelling {
-  font-size: 11px;
+  font-size: var(--font-size-100);
   font-style: italic;
   opacity: 0.6;
 }
@@ -581,7 +586,7 @@
             border: none;
             cursor: pointer;
             color: #1a73e8;
-            font-size: 13px;
+            font-size: var(--font-size-300);
             line-height: 1;
             padding: 0 0 0 2px;
             opacity: 0.7;
@@ -594,7 +599,7 @@
         .token-chip-input {
             border: none;
             outline: none;
-            font-size: 12px;
+            font-size: var(--font-size-200);
             color: #1a73e8;
             width: 120px;
             background: transparent;
@@ -611,7 +616,7 @@
             outline: none;
             border-bottom: 1px solid #dadce0;
             padding: 6px 10px;
-            font-size: 13px;
+            font-size: var(--font-size-300);
             color: #202124;
             background: transparent;
             box-sizing: border-box;
@@ -637,7 +642,7 @@
 
         .token-option {
             padding: 7px 12px;
-            font-size: 13px;
+            font-size: var(--font-size-300);
             cursor: pointer;
             color: #202124;
         }
@@ -648,7 +653,7 @@
 
         .token-no-match {
             padding: 7px 12px;
-            font-size: 13px;
+            font-size: var(--font-size-300);
             color: #9aa0a6;
             font-style: italic;
         }
@@ -674,7 +679,7 @@
           border: 1px solid var(--border-color);
           border-radius: 12px;
           padding: 2px 8px;
-          font-size: 11px;
+          font-size: var(--font-size-100);
           color: var(--text-secondary);
           cursor: pointer;
           white-space: nowrap;
@@ -693,7 +698,7 @@
           border: none;
           cursor: pointer;
           color: var(--text-secondary);
-          font-size: 13px;
+          font-size: var(--font-size-300);
           padding: 2px 4px;
           line-height: 1;
         }
@@ -711,10 +716,10 @@
           border: 1px solid var(--border-color);
           border-radius: 4px;
           color: var(--text-secondary);
-          font-size: 12px;
+          font-size: var(--font-size-200);
           padding: 5px 8px;
           cursor: pointer;
-          font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+          font-family: var(--font-family);
           box-sizing: border-box;
         }
 
@@ -739,7 +744,7 @@
         }
 
         .collapsible-label {
-            font-size: 11px;
+            font-size: var(--font-size-100);
             font-style: italic;
             font-weight: 500;
             color: var(--text-secondary);
@@ -750,7 +755,7 @@
         .collapsible-summary {
             flex: 1;
             min-width: 0;
-            font-size: 11px;
+            font-size: var(--font-size-100);
             color: var(--text-secondary);
             font-style: italic;
             overflow: hidden;
@@ -759,7 +764,7 @@
         }
 
         .collapsible-chevron {
-            font-size: 10px;
+            font-size: var(--font-size-100);
             color: var(--text-secondary);
             transition: transform 0.15s ease;
             flex-shrink: 0;


### PR DESCRIPTION
## Summary

Make the sidebar text better match Google Sheets. I am using the same typeface, colors, and sizes. Note: I'm not set up to be able to test this beyond the Main View and the Recipe View. I am not able to run "Run AI Inference" locally at this time.

<img width="414" height="612" alt="Screenshot 2026-04-21 at 5 57 11 PM" src="https://github.com/user-attachments/assets/d646fdff-1896-4bc6-a4c5-e7039e8a1e10" />

## Manual QA

> Complete for PRs targeting `main`. Mark N/A with reason for PRs targeting `develop`.

- [ ] Add-on menu appears after opening a Sheet
- [ ] Sidebar opens without errors
- [ ] Import Drive Links — imports files from a folder
- [ ] Extract Text — extracts text from a Doc/PDF/image
- [ ] Sample Rows — samples rows reproducibly with a seed
- [ ] Run AI — batch inference completes and writes output column
- [ ] Tested on a Sheet the tester does not own (shared access)

## Notes

<!-- Anything reviewers or QA testers should know -->
