### PR TITLE
feat: AI processing Phase 1 — parallel inference pipeline

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -9,6 +9,7 @@
 
 (globalThis as any).UrlFetchApp = {
   fetch: jest.fn(),
+  fetchAll: jest.fn(),
 };
 
 (globalThis as any).PropertiesService = {
@@ -19,7 +20,12 @@
 
 // ── Import after mocks ─────────────────────────────────────────
 
-import { buildGeminiPayload, callGeminiAPI, invokeGemini } from "../src/server/api";
+import {
+  buildGeminiPayload,
+  callGeminiAPI,
+  callGeminiAPIBatch,
+  invokeGemini,
+} from "../src/server/api";
 import { CONFIG } from "../src/server/config";
 import type { GeminiRequest } from "../src/server/types";
 
@@ -353,5 +359,96 @@ describe("invokeGemini", () => {
     });
     const payload = JSON.parse((UrlFetchApp.fetch as jest.Mock).mock.calls[0][1].payload);
     expect(payload.contents[0].parts[1].inline_data.mime_type).toBe("application/pdf");
+  });
+});
+
+// ── callGeminiAPIBatch tests ───────────────────────────────────
+
+function mockFetchAllResponses(bodies: unknown[]) {
+  (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue(
+    bodies.map((body) => ({ getContentText: () => JSON.stringify(body) })),
+  );
+}
+
+describe("callGeminiAPIBatch", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns one GeminiResponse per request", () => {
+    mockFetchAllResponses([
+      { candidates: [{ content: { parts: [{ text: "Result A" }] } }] },
+      { candidates: [{ content: { parts: [{ text: "Result B" }] } }] },
+    ]);
+    const reqs: GeminiRequest[] = [
+      { apiKey: "key", userParts: [{ text: "Q1" }] },
+      { apiKey: "key", userParts: [{ text: "Q2" }] },
+    ];
+    const results = callGeminiAPIBatch(reqs);
+    expect(results).toHaveLength(2);
+    expect(results[0].text).toBe("Result A");
+    expect(results[1].text).toBe("Result B");
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(callGeminiAPIBatch([])).toEqual([]);
+    expect(UrlFetchApp.fetchAll as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it("maps a Gemini error response to an error text result (does not throw)", () => {
+    mockFetchAllResponses([
+      { error: { message: "quota exceeded" } },
+      { candidates: [{ content: { parts: [{ text: "OK" }] } }] },
+    ]);
+    const reqs: GeminiRequest[] = [
+      { apiKey: "key", userParts: [{ text: "Q1" }] },
+      { apiKey: "key", userParts: [{ text: "Q2" }] },
+    ];
+    const results = callGeminiAPIBatch(reqs);
+    expect(results[0].text).toMatch(/Error:/);
+    expect(results[1].text).toBe("OK");
+  });
+
+  it("includes file_data parts in the request payload", () => {
+    mockFetchAllResponses([{ candidates: [{ content: { parts: [{ text: "ok" }] } }] }]);
+    const req: GeminiRequest = {
+      apiKey: "key",
+      userParts: [
+        { text: "Describe this file" },
+        {
+          file_data: {
+            file_uri: "https://generativelanguage.googleapis.com/v1beta/files/abc",
+            mime_type: "application/pdf",
+          },
+        },
+      ],
+    };
+    callGeminiAPIBatch([req]);
+    const calls = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[0][0];
+    const payload = JSON.parse(calls[0].payload);
+    expect(payload.contents[0].parts[1].file_data).toEqual({
+      file_uri: "https://generativelanguage.googleapis.com/v1beta/files/abc",
+      mime_type: "application/pdf",
+    });
+  });
+
+  it("uses modelName from request when provided", () => {
+    mockFetchAllResponses([{ candidates: [{ content: { parts: [{ text: "ok" }] } }] }]);
+    callGeminiAPIBatch([
+      { apiKey: "key", modelName: "gemini-1.5-pro", userParts: [{ text: "Q" }] },
+    ]);
+    const calls = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[0][0];
+    expect(calls[0].url).toContain("gemini-1.5-pro");
+  });
+
+  it("falls back to CONFIG.MODEL_NAME when modelName is omitted", () => {
+    mockFetchAllResponses([{ candidates: [{ content: { parts: [{ text: "ok" }] } }] }]);
+    callGeminiAPIBatch([{ apiKey: "key", userParts: [{ text: "Q" }] }]);
+    const calls = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[0][0];
+    expect(calls[0].url).toContain(CONFIG.MODEL_NAME);
+  });
+
+  it("returns 'No response.' when candidates are empty", () => {
+    mockFetchAllResponses([{ candidates: [] }]);
+    const results = callGeminiAPIBatch([{ apiKey: "key", userParts: [{ text: "Q" }] }]);
+    expect(results[0].text).toBe("No response.");
   });
 });

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -407,6 +407,26 @@ describe("callGeminiAPIBatch", () => {
     expect(results[1].text).toBe("OK");
   });
 
+  it("maps a non-JSON response to an error text result without aborting the batch", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      {
+        getResponseCode: () => 503,
+        getContentText: () => "<html>Service Unavailable</html>",
+      },
+      {
+        getContentText: () =>
+          JSON.stringify({ candidates: [{ content: { parts: [{ text: "OK" }] } }] }),
+      },
+    ]);
+    const reqs: GeminiRequest[] = [
+      { apiKey: "key", userParts: [{ text: "Q1" }] },
+      { apiKey: "key", userParts: [{ text: "Q2" }] },
+    ];
+    const results = callGeminiAPIBatch(reqs);
+    expect(results[0].text).toMatch(/Error:.*503/);
+    expect(results[1].text).toBe("OK");
+  });
+
   it("includes file_data parts in the request payload", () => {
     mockFetchAllResponses([{ candidates: [{ content: { parts: [{ text: "ok" }] } }] }]);
     const req: GeminiRequest = {

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -451,4 +451,25 @@ describe("callGeminiAPIBatch", () => {
     const results = callGeminiAPIBatch([{ apiKey: "key", userParts: [{ text: "Q" }] }]);
     expect(results[0].text).toBe("No response.");
   });
+
+  it("populates codePairs when executableCode and codeExecutionResult parts are present", () => {
+    mockFetchAllResponses([
+      {
+        candidates: [
+          {
+            content: {
+              parts: [
+                { executableCode: { language: "PYTHON", code: "print(42)" } },
+                { codeExecutionResult: { outcome: "OUTCOME_OK", output: "42\n" } },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+    const results = callGeminiAPIBatch([{ apiKey: "key", userParts: [{ text: "Q" }] }]);
+    expect(results[0].codePairs).toHaveLength(1);
+    expect(results[0].codePairs![0].code.code).toBe("print(42)");
+    expect(results[0].codePairs![0].result.output).toBe("42\n");
+  });
 });

--- a/__tests__/drive.test.ts
+++ b/__tests__/drive.test.ts
@@ -442,24 +442,26 @@ describe("fetchDriveMetadata", () => {
         getContentText: () => JSON.stringify({ mimeType: "image/png", size: "204800" }),
       },
     ]);
-    const result = fetchDriveMetadata(["file1", "file2"], "token");
-    expect(result.get("file1")).toEqual({ mimeType: "application/pdf", size: 102400 });
-    expect(result.get("file2")).toEqual({ mimeType: "image/png", size: 204800 });
+    const { metadata } = fetchDriveMetadata(["file1", "file2"], "token");
+    expect(metadata.get("file1")).toEqual({ mimeType: "application/pdf", size: 102400 });
+    expect(metadata.get("file2")).toEqual({ mimeType: "image/png", size: 204800 });
   });
 
   it("returns empty map for empty input", () => {
-    expect(fetchDriveMetadata([], "token").size).toBe(0);
+    expect(fetchDriveMetadata([], "token").metadata.size).toBe(0);
     expect(UrlFetchApp.fetchAll as jest.Mock).not.toHaveBeenCalled();
   });
 
-  it("throws when Drive API returns an error", () => {
+  it("records error in errors map when Drive API returns an error", () => {
     (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
       {
         getResponseCode: () => 404,
         getContentText: () => JSON.stringify({ error: { message: "File not found" } }),
       },
     ]);
-    expect(() => fetchDriveMetadata(["bad-id"], "token")).toThrow("File not found");
+    const { metadata, errors } = fetchDriveMetadata(["bad-id"], "token");
+    expect(metadata.size).toBe(0);
+    expect(errors.get("bad-id")).toContain("File not found");
   });
 
   it("falls back to HTTP status code message when error response body is not valid JSON", () => {
@@ -469,7 +471,9 @@ describe("fetchDriveMetadata", () => {
         getContentText: () => "<html>Service Unavailable</html>",
       },
     ]);
-    expect(() => fetchDriveMetadata(["id"], "token")).toThrow("HTTP 503");
+    const { metadata, errors } = fetchDriveMetadata(["id"], "token");
+    expect(metadata.size).toBe(0);
+    expect(errors.get("id")).toContain("HTTP 503");
   });
 
   it("returns size 0 for Google Workspace files that have no size field", () => {
@@ -479,8 +483,8 @@ describe("fetchDriveMetadata", () => {
         getContentText: () => JSON.stringify({ mimeType: "application/vnd.google-apps.document" }),
       },
     ]);
-    const result = fetchDriveMetadata(["docId"], "token");
-    expect(result.get("docId")).toEqual({
+    const { metadata } = fetchDriveMetadata(["docId"], "token");
+    expect(metadata.get("docId")).toEqual({
       mimeType: "application/vnd.google-apps.document",
       size: 0,
     });
@@ -529,12 +533,12 @@ describe("downloadDriveFiles", () => {
       { getResponseCode: () => 200, getContent: () => [10, 20, 30] },
     ]);
     const metadata = new Map([["fileId", { mimeType: "application/pdf", size: 0 }]]);
-    const result = downloadDriveFiles(["fileId"], metadata, "token");
-    expect(result.get("fileId")).toEqual(new Uint8Array([10, 20, 30]));
+    const { bytes } = downloadDriveFiles(["fileId"], metadata, "token");
+    expect(bytes.get("fileId")).toEqual(new Uint8Array([10, 20, 30]));
   });
 
   it("returns empty map for empty input", () => {
-    expect(downloadDriveFiles([], new Map(), "token").size).toBe(0);
+    expect(downloadDriveFiles([], new Map(), "token").bytes.size).toBe(0);
   });
 
   it("falls back to alt=media when fileId is not in metadata map", () => {
@@ -546,11 +550,13 @@ describe("downloadDriveFiles", () => {
     expect(calls[0].url).toContain("?alt=media");
   });
 
-  it("throws when a download returns HTTP error", () => {
+  it("records error in errors map when a download returns HTTP error", () => {
     (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
       { getResponseCode: () => 403, getContent: () => [] },
     ]);
     const metadata = new Map([["fileId", { mimeType: "application/pdf", size: 0 }]]);
-    expect(() => downloadDriveFiles(["fileId"], metadata, "token")).toThrow("403");
+    const { bytes, errors } = downloadDriveFiles(["fileId"], metadata, "token");
+    expect(bytes.size).toBe(0);
+    expect(errors.get("fileId")).toContain("403");
   });
 });

--- a/__tests__/drive.test.ts
+++ b/__tests__/drive.test.ts
@@ -495,8 +495,9 @@ describe("downloadDriveFiles", () => {
   beforeEach(() => jest.clearAllMocks());
 
   it("uses export URL for Google Docs", () => {
+    const mockBlob = {};
     (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
-      { getResponseCode: () => 200, getContent: () => [1, 2, 3] },
+      { getResponseCode: () => 200, getBlob: () => mockBlob },
     ]);
     const metadata = new Map([
       ["docId", { mimeType: "application/vnd.google-apps.document", size: 0 }],
@@ -507,8 +508,9 @@ describe("downloadDriveFiles", () => {
   });
 
   it("uses export URL for Google Sheets", () => {
+    const mockBlob = {};
     (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
-      { getResponseCode: () => 200, getContent: () => [1, 2, 3] },
+      { getResponseCode: () => 200, getBlob: () => mockBlob },
     ]);
     const metadata = new Map([
       ["sheetId", { mimeType: "application/vnd.google-apps.spreadsheet", size: 0 }],
@@ -519,8 +521,9 @@ describe("downloadDriveFiles", () => {
   });
 
   it("uses alt=media for binary files", () => {
+    const mockBlob = {};
     (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
-      { getResponseCode: () => 200, getContent: () => [255, 254] },
+      { getResponseCode: () => 200, getBlob: () => mockBlob },
     ]);
     const metadata = new Map([["pdfId", { mimeType: "application/pdf", size: 0 }]]);
     downloadDriveFiles(["pdfId"], metadata, "token");
@@ -528,13 +531,14 @@ describe("downloadDriveFiles", () => {
     expect(calls[0].url).toContain("?alt=media");
   });
 
-  it("returns a map of fileId to Uint8Array bytes", () => {
+  it("returns a map of fileId to Blob", () => {
+    const mockBlob = {};
     (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
-      { getResponseCode: () => 200, getContent: () => [10, 20, 30] },
+      { getResponseCode: () => 200, getBlob: () => mockBlob },
     ]);
     const metadata = new Map([["fileId", { mimeType: "application/pdf", size: 0 }]]);
     const { bytes } = downloadDriveFiles(["fileId"], metadata, "token");
-    expect(bytes.get("fileId")).toEqual(new Uint8Array([10, 20, 30]));
+    expect(bytes.get("fileId")).toBe(mockBlob);
   });
 
   it("returns empty map for empty input", () => {
@@ -542,8 +546,9 @@ describe("downloadDriveFiles", () => {
   });
 
   it("falls back to alt=media when fileId is not in metadata map", () => {
+    const mockBlob = {};
     (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
-      { getResponseCode: () => 200, getContent: () => [1, 2] },
+      { getResponseCode: () => 200, getBlob: () => mockBlob },
     ]);
     downloadDriveFiles(["unknownId"], new Map(), "token");
     const calls = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[0][0];

--- a/__tests__/drive.test.ts
+++ b/__tests__/drive.test.ts
@@ -489,6 +489,42 @@ describe("fetchDriveMetadata", () => {
       size: 0,
     });
   });
+
+  it("handles non-JSON error responses in fetchDriveMetadata", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      {
+        getResponseCode: () => 400,
+        getContentText: () => "Not a JSON string",
+      },
+    ]);
+    const { errors } = fetchDriveMetadata(["id"], "token");
+    expect(errors.get("id")).toBe("HTTP 400");
+  });
+
+  it("handles JSON error responses missing message in fetchDriveMetadata", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      {
+        getResponseCode: () => 400,
+        getContentText: () => JSON.stringify({ error: {} }),
+      },
+    ]);
+    const { errors } = fetchDriveMetadata(["id"], "token");
+    expect(errors.get("id")).toBe("HTTP 400");
+  });
+
+  it("uses default mimeType and size when missing in JSON response", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      {
+        getResponseCode: () => 200,
+        getContentText: () => JSON.stringify({}),
+      },
+    ]);
+    const { metadata } = fetchDriveMetadata(["id"], "token");
+    expect(metadata.get("id")).toEqual({
+      mimeType: "application/octet-stream",
+      size: 0,
+    });
+  });
 });
 
 describe("downloadDriveFiles", () => {
@@ -563,5 +599,21 @@ describe("downloadDriveFiles", () => {
     const { bytes, errors } = downloadDriveFiles(["fileId"], metadata, "token");
     expect(bytes.size).toBe(0);
     expect(errors.get("fileId")).toContain("403");
+  });
+
+  it("handles non-JSON error responses in downloadDriveFiles", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getResponseCode: () => 500, getContentText: () => "Server Error" },
+    ]);
+    const { errors } = downloadDriveFiles(["id"], new Map(), "token");
+    expect(errors.get("id")).toBe("HTTP 500");
+  });
+
+  it("handles JSON error responses missing message in downloadDriveFiles", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getResponseCode: () => 401, getContentText: () => JSON.stringify({ error: {} }) },
+    ]);
+    const { errors } = downloadDriveFiles(["id"], new Map(), "token");
+    expect(errors.get("id")).toBe("HTTP 401");
   });
 });

--- a/__tests__/drive.test.ts
+++ b/__tests__/drive.test.ts
@@ -39,12 +39,23 @@ const mockUi = {
   PDF: "application/pdf",
 };
 
+(globalThis as any).UrlFetchApp = {
+  fetch: jest.fn(),
+  fetchAll: jest.fn(),
+};
+
+(globalThis as any).ScriptApp = {
+  getOAuthToken: jest.fn().mockReturnValue("mock-oauth-token"),
+};
+
 // ── Import after mocks ─────────────────────────────────────────
 
 import {
   checkDriveService,
   extractTextUniversal,
   prepareDriveAttachments,
+  fetchDriveMetadata,
+  downloadDriveFiles,
 } from "../src/server/drive";
 
 // ── Tests ──────────────────────────────────────────────────────
@@ -404,5 +415,113 @@ describe("prepareDriveAttachments", () => {
     expect(result).toHaveLength(2);
     expect(result[0].mime_type).toBe("application/pdf");
     expect(result[1].mime_type).toBe("image/png");
+  });
+});
+
+describe("fetchDriveMetadata", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns a map of fileId to mimeType and size", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      {
+        getResponseCode: () => 200,
+        getContentText: () => JSON.stringify({ mimeType: "application/pdf", size: "102400" }),
+      },
+      {
+        getResponseCode: () => 200,
+        getContentText: () => JSON.stringify({ mimeType: "image/png", size: "204800" }),
+      },
+    ]);
+    const result = fetchDriveMetadata(["file1", "file2"], "token");
+    expect(result.get("file1")).toEqual({ mimeType: "application/pdf", size: 102400 });
+    expect(result.get("file2")).toEqual({ mimeType: "image/png", size: 204800 });
+  });
+
+  it("returns empty map for empty input", () => {
+    expect(fetchDriveMetadata([], "token").size).toBe(0);
+    expect(UrlFetchApp.fetchAll as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it("throws when Drive API returns an error", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      {
+        getResponseCode: () => 404,
+        getContentText: () => JSON.stringify({ error: { message: "File not found" } }),
+      },
+    ]);
+    expect(() => fetchDriveMetadata(["bad-id"], "token")).toThrow("File not found");
+  });
+
+  it("returns size 0 for Google Workspace files that have no size field", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      {
+        getResponseCode: () => 200,
+        getContentText: () => JSON.stringify({ mimeType: "application/vnd.google-apps.document" }),
+      },
+    ]);
+    const result = fetchDriveMetadata(["docId"], "token");
+    expect(result.get("docId")).toEqual({
+      mimeType: "application/vnd.google-apps.document",
+      size: 0,
+    });
+  });
+});
+
+describe("downloadDriveFiles", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("uses export URL for Google Docs", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getResponseCode: () => 200, getContent: () => [1, 2, 3] },
+    ]);
+    const metadata = new Map([
+      ["docId", { mimeType: "application/vnd.google-apps.document", size: 0 }],
+    ]);
+    downloadDriveFiles(["docId"], metadata, "token");
+    const calls = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[0][0];
+    expect(calls[0].url).toContain("export?mimeType=application/pdf");
+  });
+
+  it("uses export URL for Google Sheets", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getResponseCode: () => 200, getContent: () => [1, 2, 3] },
+    ]);
+    const metadata = new Map([
+      ["sheetId", { mimeType: "application/vnd.google-apps.spreadsheet", size: 0 }],
+    ]);
+    downloadDriveFiles(["sheetId"], metadata, "token");
+    const calls = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[0][0];
+    expect(calls[0].url).toContain("export?mimeType=text/csv");
+  });
+
+  it("uses alt=media for binary files", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getResponseCode: () => 200, getContent: () => [255, 254] },
+    ]);
+    const metadata = new Map([["pdfId", { mimeType: "application/pdf", size: 0 }]]);
+    downloadDriveFiles(["pdfId"], metadata, "token");
+    const calls = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[0][0];
+    expect(calls[0].url).toContain("?alt=media");
+  });
+
+  it("returns a map of fileId to Uint8Array bytes", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getResponseCode: () => 200, getContent: () => [10, 20, 30] },
+    ]);
+    const metadata = new Map([["fileId", { mimeType: "application/pdf", size: 0 }]]);
+    const result = downloadDriveFiles(["fileId"], metadata, "token");
+    expect(result.get("fileId")).toEqual(new Uint8Array([10, 20, 30]));
+  });
+
+  it("returns empty map for empty input", () => {
+    expect(downloadDriveFiles([], new Map(), "token").size).toBe(0);
+  });
+
+  it("throws when a download returns HTTP error", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getResponseCode: () => 403, getContent: () => [] },
+    ]);
+    const metadata = new Map([["fileId", { mimeType: "application/pdf", size: 0 }]]);
+    expect(() => downloadDriveFiles(["fileId"], metadata, "token")).toThrow("403");
   });
 });

--- a/__tests__/drive.test.ts
+++ b/__tests__/drive.test.ts
@@ -386,6 +386,16 @@ describe("prepareDriveAttachments", () => {
     expect(() => prepareDriveAttachments(["img1", "img2"])).toThrow(/combined|total/i);
   });
 
+  it("throws pre-flight error for non-PDF file exceeding INLINE_MAX_TOTAL_BYTES raw size threshold", () => {
+    // 72MB raw * 4/3 ≈ 96MB encoded > 95MB INLINE_MAX_TOTAL_BYTES
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "image/jpeg",
+      getSize: () => 72 * 1024 * 1024,
+      getName: () => "huge-image.jpg",
+    });
+    expect(() => prepareDriveAttachments(["hugeImgId"])).toThrow("File too large");
+  });
+
   it("error messages reference the Gemini Files API escape hatch", () => {
     (DriveApp.getFileById as jest.Mock).mockReturnValue({
       getMimeType: () => "application/pdf",
@@ -452,6 +462,16 @@ describe("fetchDriveMetadata", () => {
     expect(() => fetchDriveMetadata(["bad-id"], "token")).toThrow("File not found");
   });
 
+  it("falls back to HTTP status code message when error response body is not valid JSON", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      {
+        getResponseCode: () => 503,
+        getContentText: () => "<html>Service Unavailable</html>",
+      },
+    ]);
+    expect(() => fetchDriveMetadata(["id"], "token")).toThrow("HTTP 503");
+  });
+
   it("returns size 0 for Google Workspace files that have no size field", () => {
     (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
       {
@@ -515,6 +535,15 @@ describe("downloadDriveFiles", () => {
 
   it("returns empty map for empty input", () => {
     expect(downloadDriveFiles([], new Map(), "token").size).toBe(0);
+  });
+
+  it("falls back to alt=media when fileId is not in metadata map", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getResponseCode: () => 200, getContent: () => [1, 2] },
+    ]);
+    downloadDriveFiles(["unknownId"], new Map(), "token");
+    const calls = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[0][0];
+    expect(calls[0].url).toContain("?alt=media");
   });
 
   it("throws when a download returns HTTP error", () => {

--- a/__tests__/files.test.ts
+++ b/__tests__/files.test.ts
@@ -19,6 +19,7 @@ describe("uploadFilesToGemini", () => {
 
   function mockUploadResponse(fileId: string, uri: string, mimeType: string) {
     return {
+      getResponseCode: () => 200,
       getContentText: () => JSON.stringify({ file: { name: `files/${fileId}`, uri, mimeType } }),
     };
   }
@@ -61,9 +62,12 @@ describe("uploadFilesToGemini", () => {
     expect(UrlFetchApp.fetchAll as jest.Mock).not.toHaveBeenCalled();
   });
 
-  it("records error in errors map when Files API returns an error", () => {
+  it("records error in errors map when Files API returns an error in body", () => {
     (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
-      { getContentText: () => JSON.stringify({ error: { message: "quota exceeded" } }) },
+      {
+        getResponseCode: () => 200,
+        getContentText: () => JSON.stringify({ error: { message: "quota exceeded" } }),
+      },
     ]);
     const files = new Map([["fileId", new Uint8Array([1])]]);
     const mimeTypes = new Map([["fileId", "application/pdf"]]);
@@ -72,12 +76,35 @@ describe("uploadFilesToGemini", () => {
     expect(errors.get("fileId")).toContain("quota exceeded");
   });
 
+  it("records error in errors map when Files API returns HTTP error status", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getResponseCode: () => 429, getContentText: () => "" },
+    ]);
+    const files = new Map([["fileId", new Uint8Array([1])]]);
+    const mimeTypes = new Map([["fileId", "application/pdf"]]);
+    const { uploads, errors } = uploadFilesToGemini(files, mimeTypes, "key");
+    expect(uploads.size).toBe(0);
+    expect(errors.get("fileId")).toContain("429");
+  });
+
+  it("records error in errors map when Files API returns non-JSON body", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getResponseCode: () => 200, getContentText: () => "<html>error</html>" },
+    ]);
+    const files = new Map([["fileId", new Uint8Array([1])]]);
+    const mimeTypes = new Map([["fileId", "application/pdf"]]);
+    const { uploads, errors } = uploadFilesToGemini(files, mimeTypes, "key");
+    expect(uploads.size).toBe(0);
+    expect(errors.get("fileId")).toContain("Invalid JSON");
+  });
+
   it("processes files in sub-batches of 10", () => {
     const fileIds = Array.from({ length: 25 }, (_, i) => `file${i}`);
     const files = new Map(fileIds.map((id) => [id, new Uint8Array([1])]));
     const mimeTypes = new Map(fileIds.map((id) => [id, "application/pdf"]));
 
     const singleResponse = (id: string) => ({
+      getResponseCode: () => 200,
       getContentText: () =>
         JSON.stringify({ file: { uri: `https://example.com/${id}`, mimeType: "application/pdf" } }),
     });

--- a/__tests__/files.test.ts
+++ b/__tests__/files.test.ts
@@ -12,34 +12,51 @@
 
 import { uploadFilesToGemini } from "../src/server/files";
 
+// ── Helpers ────────────────────────────────────────────────────
+
+function makeBlob(id: string): GoogleAppsScript.Base.Blob {
+  return { __id: id } as unknown as GoogleAppsScript.Base.Blob;
+}
+
+function mockInitResponse(sessionUri: string) {
+  return {
+    getResponseCode: () => 200,
+    getHeaders: () => ({ "x-goog-upload-url": sessionUri }),
+  };
+}
+
+function mockUploadResponse(uri: string, mimeType: string) {
+  return {
+    getResponseCode: () => 200,
+    getContentText: () => JSON.stringify({ file: { uri, mimeType } }),
+  };
+}
+
 // ── Tests ──────────────────────────────────────────────────────
 
 describe("uploadFilesToGemini", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  function mockUploadResponse(fileId: string, uri: string, mimeType: string) {
-    return {
-      getResponseCode: () => 200,
-      getContentText: () => JSON.stringify({ file: { name: `files/${fileId}`, uri, mimeType } }),
-    };
-  }
-
   it("returns a map of fileId to uri and mimeType", () => {
-    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
-      mockUploadResponse(
-        "file1",
-        "https://generativelanguage.googleapis.com/v1beta/files/abc",
-        "application/pdf",
-      ),
-      mockUploadResponse(
-        "file2",
-        "https://generativelanguage.googleapis.com/v1beta/files/def",
-        "image/png",
-      ),
-    ]);
+    (UrlFetchApp.fetchAll as jest.Mock)
+      .mockReturnValueOnce([
+        mockInitResponse("https://upload.example.com/s1"),
+        mockInitResponse("https://upload.example.com/s2"),
+      ])
+      .mockReturnValueOnce([
+        mockUploadResponse(
+          "https://generativelanguage.googleapis.com/v1beta/files/abc",
+          "application/pdf",
+        ),
+        mockUploadResponse(
+          "https://generativelanguage.googleapis.com/v1beta/files/def",
+          "image/png",
+        ),
+      ]);
+
     const files = new Map([
-      ["file1", new Uint8Array([1, 2, 3])],
-      ["file2", new Uint8Array([4, 5, 6])],
+      ["file1", makeBlob("file1")],
+      ["file2", makeBlob("file2")],
     ]);
     const mimeTypes = new Map([
       ["file1", "application/pdf"],
@@ -62,75 +79,123 @@ describe("uploadFilesToGemini", () => {
     expect(UrlFetchApp.fetchAll as jest.Mock).not.toHaveBeenCalled();
   });
 
-  it("records error in errors map when Files API returns an error in body", () => {
-    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
-      {
-        getResponseCode: () => 200,
-        getContentText: () => JSON.stringify({ error: { message: "quota exceeded" } }),
-      },
+  it("records error when init request returns HTTP error", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValueOnce([
+      { getResponseCode: () => 429, getHeaders: () => ({}) },
     ]);
-    const files = new Map([["fileId", new Uint8Array([1])]]);
-    const mimeTypes = new Map([["fileId", "application/pdf"]]);
-    const { uploads, errors } = uploadFilesToGemini(files, mimeTypes, "key");
-    expect(uploads.size).toBe(0);
-    expect(errors.get("fileId")).toContain("quota exceeded");
-  });
-
-  it("records error in errors map when Files API returns HTTP error status", () => {
-    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
-      { getResponseCode: () => 429, getContentText: () => "" },
-    ]);
-    const files = new Map([["fileId", new Uint8Array([1])]]);
+    const files = new Map([["fileId", makeBlob("fileId")]]);
     const mimeTypes = new Map([["fileId", "application/pdf"]]);
     const { uploads, errors } = uploadFilesToGemini(files, mimeTypes, "key");
     expect(uploads.size).toBe(0);
     expect(errors.get("fileId")).toContain("429");
   });
 
-  it("records error in errors map when Files API returns non-JSON body", () => {
-    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
-      { getResponseCode: () => 200, getContentText: () => "<html>error</html>" },
+  it("records error when init response is missing session URI", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValueOnce([
+      { getResponseCode: () => 200, getHeaders: () => ({}) },
     ]);
-    const files = new Map([["fileId", new Uint8Array([1])]]);
+    const files = new Map([["fileId", makeBlob("fileId")]]);
+    const mimeTypes = new Map([["fileId", "application/pdf"]]);
+    const { uploads, errors } = uploadFilesToGemini(files, mimeTypes, "key");
+    expect(uploads.size).toBe(0);
+    expect(errors.get("fileId")).toContain("session URI");
+  });
+
+  it("records error when upload response contains error in body", () => {
+    (UrlFetchApp.fetchAll as jest.Mock)
+      .mockReturnValueOnce([mockInitResponse("https://upload.example.com/s1")])
+      .mockReturnValueOnce([
+        {
+          getResponseCode: () => 200,
+          getContentText: () => JSON.stringify({ error: { message: "quota exceeded" } }),
+        },
+      ]);
+    const files = new Map([["fileId", makeBlob("fileId")]]);
+    const mimeTypes = new Map([["fileId", "application/pdf"]]);
+    const { uploads, errors } = uploadFilesToGemini(files, mimeTypes, "key");
+    expect(uploads.size).toBe(0);
+    expect(errors.get("fileId")).toContain("quota exceeded");
+  });
+
+  it("records error when upload response returns HTTP error status", () => {
+    (UrlFetchApp.fetchAll as jest.Mock)
+      .mockReturnValueOnce([mockInitResponse("https://upload.example.com/s1")])
+      .mockReturnValueOnce([{ getResponseCode: () => 429, getContentText: () => "" }]);
+    const files = new Map([["fileId", makeBlob("fileId")]]);
+    const mimeTypes = new Map([["fileId", "application/pdf"]]);
+    const { uploads, errors } = uploadFilesToGemini(files, mimeTypes, "key");
+    expect(uploads.size).toBe(0);
+    expect(errors.get("fileId")).toContain("429");
+  });
+
+  it("records error when upload response contains non-JSON body", () => {
+    (UrlFetchApp.fetchAll as jest.Mock)
+      .mockReturnValueOnce([mockInitResponse("https://upload.example.com/s1")])
+      .mockReturnValueOnce([
+        { getResponseCode: () => 200, getContentText: () => "<html>error</html>" },
+      ]);
+    const files = new Map([["fileId", makeBlob("fileId")]]);
     const mimeTypes = new Map([["fileId", "application/pdf"]]);
     const { uploads, errors } = uploadFilesToGemini(files, mimeTypes, "key");
     expect(uploads.size).toBe(0);
     expect(errors.get("fileId")).toContain("Invalid JSON");
   });
 
-  it("processes files in sub-batches of 10", () => {
-    const fileIds = Array.from({ length: 25 }, (_, i) => `file${i}`);
-    const files = new Map(fileIds.map((id) => [id, new Uint8Array([1])]));
-    const mimeTypes = new Map(fileIds.map((id) => [id, "application/pdf"]));
-
-    const singleResponse = (id: string) => ({
-      getResponseCode: () => 200,
-      getContentText: () =>
-        JSON.stringify({ file: { uri: `https://example.com/${id}`, mimeType: "application/pdf" } }),
-    });
-
-    // Three batches: 10 + 10 + 5
+  it("sends resumable protocol headers in init request", () => {
     (UrlFetchApp.fetchAll as jest.Mock)
-      .mockReturnValueOnce(fileIds.slice(0, 10).map(singleResponse))
-      .mockReturnValueOnce(fileIds.slice(10, 20).map(singleResponse))
-      .mockReturnValueOnce(fileIds.slice(20, 25).map(singleResponse));
-
-    const { uploads } = uploadFilesToGemini(files, mimeTypes, "key");
-    expect(UrlFetchApp.fetchAll as jest.Mock).toHaveBeenCalledTimes(3);
-    expect(uploads.size).toBe(25);
-  });
-
-  it("sends multipart content-type header", () => {
-    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
-      mockUploadResponse("f1", "https://example.com/f1", "application/pdf"),
-    ]);
+      .mockReturnValueOnce([mockInitResponse("https://upload.example.com/s1")])
+      .mockReturnValueOnce([mockUploadResponse("https://example.com/f1", "application/pdf")]);
     uploadFilesToGemini(
-      new Map([["f1", new Uint8Array([1])]]),
+      new Map([["f1", makeBlob("f1")]]),
       new Map([["f1", "application/pdf"]]),
       "key",
     );
-    const calls = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[0][0];
-    expect(calls[0].contentType).toMatch(/multipart\/related/);
-    expect(calls[0].headers["X-Goog-Upload-Protocol"]).toBe("multipart");
+    const initCall = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[0][0];
+    expect(initCall[0].headers["X-Goog-Upload-Protocol"]).toBe("resumable");
+    expect(initCall[0].headers["X-Goog-Upload-Command"]).toBe("start");
+    expect(initCall[0].headers["X-Goog-Upload-Header-Content-Type"]).toBe("application/pdf");
+  });
+
+  it("passes Blob directly as payload in upload request — no Array.from()", () => {
+    const blob = makeBlob("f1");
+    (UrlFetchApp.fetchAll as jest.Mock)
+      .mockReturnValueOnce([mockInitResponse("https://upload.example.com/s1")])
+      .mockReturnValueOnce([mockUploadResponse("https://example.com/f1", "application/pdf")]);
+    uploadFilesToGemini(new Map([["f1", blob]]), new Map([["f1", "application/pdf"]]), "key");
+    const uploadCall = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[1][0];
+    expect(uploadCall[0].payload).toBe(blob);
+  });
+
+  it("uses the session URI from the init response as the upload URL", () => {
+    const sessionUri = "https://upload.example.com/unique-session-123";
+    (UrlFetchApp.fetchAll as jest.Mock)
+      .mockReturnValueOnce([mockInitResponse(sessionUri)])
+      .mockReturnValueOnce([mockUploadResponse("https://example.com/f1", "application/pdf")]);
+    uploadFilesToGemini(
+      new Map([["f1", makeBlob("f1")]]),
+      new Map([["f1", "application/pdf"]]),
+      "key",
+    );
+    const uploadCall = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[1][0];
+    expect(uploadCall[0].url).toBe(sessionUri);
+  });
+
+  it("skips upload phase entirely when all init requests fail", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValueOnce([
+      { getResponseCode: () => 503, getHeaders: () => ({}) },
+      { getResponseCode: () => 503, getHeaders: () => ({}) },
+    ]);
+    const files = new Map([
+      ["f1", makeBlob("f1")],
+      ["f2", makeBlob("f2")],
+    ]);
+    const mimeTypes = new Map([
+      ["f1", "application/pdf"],
+      ["f2", "application/pdf"],
+    ]);
+    const { uploads, errors } = uploadFilesToGemini(files, mimeTypes, "key");
+    expect(UrlFetchApp.fetchAll as jest.Mock).toHaveBeenCalledTimes(1);
+    expect(uploads.size).toBe(0);
+    expect(errors.size).toBe(2);
   });
 });

--- a/__tests__/files.test.ts
+++ b/__tests__/files.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for src/server/files.ts
+ */
+
+// ── Mock globals BEFORE imports ────────────────────────────────
+
+(globalThis as any).UrlFetchApp = {
+  fetchAll: jest.fn(),
+};
+
+// ── Import after mocks ─────────────────────────────────────────
+
+import { uploadFilesToGemini } from "../src/server/files";
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe("uploadFilesToGemini", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  function mockUploadResponse(fileId: string, uri: string, mimeType: string) {
+    return {
+      getContentText: () => JSON.stringify({ file: { name: `files/${fileId}`, uri, mimeType } }),
+    };
+  }
+
+  it("returns a map of fileId to uri and mimeType", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      mockUploadResponse(
+        "file1",
+        "https://generativelanguage.googleapis.com/v1beta/files/abc",
+        "application/pdf",
+      ),
+      mockUploadResponse(
+        "file2",
+        "https://generativelanguage.googleapis.com/v1beta/files/def",
+        "image/png",
+      ),
+    ]);
+    const files = new Map([
+      ["file1", new Uint8Array([1, 2, 3])],
+      ["file2", new Uint8Array([4, 5, 6])],
+    ]);
+    const mimeTypes = new Map([
+      ["file1", "application/pdf"],
+      ["file2", "image/png"],
+    ]);
+    const result = uploadFilesToGemini(files, mimeTypes, "test-key");
+    expect(result.get("file1")).toEqual({
+      uri: "https://generativelanguage.googleapis.com/v1beta/files/abc",
+      mimeType: "application/pdf",
+    });
+    expect(result.get("file2")).toEqual({
+      uri: "https://generativelanguage.googleapis.com/v1beta/files/def",
+      mimeType: "image/png",
+    });
+  });
+
+  it("returns empty map for empty input", () => {
+    const result = uploadFilesToGemini(new Map(), new Map(), "key");
+    expect(result.size).toBe(0);
+    expect(UrlFetchApp.fetchAll as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it("throws when Files API returns an error", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getContentText: () => JSON.stringify({ error: { message: "quota exceeded" } }) },
+    ]);
+    const files = new Map([["fileId", new Uint8Array([1])]]);
+    const mimeTypes = new Map([["fileId", "application/pdf"]]);
+    expect(() => uploadFilesToGemini(files, mimeTypes, "key")).toThrow("quota exceeded");
+  });
+
+  it("processes files in sub-batches of 10", () => {
+    const fileIds = Array.from({ length: 25 }, (_, i) => `file${i}`);
+    const files = new Map(fileIds.map((id) => [id, new Uint8Array([1])]));
+    const mimeTypes = new Map(fileIds.map((id) => [id, "application/pdf"]));
+
+    const singleResponse = (id: string) => ({
+      getContentText: () =>
+        JSON.stringify({ file: { uri: `https://example.com/${id}`, mimeType: "application/pdf" } }),
+    });
+
+    // Three batches: 10 + 10 + 5
+    (UrlFetchApp.fetchAll as jest.Mock)
+      .mockReturnValueOnce(fileIds.slice(0, 10).map(singleResponse))
+      .mockReturnValueOnce(fileIds.slice(10, 20).map(singleResponse))
+      .mockReturnValueOnce(fileIds.slice(20, 25).map(singleResponse));
+
+    const result = uploadFilesToGemini(files, mimeTypes, "key");
+    expect(UrlFetchApp.fetchAll as jest.Mock).toHaveBeenCalledTimes(3);
+    expect(result.size).toBe(25);
+  });
+
+  it("sends multipart content-type header", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      mockUploadResponse("f1", "https://example.com/f1", "application/pdf"),
+    ]);
+    uploadFilesToGemini(
+      new Map([["f1", new Uint8Array([1])]]),
+      new Map([["f1", "application/pdf"]]),
+      "key",
+    );
+    const calls = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[0][0];
+    expect(calls[0].contentType).toMatch(/multipart\/related/);
+    expect(calls[0].headers["X-Goog-Upload-Protocol"]).toBe("multipart");
+  });
+});

--- a/__tests__/files.test.ts
+++ b/__tests__/files.test.ts
@@ -44,30 +44,32 @@ describe("uploadFilesToGemini", () => {
       ["file1", "application/pdf"],
       ["file2", "image/png"],
     ]);
-    const result = uploadFilesToGemini(files, mimeTypes, "test-key");
-    expect(result.get("file1")).toEqual({
+    const { uploads } = uploadFilesToGemini(files, mimeTypes, "test-key");
+    expect(uploads.get("file1")).toEqual({
       uri: "https://generativelanguage.googleapis.com/v1beta/files/abc",
       mimeType: "application/pdf",
     });
-    expect(result.get("file2")).toEqual({
+    expect(uploads.get("file2")).toEqual({
       uri: "https://generativelanguage.googleapis.com/v1beta/files/def",
       mimeType: "image/png",
     });
   });
 
   it("returns empty map for empty input", () => {
-    const result = uploadFilesToGemini(new Map(), new Map(), "key");
-    expect(result.size).toBe(0);
+    const { uploads } = uploadFilesToGemini(new Map(), new Map(), "key");
+    expect(uploads.size).toBe(0);
     expect(UrlFetchApp.fetchAll as jest.Mock).not.toHaveBeenCalled();
   });
 
-  it("throws when Files API returns an error", () => {
+  it("records error in errors map when Files API returns an error", () => {
     (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
       { getContentText: () => JSON.stringify({ error: { message: "quota exceeded" } }) },
     ]);
     const files = new Map([["fileId", new Uint8Array([1])]]);
     const mimeTypes = new Map([["fileId", "application/pdf"]]);
-    expect(() => uploadFilesToGemini(files, mimeTypes, "key")).toThrow("quota exceeded");
+    const { uploads, errors } = uploadFilesToGemini(files, mimeTypes, "key");
+    expect(uploads.size).toBe(0);
+    expect(errors.get("fileId")).toContain("quota exceeded");
   });
 
   it("processes files in sub-batches of 10", () => {
@@ -86,9 +88,9 @@ describe("uploadFilesToGemini", () => {
       .mockReturnValueOnce(fileIds.slice(10, 20).map(singleResponse))
       .mockReturnValueOnce(fileIds.slice(20, 25).map(singleResponse));
 
-    const result = uploadFilesToGemini(files, mimeTypes, "key");
+    const { uploads } = uploadFilesToGemini(files, mimeTypes, "key");
     expect(UrlFetchApp.fetchAll as jest.Mock).toHaveBeenCalledTimes(3);
-    expect(result.size).toBe(25);
+    expect(uploads.size).toBe(25);
   });
 
   it("sends multipart content-type header", () => {

--- a/__tests__/inference.test.ts
+++ b/__tests__/inference.test.ts
@@ -42,7 +42,7 @@
 
 // ── Import after mocks ─────────────────────────────────────────
 
-import { runInference } from "../src/server/inference";
+import { runInference, buildInferenceRequest } from "../src/server/inference";
 
 // ── Helpers ────────────────────────────────────────────────────
 
@@ -189,5 +189,105 @@ describe("runInference", () => {
       expect(payload.contents[0].parts[0].inline_data).toBeDefined();
       expect(payload.contents[0].parts[0].text).toBeUndefined();
     });
+  });
+});
+
+describe("buildInferenceRequest", () => {
+  it("returns a GeminiRequest for a text input", () => {
+    const req = buildInferenceRequest([{ kind: "text", value: "Hello" }]);
+    expect(req).not.toBeNull();
+    expect(req!.userParts).toEqual([{ text: "Hello" }]);
+  });
+
+  it("returns null when all inputs are empty", () => {
+    expect(buildInferenceRequest([{ kind: "text", value: "" }])).toBeNull();
+    expect(buildInferenceRequest([{ kind: "text", value: null }])).toBeNull();
+  });
+
+  it("includes systemPrompt in the returned request", () => {
+    const req = buildInferenceRequest([{ kind: "text", value: "Q" }], "Be concise");
+    expect(req!.systemPrompt).toBe("Be concise");
+  });
+
+  it("includes tools in the returned request", () => {
+    const req = buildInferenceRequest([{ kind: "text", value: "Q" }], undefined, ["google_search"]);
+    expect(req!.tools).toEqual(["google_search"]);
+  });
+
+  it("uses file URI from fileUriMap for file inputs", () => {
+    // extractId requires 25+ char IDs (real Drive IDs are always this length)
+    const realFileId = "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs";
+    const fileUriMap = new Map([
+      [
+        realFileId,
+        {
+          uri: "https://generativelanguage.googleapis.com/v1beta/files/abc",
+          mimeType: "application/pdf",
+        },
+      ],
+    ]);
+    const req = buildInferenceRequest(
+      [{ kind: "file", value: `https://drive.google.com/file/d/${realFileId}/view` }],
+      undefined,
+      undefined,
+      fileUriMap,
+    );
+    expect(req).not.toBeNull();
+    expect(req!.userParts).toEqual([
+      {
+        file_data: {
+          file_uri: "https://generativelanguage.googleapis.com/v1beta/files/abc",
+          mime_type: "application/pdf",
+        },
+      },
+    ]);
+  });
+
+  it("skips file inputs with no URI in fileUriMap", () => {
+    const fileUriMap = new Map<string, { uri: string; mimeType: string }>();
+    // Use a realistic 25+ char ID that is NOT in the map
+    const req = buildInferenceRequest(
+      [
+        {
+          kind: "file",
+          value: "https://drive.google.com/file/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs/view",
+        },
+      ],
+      undefined,
+      undefined,
+      fileUriMap,
+    );
+    // No parts — returns null
+    expect(req).toBeNull();
+  });
+
+  it("uses prepareDriveAttachments (inline path) when no fileUriMap provided", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/pdf",
+      getSize: () => 1000,
+      getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+      getName: () => "test.pdf",
+    });
+    (Utilities.base64Encode as jest.Mock).mockReturnValue("encoded==");
+
+    // Use a realistic 25+ char ID so extractId can parse it
+    const req = buildInferenceRequest([
+      {
+        kind: "file",
+        value: "https://drive.google.com/file/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs/view",
+      },
+    ]);
+    expect(req).not.toBeNull();
+    expect(req!.userParts[0]).toHaveProperty("inline_data");
+  });
+
+  it("prefixes text parts with label when label is set", () => {
+    const req = buildInferenceRequest([{ kind: "text", value: "content", label: "Article" }]);
+    expect(req!.userParts[0]).toEqual({ text: "Article: content" });
+  });
+
+  it("does not add apiKey (caller responsibility)", () => {
+    const req = buildInferenceRequest([{ kind: "text", value: "Q" }]);
+    expect(req).not.toHaveProperty("apiKey");
   });
 });

--- a/__tests__/panels/configure-ai-run.test.ts
+++ b/__tests__/panels/configure-ai-run.test.ts
@@ -5,6 +5,7 @@
 jest.mock("../../src/client/services", () => ({
   getSheetHeaders: jest.fn(),
   runBatchAI: jest.fn(),
+  getActiveRangeInfo: jest.fn().mockResolvedValue(null),
   getJobProgress: jest.fn().mockResolvedValue(null),
 }));
 
@@ -200,8 +201,9 @@ describe("ConfigureAIRunPanel — Run AI", () => {
       outputCol: "ai_inference",
     });
     container.querySelector<HTMLButtonElement>("#run-btn")!.click();
-    await Promise.resolve();
-    await Promise.resolve(); // flush rejection
+    // Extra ticks: getActiveRangeInfo adds an async hop before runBatchAI, so
+    // the catch handler fires one tick later than in the single-dispatch path.
+    for (let i = 0; i < 5; i++) await Promise.resolve();
     expect(globalThis.alert).toHaveBeenCalledWith("Error: API error");
   });
 

--- a/__tests__/services.test.ts
+++ b/__tests__/services.test.ts
@@ -6,6 +6,7 @@ const mockRun = {
   withSuccessHandler: jest.fn().mockReturnThis(),
   withFailureHandler: jest.fn().mockReturnThis(),
   getSheetHeaders: jest.fn(),
+  getActiveRangeInfo: jest.fn(),
   runBatchAI: jest.fn(),
   runTool: jest.fn(),
   prepRecipe: jest.fn(),
@@ -204,5 +205,30 @@ describe("getJobProgress", () => {
     const promise = services.getJobProgress("job-789");
     handlers.reject(new Error("progress error"));
     await expect(promise).rejects.toThrow("progress error");
+  });
+});
+
+describe("getActiveRangeInfo", () => {
+  it("calls google.script.run.getActiveRangeInfo and resolves with range", async () => {
+    const handlers = captureHandlers();
+    const range = { start: 1, end: 5 };
+    const promise = services.getActiveRangeInfo();
+    handlers.resolve(range);
+    await expect(promise).resolves.toEqual(range);
+    expect(mockRun.getActiveRangeInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves with null when no range is active", async () => {
+    const handlers = captureHandlers();
+    const promise = services.getActiveRangeInfo();
+    handlers.resolve(null);
+    await expect(promise).resolves.toBeNull();
+  });
+
+  it("rejects on failure", async () => {
+    const handlers = captureHandlers();
+    const promise = services.getActiveRangeInfo();
+    handlers.reject(new Error("range error"));
+    await expect(promise).rejects.toThrow("range error");
   });
 });

--- a/docs/plans/2026-04-24-ai-processing-redesign.md
+++ b/docs/plans/2026-04-24-ai-processing-redesign.md
@@ -1,0 +1,319 @@
+# AI Processing Redesign — Design Document
+
+## Context
+
+The chunked batch execution design (`2026-03-31-chunked-batch-execution-design.md`) solved
+the Apps Script 6-minute timeout by splitting `runBatchAI` into client-orchestrated 50-row
+chunks. That design explicitly deferred two follow-on improvements:
+
+> **Time-based trigger chaining** would remove the sidebar-open requirement.
+> **External pipeline dispatch** — for batches beyond ~5,000 rows, the right tool is a
+> Vertex AI batch inference job. The `dispatchChunked` interface is designed to be
+> replaceable.
+
+This document designs both. The problem that motivates them is **speed**, not timeouts.
+At 3–6 seconds per row (sequential Drive fetch + sequential Gemini call), a 300-row batch
+takes 15–30 minutes of babysitting. Users routinely need to process 1,000+ rows.
+
+## The Two User Stories
+
+**Small batch (< ~500 rows):** User wants to watch results stream in, chunk by chunk,
+in real time. Sidebar stays open. Speed is the priority.
+
+**Large batch (1,000+ rows):** User wants to submit the job and come back when it's done.
+Closing the sidebar should not stop the run. Throughput over thousands of rows matters
+more than live feedback.
+
+## Root Cause Analysis
+
+The current per-row flow has two serial bottlenecks:
+
+1. **Drive download** — `DriveApp.getFileById()` + `file.getBlob().getBytes()` are GAS
+   service calls. Single-threaded by design. Cannot be parallelized with `fetchAll()`.
+
+2. **Gemini API call** — `UrlFetchApp.fetch()` fires one HTTP request at a time.
+
+At 3s/call × 50 rows = 2.5 minutes per chunk. With parallelism, both steps can run
+concurrently within a chunk — the wall time becomes the slowest single call, not their sum.
+
+Note: base64 encoding (between download and API call) is CPU-bound and always serial in
+GAS, but it is not the bottleneck — encoding 1MB takes ~5–10ms vs. 1–3s for I/O.
+
+## The Option Space
+
+| Lever | What it does | GAS-native? |
+|---|---|---|
+| `UrlFetchApp.fetchAll()` | Fire N HTTP requests in parallel | Yes |
+| Drive API via HTTP + OAuth token | Download Drive files as plain HTTP (parallelizable) | Yes, via `ScriptApp.getOAuthToken()` |
+| Gemini Files API | Upload a file once, reference by URI instead of inline base64 | Yes, via UrlFetchApp |
+| Gemini Batch API | Submit a whole job as JSONL, async results | Yes, via time-driven triggers |
+
+**Ruled out:**
+- **Context caching** — only helps with large shared system prompts. Not the bottleneck.
+- **Vertex AI Batch Prediction** — requires GCP service account auth and IAM setup with
+  no meaningful advantage over the Gemini Batch API for this use case.
+- **Cloud Run / external runtime** — the GAS model distributes computational load across
+  each user's execution context. Centralizing to Cloud Run adds operational overhead
+  (scaling, multi-tenancy, billing) without a clear payoff. The Batch API already
+  offloads the heavy inference work to Google's servers. Revisit only if file upload
+  volume hits concrete GAS memory limits.
+
+---
+
+## Path 1 — Real-Time Parallel (Small Batches)
+
+### Goal
+
+Make each 50-row chunk 5–10× faster by parallelizing both Drive downloads and Gemini
+calls within the chunk.
+
+### Key Unlock
+
+`ScriptApp.getOAuthToken()` returns the current user's Bearer token. This lets
+`UrlFetchApp` hit Drive export URLs directly — turning GAS service calls into plain HTTP
+requests that `fetchAll()` can parallelize.
+
+### New Per-Chunk Flow
+
+```
+Current (sequential):
+  for each row:
+    DriveApp.getFileById() → getMimeType() → getBlob() → base64 → UrlFetchApp.fetch()
+
+New (parallel):
+  1. Metadata pass  — fetchAll() one Drive API call per unique file → mimeType + size
+  2. Download pass  — fetchAll() Drive export URLs for all unique files
+  3. Encode pass    — base64 encode all blobs (serial, ~5ms/file, negligible)
+  4. Gemini pass    — fetchAll() all generateContent calls for the chunk
+  5. Write pass     — batch-write all results to the sheet
+```
+
+Drive file deduplication applies within a chunk: if the same Drive URL appears in
+multiple rows, it is downloaded once and the encoded blob is reused for each row's
+Gemini payload.
+
+### Drive Export URLs
+
+| File type | URL pattern |
+|---|---|
+| Google Docs | `GET /drive/v3/files/{id}/export?mimeType=application/pdf` |
+| Google Sheets | `GET /drive/v3/files/{id}/export?mimeType=text/csv` (one sheet) — see note |
+| PDF / image / video / audio | `GET /drive/v3/files/{id}?alt=media` |
+
+Auth header: `Authorization: Bearer {ScriptApp.getOAuthToken()}`.
+
+**Sheets caveat:** The current Sheets export logic in `exportAndEncodeFile` uses
+`SpreadsheetApp` to enumerate sheets and export each as CSV. The Drive export endpoint
+only exports the first sheet as CSV. Multi-sheet exports still require `SpreadsheetApp`
+and cannot be parallelized. This is an acceptable limitation for the initial
+implementation — document it, address in a follow-up if multi-sheet files become common.
+
+### Memory Ceiling
+
+Apps Script execution memory is roughly 50MB. At ~1.3MB base64 per 1MB PDF, a 50-row
+chunk with 1MB PDFs reaches ~65MB — above the safe ceiling. The chunk size constant
+(currently `50` in `configure-ai-run.ts`) should be made adaptive based on estimated
+file sizes from the metadata pass. Initial implementation: keep the fixed 50-row chunk
+but add a per-row size guard that skips parallelization and falls back to sequential
+for rows whose files exceed a threshold.
+
+### Progress UX
+
+`fetchAll()` results arrive all-at-once (when the slowest call in the batch finishes),
+not row-by-row. The per-row `"Processing row N of 50"` progress updates inside a chunk
+go away. Replace with:
+
+- **During download pass:** `"Downloading files for chunk N of M..."`
+- **During Gemini pass:** `"Running AI on chunk N of M..."`
+- **Between chunks:** existing `"Chunk N of M — starting..."` (unchanged)
+
+This is a minor UX regression within a chunk but a major improvement in total time.
+
+### Files Touched
+
+| File | Change |
+|---|---|
+| `src/server/drive.ts` | Add `downloadDriveFilesParallel(fileIds, oauthToken)` — returns `Map<fileId, GeminiInlineData[]>` using fetchAll; keep `prepareDriveAttachments` as fallback |
+| `src/server/inference.ts` | Add `runInferenceBatch(rows, systemPrompts, tools)` — accepts pre-fetched blobs, fires all Gemini calls via fetchAll |
+| `src/server/api.ts` | Add `callGeminiAPIBatch(requests)` — wraps `UrlFetchApp.fetchAll()`, maps responses back to requests by index |
+| `src/server/index.ts` | Refactor `runBatchAI` to use parallel path when `DriveApp` service is not needed or falls back gracefully |
+| `src/shared/types.ts` | No changes needed |
+
+---
+
+## Path 2 — Async Batch (Large Batches)
+
+### Goal
+
+Allow users to submit 1,000+ row jobs that run entirely on Google's infrastructure.
+The sidebar can be closed. Results are written to the sheet when the job completes.
+
+### Infrastructure
+
+**Gemini Files API** — Upload files to Gemini's servers, get back a stable URI
+(`https://generativelanguage.googleapis.com/v1beta/files/abc123`). Files are cached
+for 48 hours. Use URIs in the batch JSONL instead of inline base64 — dramatically
+smaller payloads.
+
+**Gemini Batch API** — Submit a JSONL file (one request per line), get back a batch job
+name. Gemini runs the job asynchronously. Poll for status; download results JSONL when
+complete.
+
+**GAS time-driven triggers** — Installable triggers that fire on a schedule, independent
+of whether any user has the spreadsheet open. The polling trigger fires every minute to
+check batch job status.
+
+### Four-Phase Flow
+
+#### Phase 1 — File Upload (one GAS execution, sidebar open)
+
+1. Collect all unique Drive file IDs across the full row range
+2. Get `ScriptApp.getOAuthToken()` once
+3. Download all files via Drive export URLs (`fetchAll()` in chunks of 20)
+4. Upload each file to Gemini Files API (`fetchAll()` in chunks of 20)
+5. Record `driveFileId → geminiFileUri` mapping in memory
+
+Deduplication: each unique Drive file is uploaded once regardless of how many rows
+reference it. The 48-hour cache means re-runs within the same day can skip re-upload
+if URIs are persisted (future optimization; initial implementation always re-uploads).
+
+#### Phase 2 — Job Submission (same execution)
+
+1. Build JSONL — one line per row:
+   ```json
+   {"key": "row-2", "request": {"model": "...", "contents": [...fileData URIs + text parts...], "systemInstruction": {...}}}
+   ```
+2. POST JSONL to Gemini Batch API endpoint
+3. Receive batch job name: `batches/abc123`
+4. Persist job state to `UserProperties` (see State Management below)
+5. Create a time-driven trigger (every 1 minute) via `ScriptApp.newTrigger()`
+6. Return control to the sidebar — user sees "Job submitted"
+
+#### Phase 3 — Polling (trigger fires every ~1 minute)
+
+Triggered function: `pollBatchJob()`
+
+1. Read job state from `UserProperties` — if missing, delete the trigger and exit
+   (zombie guard)
+2. GET batch job status from Gemini API
+3. If `PENDING` or `RUNNING`: write progress to `CacheService` so sidebar can display;
+   check `submittedAt` — if >24 hours old with no results, mark as stale and stop
+4. If `SUCCEEDED`: proceed to Phase 4
+5. If `FAILED` or `CANCELLED`: write error to a well-known `CacheService` key, clean up
+   (delete trigger + delete UserProperties key)
+
+#### Phase 4 — Results Writing (same trigger execution as Phase 3 success)
+
+1. Download results JSONL from Gemini API response
+2. Parse each line — map `key` field (`"row-2"`) back to sheet row number
+3. Write results to the output column — same rich text / plain text logic as current
+   `runBatchAI`
+4. Clean up: delete time-driven trigger, delete UserProperties batch job key
+5. Write completion status to CacheService for sidebar to display
+
+### State Management
+
+Job state is stored in **`UserProperties`** (per-user, all spreadsheets) with keys
+namespaced by spreadsheet ID:
+
+```
+Key:   batch_job_{spreadsheetId}
+Value: JSON string, ~500 bytes
+```
+
+```ts
+interface BatchJobState {
+  jobName: string;          // "batches/abc123"
+  triggerId: string;        // ScriptApp trigger ID, for deletion
+  spreadsheetId: string;
+  sheetName: string;        // sheet name (not index — sheets can be reordered)
+  rowRange: { start: number; end: number };
+  outputCol: string;
+  groundingCol?: string;
+  applyMarkdown: boolean;
+  includeGrounding: boolean;
+  submittedAt: string;      // ISO 8601, for stale job detection
+}
+```
+
+**Cleanup contract — all terminal states delete both the trigger and the property:**
+
+| Outcome | Who cleans up |
+|---|---|
+| Job succeeded | `pollBatchJob()` after writing results |
+| Job failed / cancelled | `pollBatchJob()` after surfacing error |
+| User cancels from sidebar | `cancelBatchJob()` server function |
+| Zombie (property missing on trigger fire) | `pollBatchJob()` deletes trigger and exits |
+| Stale job (>24h, no results) | `pollBatchJob()` marks stale, cleans up |
+
+**One active batch job per spreadsheet per user.** `submitBatchJob()` checks for an
+existing `batch_job_{spreadsheetId}` key before proceeding and rejects with a clear
+message if one exists.
+
+### New Server Functions
+
+| Function | Description |
+|---|---|
+| `submitBatchJob(config: RunConfig)` | Phases 1–2: upload files, submit job, create trigger, persist state |
+| `pollBatchJob()` | Phase 3–4: poll status, write results, clean up — called by trigger |
+| `getBatchJobStatus()` | Sidebar polls this to show progress: reads CacheService key |
+| `cancelBatchJob()` | Calls Gemini cancel endpoint, deletes trigger, deletes UserProperties key |
+
+`pollBatchJob` must be exported from `src/server/index.ts` and added to `rollup.config.js`
+footer as a global stub — it is called by an installable trigger, not by
+`google.script.run`.
+
+### Sidebar UX Changes
+
+**`ConfigureAIRunPanel`** gets a second run mode selector (or a threshold-based auto-switch):
+
+- **Real-time** (default for < N rows): existing chunked dispatch
+- **Async batch** (default for ≥ N rows, or user-selectable): calls `submitBatchJob()`
+
+**New batch status state in the panel / job strip:**
+
+- `"submitting"` — upload + submission in progress (may take 1–2 minutes for large file sets)
+- `"batch-pending"` — job submitted, waiting for Gemini to start
+- `"batch-running"` — Gemini is processing; show row count progress if API provides it
+- `"batch-complete"` — results written; show completion toast
+- `"batch-failed"` — surface error message; offer retry or clear
+
+The job indicator persists across navigation (already supported by `JobIndicator`), so
+the user can navigate the sidebar freely while a batch job runs.
+
+---
+
+## What to Build Now vs. Later
+
+### Phase A — Now (3–5 days): Real-Time Parallelization
+
+Delivers the biggest usability improvement for the common case (small-medium batches,
+Drive file attachments). Works within the existing chunked execution architecture — no
+new RPC functions, no trigger infrastructure, no UX redesign.
+
+1. Add `downloadDriveFilesParallel()` to `drive.ts`
+2. Add `callGeminiAPIBatch()` to `api.ts`
+3. Add `runInferenceBatch()` to `inference.ts`
+4. Refactor `runBatchAI` inner loop to use the parallel path per chunk
+5. Update progress messages for batch UX
+
+### Phase B — Next (1–2 sprints): Async Batch Path
+
+Required for 1,000+ row reliability. Sidebar-close-safe. Larger architectural footprint:
+new server functions, trigger management, UserProperties lifecycle, sidebar UX additions.
+
+1. Implement `submitBatchJob()` (file upload + JSONL build + batch submission + trigger creation)
+2. Implement `pollBatchJob()` (status check + results writing + cleanup)
+3. Implement `getBatchJobStatus()` and `cancelBatchJob()`
+4. Add global stubs to `rollup.config.js` for trigger-called functions
+5. Add batch mode to `ConfigureAIRunPanel`
+6. Add batch job states to `JobStore` / `JobIndicator`
+
+### Deferred
+
+- **Multi-sheet Google Sheets export parallelization** — SpreadsheetApp dependency makes
+  this hard; address if multi-sheet files become a common source format
+- **Gemini Files API URI caching across runs** — skip re-upload if same Drive file was
+  uploaded within 48 hours; requires persisting `driveId → geminiUri` in PropertiesService
+- **Cloud Run escape hatch** — only if GAS memory limits become a concrete problem for
+  Phase B file uploads at very high row counts

--- a/docs/plans/2026-05-05-ai-processing-phase1-design.md
+++ b/docs/plans/2026-05-05-ai-processing-phase1-design.md
@@ -1,0 +1,203 @@
+# AI Processing Redesign — Phase 1: Parallel Inference Pipeline
+
+## Context
+
+The current per-row sequential inference loop in `runBatchAI` processes ~5s per row. At
+1,000 rows that is ~83 minutes of wall time with the sidebar open throughout. PRs #77 and
+#78 added chunked execution and cancellation, but the fundamental bottleneck — sequential
+Drive fetches and sequential Gemini calls inside each chunk — remains.
+
+Phase 1 replaces the sequential inner loop with a parallel pipeline using
+`UrlFetchApp.fetchAll()`. The client-side chunked execution system stays; what changes is
+what happens inside each chunk.
+
+Phase 2 (async fire-and-forget via Gemini Batch API) is designed but not yet planned —
+see `docs/plans/2026-05-05-ai-processing-phase2-notes.md`.
+
+## Root Cause
+
+Two serial bottlenecks per row:
+
+1. **Drive download** — `DriveApp.getFileById().getBlob().getBytes()` is a GAS service
+   call. Single-threaded by design, cannot be parallelized.
+
+2. **Gemini API call** — `UrlFetchApp.fetch()` fires one HTTP request at a time.
+
+Fix: `ScriptApp.getOAuthToken()` turns Drive downloads into plain HTTP requests that
+`fetchAll()` can parallelize. Files are uploaded to the Gemini Files API to get URI
+references, eliminating large inline base64 payloads. All Gemini inference calls then
+fire together via a second `fetchAll()`.
+
+## Architecture
+
+### What stays unchanged
+
+The client-side chunked execution system is untouched — GAS's 6-minute execution limit
+still applies per `google.script.run` call.
+
+```
+computeChunks()       chunk boundary math — unchanged
+runChunks()           client-side chunk loop — unchanged
+JobStore              job tracking, cancellation, polling — unchanged
+writeJobProgress()    CacheService progress writes — unchanged
+getJobProgress()      sidebar polling — unchanged
+SSI custom function   uses runInference(), text-only — unaffected
+```
+
+Chunk size increases from 10 to 50 rows because each chunk now completes in ~15–25s
+instead of ~50s, well within the 6-minute window.
+
+### New per-chunk flow
+
+**Text-only chunk** (no Drive file inputs — skips all file work):
+
+```
+1. Build all N request payloads (pure, no I/O)
+2. fetchAll N Gemini inference calls → N results     ← parallel
+3. Batch write N results → single SpreadsheetApp.flush()
+```
+
+**Multimodal chunk** (has Drive file inputs — two waves of parallelism):
+
+```
+Wave 1 — file work:
+  1a. fetchAll Drive metadata calls → mimeType + size per unique file  ← parallel
+  1b. fetchAll Drive export URLs → raw bytes per unique file            ← parallel
+  1c. fetchAll Gemini Files API uploads → Map<driveId, geminiUri>       ← parallel
+      (processed in sub-batches of 10 to manage peak memory)
+
+Wave 2 — inference:
+  2.  Build all N request payloads using URI refs from map (pure, no I/O)
+  3.  fetchAll N Gemini inference calls → N results                     ← parallel
+  4.  Batch write N results → single SpreadsheetApp.flush()
+```
+
+Wave 2 cannot start until Wave 1 completes — inference payloads depend on the URI map.
+Within each wave, all requests are concurrent.
+
+Drive file deduplication applies within a chunk: if the same Drive URL appears in
+multiple rows, it is downloaded and uploaded once; the URI is reused across all rows.
+
+### Drive export URLs (Wave 1b)
+
+All requests use `Authorization: Bearer {ScriptApp.getOAuthToken()}`.
+
+| File type | URL |
+|---|---|
+| Google Docs | `GET /drive/v3/files/{id}/export?mimeType=application/pdf` |
+| PDF / image / video / audio | `GET /drive/v3/files/{id}?alt=media` |
+| Google Sheets | `GET /drive/v3/files/{id}/export?mimeType=text/csv` |
+
+**Sheets caveat:** Drive export only produces the first sheet as CSV. Multi-sheet exports
+still require `SpreadsheetApp` to enumerate sheets and cannot be parallelized. Accepted
+limitation — address in a follow-up if multi-sheet sources become common.
+
+### Inline data vs. Files API
+
+Two separate paths are maintained:
+
+**`runBatchAI` (parallel batch path):** always uses Files API for Drive files. Sequential
+`DriveApp` fetches are the bottleneck regardless of file size — the parallelism benefit
+outweighs the extra Files API upload round trip.
+
+**`runInference` (single-call path, SSI only):** keeps `prepareDriveAttachments()` and
+the inline base64 path. Drive file handling in `runInference` is preserved specifically
+to support a future "Test Row" feature — see Deferred.
+
+## File Changes
+
+### New: `src/server/files.ts`
+
+- `uploadFilesToGemini(files: Map<string, Uint8Array>, mimeTypes: Map<string, string>, apiKey: string): Map<string, string>`
+  — multipart `fetchAll` uploads to Gemini Files API; returns `driveId → geminiUri`; processed in sub-batches of 10
+
+### `src/server/drive.ts`
+
+| Change | Function | Notes |
+|---|---|---|
+| ADD | `fetchDriveMetadata(fileIds, oauthToken)` | Wave 1a — parallel Drive API metadata via `fetchAll` |
+| ADD | `downloadDriveFiles(fileIds, metadata, oauthToken)` | Wave 1b — parallel Drive export via `fetchAll` |
+| KEEP | `prepareDriveAttachments()` | Inline path for `runInference` / future Test Row |
+| KEEP | `exportAndEncodeFile()` | Used by `prepareDriveAttachments` |
+| KEEP | `extractTextUniversal()` | Text extraction tool — unaffected |
+| KEEP | `checkDriveService()` | Unaffected |
+
+### `src/server/api.ts`
+
+| Change | Function | Notes |
+|---|---|---|
+| ADD | `callGeminiAPIBatch(payloads, apiKey)` | Wraps `UrlFetchApp.fetchAll`, maps responses by index |
+| KEEP | `callGeminiAPI()` | Single-call path — used by `invokeGemini` |
+| KEEP | `invokeGemini()` | SSI entry point — unchanged |
+| KEEP | `buildGeminiPayload()` | Payload assembly — unchanged |
+
+### `src/server/inference.ts`
+
+The user-parts assembly is extracted into a private helper shared by both paths:
+
+| Change | Function | Notes |
+|---|---|---|
+| EXTRACT (private) | `buildUserParts(promptInputs, fileUriMap?)` | Text inputs: same as today. File inputs: URI lookup from map when provided |
+| ADD | `buildInferenceRequest(promptInputs, systemPrompt?, tools?, fileUriMap?)` | Calls `buildUserParts`, returns `GeminiRequest \| null` — no HTTP call; used by batch path in `index.ts` |
+| SIMPLIFY | `runInference(promptInputs, systemPrompt?, tools?)` | Becomes: `buildInferenceRequest` + `invokeGemini`; Drive file branch preserved but not called by SSI |
+
+### `src/server/types.ts`
+
+- ADD `GeminiFileData: { fileUri: string; mimeType: string }`
+- EXPAND `GeminiUserPart` union to include `{ fileData: GeminiFileData }`
+
+### `src/server/index.ts`
+
+- REFACTOR `runBatchAI` inner loop:
+  - Detect `hasFileInputs` from `config.promptCols`
+  - Text-only path: `buildInferenceRequest` × N → `callGeminiAPIBatch`
+  - Multimodal path: file waves → `buildInferenceRequest` × N → `callGeminiAPIBatch`
+  - Batch write all results per chunk; single `SpreadsheetApp.flush()` per chunk
+
+### `src/client/panels/configure-ai-run.ts`
+
+| Change | Detail |
+|---|---|
+| `CHUNK_SIZE` | 10 → 50 |
+| `CHUNK_WARN_THRESHOLD` | 50 → 200 |
+| Time estimate in warning dialog | `~5s/row` → `~0.5s/row` |
+| Progress messages | Per-pass (see below) |
+
+## Progress UX
+
+`fetchAll` returns all-at-once, so per-row progress within a chunk is replaced with
+per-pass messages written via `writeJobProgress`:
+
+```
+"Downloading files for chunk N of M..."    (wave 1b, multimodal only)
+"Uploading files for chunk N of M..."      (wave 1c, multimodal only)
+"Running AI on chunk N of M..."            (wave 2 / inference pass)
+```
+
+Between-chunk `"Rows X–Y of Z"` messages are unchanged.
+
+## Performance
+
+| Scenario | Current | Phase 1 |
+|---|---|---|
+| 1,000 text-only rows | ~83 min | ~8–10 min |
+| 1,000 multimodal rows (small files) | ~83 min | ~15–20 min |
+| Chunk execution time | ~50s (10 rows) | ~15–25s (50 rows) |
+
+## Deferred
+
+- **"Test Row" feature** — single-row interactive inference via `runInference()` +
+  `prepareDriveAttachments()` inline data; natural home for a future "Test this row"
+  button in `ConfigureAIRunPanel`. `prepareDriveAttachments` is kept specifically to
+  support this (see `memory/project_test_row_concept.md`).
+
+- **Cross-run URI cache** — `PropertiesService` cache of `driveId → geminiUri` with 48h
+  TTL, lazy expiry cleanup, LRU eviction backstop; avoids re-uploading files across runs.
+  Slot in as a Phase 1 follow-up once the Files API upload path is stable.
+
+- **Multi-sheet Sheets export parallelization** — `SpreadsheetApp` dependency prevents
+  HTTP parallelism; defer unless multi-sheet sources become common.
+
+- **Phase 2: Async Batch Mode** — fire-and-forget for 1,000+ row jobs via Gemini Batch
+  API + GCS + time-driven triggers. Full design in
+  `docs/plans/2026-05-05-ai-processing-phase2-notes.md`.

--- a/docs/plans/2026-05-05-ai-processing-phase2-notes.md
+++ b/docs/plans/2026-05-05-ai-processing-phase2-notes.md
@@ -1,0 +1,214 @@
+# AI Processing Redesign — Phase 2: Async Batch Mode (Design Notes)
+
+**Status:** Designed, not yet planned.
+**Prerequisite:** Phase 1 (`docs/plans/2026-05-05-ai-processing-phase1-design.md`) complete.
+**To resume:** Run the brainstorming or writing-plans skill against this document.
+
+---
+
+## Problem This Solves
+
+Phase 1 brings 1,000 rows from ~83 min to ~8–10 min. But the sidebar must stay open the
+entire time, and any disconnection stops the run. For jobs above ~500 rows, users want
+to submit the job and come back when it's done.
+
+Phase 2 adds a second run mode: fire-and-forget via the Gemini Batch API. No execution
+window, no sidebar requirement, 50% token cost discount.
+
+---
+
+## User Stories
+
+**Small batch (< ~500 rows):** Use Phase 1 parallel path. Live progress, results stream
+in chunk by chunk.
+
+**Large batch (500+ rows):** Submit the job, close the sidebar, come back later. Results
+written to sheet when Gemini finishes (minutes to hours depending on job size).
+
+---
+
+## Infrastructure Required
+
+- **Gemini Batch API** — accepts JSONL of requests, processes async, returns JSONL of
+  results. 50% token cost discount vs. standard API.
+- **GCS bucket** — input/output staging for JSONL files. Batch API reads input from and
+  writes output to GCS.
+- **GAS time-driven trigger** — fires every minute, independent of whether any user has
+  the spreadsheet open. Polls job status and writes results on completion.
+
+New OAuth scope needed: `https://www.googleapis.com/auth/devstorage.read_write`
+
+---
+
+## Four-Phase Job Lifecycle
+
+### Phase 1 — File Upload (sidebar open, ~1–2 min for large file sets)
+
+1. Collect all unique Drive file IDs across the full row range
+2. `downloadDriveFiles()` + `uploadFilesToGemini()` in parallel sub-batches of 20
+3. Build `fileUriMap: driveId → geminiUri`
+
+Deduplication: each unique Drive file is uploaded once regardless of how many rows
+reference it. Initial implementation always re-uploads (no cross-run cache); URI caching
+is a follow-up (see Phase 1 deferred section).
+
+### Phase 2 — Job Submission (same GAS execution as Phase 1)
+
+1. Build JSONL — one line per row:
+   ```json
+   {"key": "row-42", "request": {"model": "...", "contents": [...], "systemInstruction": {...}}}
+   ```
+2. POST JSONL to GCS bucket
+3. POST to Gemini Batch API endpoint → receive `batchJobName` (`"batches/abc123"`)
+4. Persist `BatchJobState` to `UserProperties` (keyed by spreadsheet ID)
+5. Create time-driven trigger: `ScriptApp.newTrigger("pollBatchJob").timeBased().everyMinutes(1).create()`
+6. Return control to sidebar — user sees "Job submitted"
+
+### Phase 3 — Polling (trigger fires every ~1 min, no sidebar required)
+
+Triggered function: `pollBatchJob()`
+
+1. Read `BatchJobState` from `UserProperties`
+   - Key missing → zombie guard: delete trigger and exit
+2. GET batch job status from Gemini API
+3. Branch on status:
+   - `PENDING` / `RUNNING`: write progress to `CacheService`; check `submittedAt` —
+     if >24h with no result, mark stale and clean up
+   - `FAILED` / `CANCELLED`: write error to `CacheService`, clean up
+   - `SUCCEEDED`: proceed to Phase 4
+
+### Phase 4 — Results Writing (same trigger execution as Phase 3 success)
+
+1. Download results JSONL from GCS
+2. Parse each line — map `"key"` field (`"row-42"`) back to sheet row number
+3. Write to output column — same rich text / plain text logic as `runBatchAI`
+4. Clean up: delete trigger, delete `UserProperties` key
+5. Write completion status to `CacheService` for sidebar to display
+
+---
+
+## Job State
+
+Stored in `UserProperties` (per-user, all spreadsheets), keyed by spreadsheet ID so
+multiple users of the same add-on have independent jobs.
+
+**One active batch job per spreadsheet per user.** `submitBatchJob()` rejects if a key
+already exists.
+
+```typescript
+interface BatchJobState {
+  jobName: string;           // "batches/abc123"
+  triggerId: string;         // ScriptApp trigger ID — for clean deletion
+  spreadsheetId: string;
+  sheetName: string;         // name not index — sheets can be reordered
+  rowRange: { start: number; end: number };
+  outputCol: string;
+  groundingCol?: string;
+  applyMarkdown: boolean;
+  includeGrounding: boolean;
+  submittedAt: string;       // ISO 8601 — stale job detection (>24h)
+}
+```
+
+### Cleanup contract
+
+All terminal states delete both the trigger and the `UserProperties` key:
+
+| Outcome | Who cleans up |
+|---|---|
+| Job succeeded | `pollBatchJob()` after writing results |
+| Job failed / cancelled | `pollBatchJob()` after surfacing error |
+| User cancels from sidebar | `cancelBatchJob()` server function |
+| Zombie (property missing on trigger fire) | `pollBatchJob()` deletes trigger and exits |
+| Stale job (>24h, no results) | `pollBatchJob()` marks stale, cleans up |
+
+---
+
+## New Server Functions
+
+All four live in a new file: **`src/server/batch.ts`**
+
+| Function | Called by |
+|---|---|
+| `submitBatchJob(config: RunConfig)` | `google.script.run` from sidebar |
+| `pollBatchJob()` | Time-driven trigger (global stub in `rollup.config.js` footer) |
+| `getBatchJobStatus()` | `google.script.run` — sidebar polls `CacheService` key |
+| `cancelBatchJob()` | `google.script.run` from sidebar |
+
+`pollBatchJob` must be exported from `src/server/index.ts` and added as a global stub in
+`rollup.config.js` — it is called by an installable trigger, not by `google.script.run`.
+
+---
+
+## Client Changes
+
+### `ConfigureAIRunPanel` — threshold-based mode selector
+
+```
+rowCount <= 500:    [Run AI]                → Phase 1 parallel path
+
+rowCount > 500:     [Run Now]               → Phase 1 parallel path (slower, immediate)
+                    [Submit Batch]          → Phase 2 async batch path
+```
+
+### New job states in `JobStore` / `JobIndicator`
+
+```
+"submitting"        upload + submission in progress (~1–2 min for large file sets)
+"batch-pending"     job submitted, waiting for Gemini to start
+"batch-running"     Gemini is processing
+"batch-complete"    results written to sheet
+"batch-failed"      surface error message, offer retry
+```
+
+`JobIndicator` already persists across navigation — user can browse the sidebar freely
+while a batch job runs.
+
+### New service calls (`src/client/services.ts`)
+
+`submitBatchJob`, `getBatchJobStatus`, `cancelBatchJob`
+
+### New declarations (`src/client/google.d.ts`)
+
+Same three functions.
+
+---
+
+## File Changes Summary
+
+```
+src/server/batch.ts              NEW — submitBatchJob, pollBatchJob,
+                                       getBatchJobStatus, cancelBatchJob
+
+src/server/index.ts              EXPORT submitBatchJob, getBatchJobStatus,
+                                        cancelBatchJob (re-export from batch.ts)
+
+rollup.config.js                 ADD pollBatchJob global stub (trigger target)
+                                 ADD submitBatchJob, getBatchJobStatus,
+                                     cancelBatchJob stubs
+
+src/client/panels/
+  configure-ai-run.ts            ADD threshold logic (500-row), Submit Batch
+                                     button, batch mode dispatch
+src/client/services.ts           ADD submitBatchJob, getBatchJobStatus,
+                                     cancelBatchJob
+src/client/google.d.ts           ADD same three declarations
+src/client/job-store.ts          ADD batch job status states
+```
+
+---
+
+## Deferred from Phase 2
+
+- **Cross-run URI cache** — upload files once per 48h window instead of re-uploading on
+  every batch submission. `PropertiesService` cache keyed by `driveId + driveModifiedAt`,
+  lazy expiry cleanup, LRU eviction backstop at ~1,500 entries. Design discussed in
+  brainstorming session 2026-05-05.
+
+- **Context caching** — Gemini server-side token caching for large shared system prompts.
+  Only useful when system prompts are large and repeated across many rows. Not the current
+  bottleneck; revisit if prompt patterns change.
+
+- **Vertex AI Batch Prediction** — provides BigQuery integration and more granular GCP
+  tooling, but no meaningful advantage over Gemini Batch API for this use case. Ruled out
+  for now.

--- a/docs/plans/2026-05-06-parallel-pipeline-stabilization.md
+++ b/docs/plans/2026-05-06-parallel-pipeline-stabilization.md
@@ -1,0 +1,178 @@
+# Parallel Inference Pipeline — Stabilization & Memory Architecture
+
+**Date:** 2026-05-06  
+**Follows:** `2026-05-05-ai-processing-phase1-design.md`
+
+This document records the architectural decisions made during the stabilization pass
+on the Phase 1 parallel inference pipeline, and defines the current state of the system
+as a handoff reference.
+
+---
+
+## What Was Stabilized
+
+The Phase 1 design was implemented but crashed in production on real-world runs due to
+three classes of bugs: shared-drive auth failures, per-file errors aborting entire chunks,
+and V8 memory exhaustion from the file upload approach. This pass addressed all three.
+
+---
+
+## Decision 1: Shared Drive Support (`supportsAllDrives=true`)
+
+**Problem:** Files in shared/Team Drives returned HTTP 404 from the Drive REST API v3,
+even though `DriveApp.getFileById()` could access them. The raw HTTP path
+(`fetchDriveMetadata`, `downloadDriveFiles`) was not authorized for shared drives by
+default.
+
+**Fix:** Added `&supportsAllDrives=true` to all three Drive API v3 URL templates in
+`fetchDriveMetadata` and `downloadDriveFiles`.
+
+**Why not use DriveApp directly:** `DriveApp` is sequential. Replacing `fetchAll`-based
+downloads with `DriveApp.getFileById().getBlob()` calls would eliminate the parallelism
+that is the entire point of the Phase 1 redesign. The correct fix is the query parameter,
+not a different API.
+
+---
+
+## Decision 2: Partial-Success Pattern for Wave 1
+
+**Problem:** A single failing file in any of the three Wave 1 stages (`fetchDriveMetadata`,
+`downloadDriveFiles`, `uploadFilesToGemini`) was aborting the entire chunk. One bad file ID
+caused every row in a 40-row chunk to fail silently.
+
+**Fix:** All three Wave 1 functions now return `{ result, errors: Map<string, string> }`
+instead of throwing. Each function passes only its successes to the next stage:
+
+```
+metadata fetch → passes only files whose metadata succeeded → download
+download       → passes only files that downloaded successfully → upload
+upload         → passes only files that uploaded successfully → fileUriMap
+```
+
+Errors from all three stages are merged into a single `fileErrors` map. Rows whose files
+appear in that map receive a `[File error: ...]` cell value; rows whose files are clean
+proceed normally to Wave 2 inference.
+
+**Single-flush invariant:** File-error cell writes and inference results both land in the
+same post-batch write loop, followed by one `SpreadsheetApp.flush()`. This ensures that on
+a 6-minute timeout the sheet is never left in a partially-written state from a previous
+chunk.
+
+---
+
+## Decision 3: Resumable Upload Protocol (Blob payload)
+
+This was the most significant architectural change in this session.
+
+**Original design:** `uploadFilesToGemini` used the Gemini Files API multipart upload — a
+single `fetchAll` call per sub-batch, with each request body constructed as:
+
+```
+pre (header string → Uint8Array) + bytes (Uint8Array) + post (footer string → Uint8Array)
+→ body (Uint8Array concatenation)
+→ Array.from(body) (Byte[] = number[], passed to UrlFetchApp)
+```
+
+**The memory problem:** V8's `number[]` stores each element as a 64-bit float — 8 bytes per
+byte of file content. A 2MB file became ~18MB of V8 heap just for the upload payload
+(`Uint8Array` body + `Array.from` expansion + the original download bytes). With 5–10 files
+in a sub-batch, this exceeded GAS's ~50MB V8 heap limit and caused "JavaScript runtime
+exited unexpectedly" crashes.
+
+**Fix:** Switched to the Gemini Files API **resumable** upload protocol. Each file now takes
+two requests instead of one:
+
+1. **Init** (`POST` with JSON metadata) → response header `x-goog-upload-url` contains a
+   session URI
+2. **Upload** (`POST` to session URI with `payload: blob`) — the GAS `Blob` object returned
+   by `response.getBlob()` is passed directly to `UrlFetchApp` as `BlobSource`
+
+**Why this eliminates the memory problem:** The `Blob` from `response.getBlob()` is a GAS
+native object. When passed as `payload` to `UrlFetchApp.fetchAll`, GAS transfers the bytes
+from the download buffer to the upload buffer inside its own C++ layer. Our JavaScript code
+never calls `getBytes()`, `getContent()`, or `Array.from()` on file content. V8 heap
+pressure per file is now the Blob proxy object (~hundreds of bytes), not the file content.
+
+**Header case sensitivity:** GAS's `HTTPResponse.getHeaders()` normalizes response header
+keys to lowercase. The session URI header from Google's API arrives as `x-goog-upload-url`
+(lowercase), not `X-Goog-Upload-URL`. The implementation uses a case-insensitive lookup:
+
+```typescript
+const sessionUri = Object.entries(headers).find(
+  ([k]) => k.toLowerCase() === "x-goog-upload-url",
+)?.[1];
+```
+
+---
+
+## Decision 4: Client-Side Chunking for Sheet-Selection Mode
+
+**Problem:** When the user selected rows via the spreadsheet (no explicit row range), the
+`handleRun` path in `ConfigureAIRunPanel` called `runBatchAI` directly — bypassing the
+`computeChunks` / `runChunks` loop that enforces the `CHUNK_SIZE` limit. A 71-row selection
+processed all 71 rows in one 6-minute execution slot.
+
+**Fix:** Added `getActiveRangeInfo()` as a new server function that returns the active
+selection bounds. In the `else` branch of `handleRun`, the client now calls
+`getActiveRangeInfo()` first, then chunks the result identically to the explicit row-range
+path.
+
+---
+
+## Current Tunable Parameters
+
+| Constant | Location | Current Value | Meaning |
+|---|---|---|---|
+| `CHUNK_SIZE` | `src/client/panels/configure-ai-run.ts` | `40` | Rows per `google.script.run` call |
+| `CHUNK_WARN_THRESHOLD` | same | `200` | Show confirmation dialog above this row count |
+| `FILE_PIPELINE_BATCH_SIZE` | `src/server/index.ts` | `10` | Files per download→upload sub-batch in Wave 1 |
+
+**`CHUNK_SIZE` guidance:** Each chunk's Wave 2 inference runs N Gemini calls in parallel via
+`fetchAll`. At ~1s average per call, 40 rows takes ~40s of network time plus Wave 1 file
+work. Well within the 6-minute slot. Could be increased to 60–80 if file volumes are low.
+
+**`FILE_PIPELINE_BATCH_SIZE` guidance:** `UrlFetchApp.fetchAll` has an undocumented
+practical limit around 20 concurrent requests. The resumable protocol uses two `fetchAll`
+passes per sub-batch (init + upload), so 10 files × 2 = 20 requests per pass — at the
+safe limit. Reduce to 5 if rate-limit errors appear during upload; increase only if the
+`fetchAll` limit is confirmed higher.
+
+---
+
+## Current File Responsibilities
+
+| File | Responsibility |
+|---|---|
+| `src/server/index.ts` | `runBatchAI` orchestrator — Wave 1 sub-batch loop + Wave 2 batch inference + single flush |
+| `src/server/drive.ts` | `fetchDriveMetadata`, `downloadDriveFiles` — parallel Drive HTTP via `fetchAll`; `prepareDriveAttachments` — inline base64 path for SSI custom function |
+| `src/server/files.ts` | `uploadFilesToGemini` — two-phase resumable upload; Blob pass-through, no `Array.from()` |
+| `src/server/api.ts` | `callGeminiAPIBatch` — parallel Gemini inference via `fetchAll`; `callGeminiAPI` / `invokeGemini` — single-call path for SSI |
+| `src/client/panels/configure-ai-run.ts` | Client chunking — `computeChunks`, `runChunks`, `getActiveRangeInfo` integration |
+
+---
+
+## Future Parallelization Work
+
+> **Note for future sessions:** The current two-wave sequential design (all files upload →
+> then all inference fires) is correct and stable, but leaves throughput on the table for
+> mixed chunks where some rows have files and others do not. A more efficient architecture
+> would pipeline at the row level: as soon as a row's files finish uploading, queue that row
+> for inference rather than waiting for all files across the chunk to complete. This would
+> allow Wave 2 inference to begin for file-ready rows while Wave 1 continues processing the
+> remaining files in parallel.
+>
+> Additional candidates worth evaluating before a future redesign:
+>
+> - **Gemini Files API URI caching** — files uploaded in one chunk are valid for 48 hours.
+>   Persisting `driveId → geminiUri` in `CacheService` across chunks would eliminate
+>   re-uploading the same file in consecutive chunks of the same run.
+>
+> - **True async execution** — the current model requires the sidebar to remain open for the
+>   duration of a run. Time-based triggers firing independent chunk workers would allow
+>   runs to complete in the background and report results via a completion column or
+>   notification.
+>
+> - **Vertex AI Batch Prediction** — for very large jobs (1,000+ rows), the Gemini Batch
+>   API (designed in `2026-05-05-ai-processing-phase2-notes.md`) remains the most scalable
+>   path. The Phase 1 parallel pipeline is the right foundation for runs up to a few hundred
+>   rows; above that threshold the async batch path becomes necessary.

--- a/docs/superpowers/plans/2026-05-05-ai-processing-phase1.md
+++ b/docs/superpowers/plans/2026-05-05-ai-processing-phase1.md
@@ -1,0 +1,1243 @@
+# AI Processing Phase 1: Parallel Inference Pipeline
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the sequential per-row inference loop in `runBatchAI` with a parallel pipeline using `UrlFetchApp.fetchAll()`, reducing 1,000-row runs from ~83 minutes to ~8–10 minutes.
+
+**Architecture:** Two waves of parallelism per chunk. Wave 1 (multimodal only): fetch Drive metadata → download files → upload to Gemini Files API, all via `fetchAll`. Wave 2: build all N request payloads, fire all N Gemini inference calls via `fetchAll`, batch-write results. The client-side chunk loop (`computeChunks`/`runChunks`/`JobStore`) is unchanged — GAS's 6-minute execution limit still applies per call.
+
+**Tech Stack:** Google Apps Script V8, TypeScript, `UrlFetchApp.fetchAll`, Gemini Files API (`/upload/v1beta/files`), Drive API v3 (`/drive/v3/files`), Jest + ts-jest.
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `src/server/api.ts` | Add `callGeminiAPIBatch` |
+| `src/server/drive.ts` | Add `fetchDriveMetadata`, `downloadDriveFiles` |
+| `src/server/files.ts` | **NEW** — `uploadFilesToGemini` |
+| `src/server/inference.ts` | Extract `buildUserParts` (private), add `buildInferenceRequest`, simplify `runInference` |
+| `src/server/index.ts` | Refactor `runBatchAI` inner loop — no unit tests (excluded from coverage) |
+| `src/client/panels/configure-ai-run.ts` | Update `CHUNK_SIZE`, `CHUNK_WARN_THRESHOLD`, warning dialog copy |
+| `__tests__/api.test.ts` | Add `callGeminiAPIBatch` tests + `file_data` passthrough test |
+| `__tests__/drive.test.ts` | Add `fetchDriveMetadata` + `downloadDriveFiles` tests |
+| `__tests__/files.test.ts` | **NEW** — `uploadFilesToGemini` tests |
+| `__tests__/inference.test.ts` | Add `buildInferenceRequest` tests |
+| `jest.config.cjs` | Add coverage threshold for `src/server/files.ts` |
+
+**Note:** `src/server/types.ts` already has `GeminiFileApiData` (with `file_uri` and `mime_type` fields) and the `file_data` variant of `GeminiUserPart`. No changes needed.
+
+---
+
+## Task 1: Add `callGeminiAPIBatch` to `api.ts`
+
+**Files:**
+- Modify: `src/server/api.ts`
+- Test: `__tests__/api.test.ts`
+
+- [ ] **Step 1: Add `fetchAll` mock to api.test.ts and write failing tests**
+
+Add `UrlFetchApp.fetchAll` to the existing mock at the top of `__tests__/api.test.ts` (before imports), then add a `describe("callGeminiAPIBatch")` block at the bottom of the file:
+
+```typescript
+// In the existing mock block at the top (before imports):
+(globalThis as any).UrlFetchApp = {
+  fetch: jest.fn(),
+  fetchAll: jest.fn(),
+};
+```
+
+```typescript
+// Add at the bottom of __tests__/api.test.ts:
+
+import { callGeminiAPIBatch } from "../src/server/api";
+
+function mockFetchAllResponses(bodies: unknown[]) {
+  (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue(
+    bodies.map((body) => ({ getContentText: () => JSON.stringify(body) })),
+  );
+}
+
+describe("callGeminiAPIBatch", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns one GeminiResponse per request", () => {
+    mockFetchAllResponses([
+      { candidates: [{ content: { parts: [{ text: "Result A" }] } }] },
+      { candidates: [{ content: { parts: [{ text: "Result B" }] } }] },
+    ]);
+    const reqs: GeminiRequest[] = [
+      { apiKey: "key", userParts: [{ text: "Q1" }] },
+      { apiKey: "key", userParts: [{ text: "Q2" }] },
+    ];
+    const results = callGeminiAPIBatch(reqs);
+    expect(results).toHaveLength(2);
+    expect(results[0].text).toBe("Result A");
+    expect(results[1].text).toBe("Result B");
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(callGeminiAPIBatch([])).toEqual([]);
+    expect(UrlFetchApp.fetchAll as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it("maps a Gemini error response to an error text result (does not throw)", () => {
+    mockFetchAllResponses([
+      { error: { message: "quota exceeded" } },
+      { candidates: [{ content: { parts: [{ text: "OK" }] } }] },
+    ]);
+    const reqs: GeminiRequest[] = [
+      { apiKey: "key", userParts: [{ text: "Q1" }] },
+      { apiKey: "key", userParts: [{ text: "Q2" }] },
+    ];
+    const results = callGeminiAPIBatch(reqs);
+    expect(results[0].text).toMatch(/Error:/);
+    expect(results[1].text).toBe("OK");
+  });
+
+  it("includes file_data parts in the request payload", () => {
+    mockFetchAllResponses([
+      { candidates: [{ content: { parts: [{ text: "ok" }] } }] },
+    ]);
+    const req: GeminiRequest = {
+      apiKey: "key",
+      userParts: [
+        { text: "Describe this file" },
+        { file_data: { file_uri: "https://generativelanguage.googleapis.com/v1beta/files/abc", mime_type: "application/pdf" } },
+      ],
+    };
+    callGeminiAPIBatch([req]);
+    const calls = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[0][0];
+    const payload = JSON.parse(calls[0].payload);
+    expect(payload.contents[0].parts[1].file_data).toEqual({
+      file_uri: "https://generativelanguage.googleapis.com/v1beta/files/abc",
+      mime_type: "application/pdf",
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+npx jest __tests__/api.test.ts -t "callGeminiAPIBatch" --no-coverage
+```
+
+Expected: FAIL — `callGeminiAPIBatch is not a function`
+
+- [ ] **Step 3: Implement `callGeminiAPIBatch` in `src/server/api.ts`**
+
+Add after the existing `callGeminiAPI` function. Unlike `callGeminiAPI` (which throws on error), the batch version maps errors to `{ text: "Error: ..." }` so one bad row does not abort the whole chunk:
+
+```typescript
+/**
+ * Fire N Gemini generateContent requests in parallel via UrlFetchApp.fetchAll.
+ * Per-response errors are mapped to { text: "Error: ..." } rather than throwing,
+ * so a single failed row does not abort the rest of the batch.
+ */
+export function callGeminiAPIBatch(reqs: GeminiRequest[]): GeminiResponse[] {
+  if (reqs.length === 0) return [];
+
+  const requests = reqs.map((req) => {
+    const modelName = req.modelName ?? CONFIG.MODEL_NAME;
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent?key=${req.apiKey}`;
+    return {
+      url,
+      method: "post" as const,
+      contentType: "application/json",
+      payload: JSON.stringify(buildGeminiPayload(req)),
+      muteHttpExceptions: true,
+    };
+  });
+
+  const responses = UrlFetchApp.fetchAll(requests);
+
+  return responses.map((response, i) => {
+    const json = JSON.parse(response.getContentText()) as Record<string, unknown>;
+
+    if (json.error) {
+      return { text: `Error: ${(json.error as { message: string }).message}` };
+    }
+
+    const candidate = (json.candidates as Array<Record<string, unknown>> | undefined)?.[0];
+    const parts =
+      (candidate?.content as { parts?: Array<Record<string, unknown>> } | undefined)?.parts ?? [];
+
+    const textParts = parts
+      .filter((p): p is { text: string } => typeof p["text"] === "string")
+      .map((p) => p.text);
+    const text = textParts.join("\n\n") || "No response.";
+
+    const codePairs: GeminiCodePair[] = [];
+    for (let j = 0; j < parts.length - 1; j++) {
+      const curr = parts[j];
+      const next = parts[j + 1];
+      if (curr["executableCode"] !== undefined && next["codeExecutionResult"] !== undefined) {
+        codePairs.push({
+          code: curr["executableCode"] as GeminiCodePair["code"],
+          result: next["codeExecutionResult"] as GeminiCodePair["result"],
+        });
+        j++;
+      }
+    }
+
+    const groundingMetadata = candidate?.["groundingMetadata"] as
+      | GeminiResponse["groundingMetadata"]
+      | undefined;
+
+    return {
+      text,
+      ...(groundingMetadata !== undefined && { groundingMetadata }),
+      ...(codePairs.length > 0 && { codePairs }),
+    };
+  });
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+npx jest __tests__/api.test.ts --no-coverage
+```
+
+Expected: all tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/api.ts __tests__/api.test.ts
+git commit -m "feat: add callGeminiAPIBatch for parallel Gemini inference"
+```
+
+---
+
+## Task 2: Add parallel Drive functions to `drive.ts`
+
+**Files:**
+- Modify: `src/server/drive.ts`
+- Test: `__tests__/drive.test.ts`
+
+- [ ] **Step 1: Add `UrlFetchApp.fetchAll` and `ScriptApp` to the mock block in `drive.test.ts`**
+
+At the top of `__tests__/drive.test.ts`, add to the existing mock block (before imports):
+
+```typescript
+(globalThis as any).UrlFetchApp = {
+  fetch: jest.fn(),
+  fetchAll: jest.fn(),
+};
+
+(globalThis as any).ScriptApp = {
+  getOAuthToken: jest.fn().mockReturnValue("mock-oauth-token"),
+};
+```
+
+- [ ] **Step 2: Add failing tests for `fetchDriveMetadata` and `downloadDriveFiles`**
+
+Add to `__tests__/drive.test.ts` (after existing imports, update the import line):
+
+```typescript
+import {
+  checkDriveService,
+  extractTextUniversal,
+  prepareDriveAttachments,
+  fetchDriveMetadata,
+  downloadDriveFiles,
+} from "../src/server/drive";
+```
+
+Then add these describe blocks at the bottom of the file:
+
+```typescript
+describe("fetchDriveMetadata", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns a map of fileId to mimeType and size", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getContentText: () => JSON.stringify({ mimeType: "application/pdf", size: "102400" }) },
+      { getContentText: () => JSON.stringify({ mimeType: "image/png", size: "204800" }) },
+    ]);
+    const result = fetchDriveMetadata(["file1", "file2"], "token");
+    expect(result.get("file1")).toEqual({ mimeType: "application/pdf", size: 102400 });
+    expect(result.get("file2")).toEqual({ mimeType: "image/png", size: 204800 });
+  });
+
+  it("returns empty map for empty input", () => {
+    expect(fetchDriveMetadata([], "token").size).toBe(0);
+    expect(UrlFetchApp.fetchAll as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it("throws when Drive API returns an error", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getContentText: () => JSON.stringify({ error: { message: "File not found" } }) },
+    ]);
+    expect(() => fetchDriveMetadata(["bad-id"], "token")).toThrow("File not found");
+  });
+});
+
+describe("downloadDriveFiles", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("uses export URL for Google Docs", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getResponseCode: () => 200, getContent: () => [1, 2, 3] },
+    ]);
+    const metadata = new Map([["docId", { mimeType: "application/vnd.google-apps.document", size: 0 }]]);
+    downloadDriveFiles(["docId"], metadata, "token");
+    const calls = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[0][0];
+    expect(calls[0].url).toContain("export?mimeType=application/pdf");
+  });
+
+  it("uses export URL for Google Sheets", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getResponseCode: () => 200, getContent: () => [1, 2, 3] },
+    ]);
+    const metadata = new Map([["sheetId", { mimeType: "application/vnd.google-apps.spreadsheet", size: 0 }]]);
+    downloadDriveFiles(["sheetId"], metadata, "token");
+    const calls = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[0][0];
+    expect(calls[0].url).toContain("export?mimeType=text/csv");
+  });
+
+  it("uses alt=media for binary files", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getResponseCode: () => 200, getContent: () => [255, 254] },
+    ]);
+    const metadata = new Map([["pdfId", { mimeType: "application/pdf", size: 0 }]]);
+    downloadDriveFiles(["pdfId"], metadata, "token");
+    const calls = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[0][0];
+    expect(calls[0].url).toContain("?alt=media");
+  });
+
+  it("returns a map of fileId to Uint8Array bytes", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getResponseCode: () => 200, getContent: () => [10, 20, 30] },
+    ]);
+    const metadata = new Map([["fileId", { mimeType: "application/pdf", size: 0 }]]);
+    const result = downloadDriveFiles(["fileId"], metadata, "token");
+    expect(result.get("fileId")).toEqual(new Uint8Array([10, 20, 30]));
+  });
+
+  it("returns empty map for empty input", () => {
+    expect(downloadDriveFiles([], new Map(), "token").size).toBe(0);
+  });
+
+  it("throws when a download returns HTTP error", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getResponseCode: () => 403, getContent: () => [] },
+    ]);
+    const metadata = new Map([["fileId", { mimeType: "application/pdf", size: 0 }]]);
+    expect(() => downloadDriveFiles(["fileId"], metadata, "token")).toThrow("403");
+  });
+});
+```
+
+- [ ] **Step 3: Run failing tests**
+
+```bash
+npx jest __tests__/drive.test.ts -t "fetchDriveMetadata|downloadDriveFiles" --no-coverage
+```
+
+Expected: FAIL — functions not found
+
+- [ ] **Step 4: Implement `fetchDriveMetadata` and `downloadDriveFiles` in `src/server/drive.ts`**
+
+Add these exports at the bottom of `src/server/drive.ts`:
+
+```typescript
+/**
+ * Fetch mimeType and size for a list of Drive file IDs in parallel via fetchAll.
+ * Uses the Drive API v3 files.get endpoint with an OAuth Bearer token.
+ */
+export function fetchDriveMetadata(
+  fileIds: string[],
+  oauthToken: string,
+): Map<string, { mimeType: string; size: number }> {
+  if (fileIds.length === 0) return new Map();
+
+  const requests = fileIds.map((id) => ({
+    url: `https://www.googleapis.com/drive/v3/files/${id}?fields=id%2CmimeType%2Csize`,
+    method: "get" as const,
+    headers: { Authorization: `Bearer ${oauthToken}` },
+    muteHttpExceptions: true,
+  }));
+
+  const responses = UrlFetchApp.fetchAll(requests);
+  const result = new Map<string, { mimeType: string; size: number }>();
+
+  responses.forEach((response, i) => {
+    const json = JSON.parse(response.getContentText()) as {
+      mimeType?: string;
+      size?: string;
+      error?: { message: string };
+    };
+    if (json.error) {
+      throw new Error(`Failed to fetch metadata for ${fileIds[i]}: ${json.error.message}`);
+    }
+    result.set(fileIds[i], {
+      mimeType: json.mimeType ?? "application/octet-stream",
+      size: parseInt(json.size ?? "0", 10),
+    });
+  });
+
+  return result;
+}
+
+/**
+ * Download raw file bytes for a list of Drive files in parallel via fetchAll.
+ * Routes Google Docs/Sheets to their export endpoints; all other types use alt=media.
+ */
+export function downloadDriveFiles(
+  fileIds: string[],
+  metadata: Map<string, { mimeType: string; size: number }>,
+  oauthToken: string,
+): Map<string, Uint8Array> {
+  if (fileIds.length === 0) return new Map();
+
+  const DOCS_MIME = "application/vnd.google-apps.document";
+  const SHEETS_MIME = "application/vnd.google-apps.spreadsheet";
+
+  const requests = fileIds.map((id) => {
+    const mimeType = metadata.get(id)?.mimeType ?? "";
+    let url: string;
+    if (mimeType === DOCS_MIME) {
+      url = `https://www.googleapis.com/drive/v3/files/${id}/export?mimeType=application%2Fpdf`;
+    } else if (mimeType === SHEETS_MIME) {
+      url = `https://www.googleapis.com/drive/v3/files/${id}/export?mimeType=text%2Fcsv`;
+    } else {
+      url = `https://www.googleapis.com/drive/v3/files/${id}?alt=media`;
+    }
+    return {
+      url,
+      method: "get" as const,
+      headers: { Authorization: `Bearer ${oauthToken}` },
+      muteHttpExceptions: true,
+    };
+  });
+
+  const responses = UrlFetchApp.fetchAll(requests);
+  const result = new Map<string, Uint8Array>();
+
+  responses.forEach((response, i) => {
+    const code = response.getResponseCode();
+    if (code >= 400) {
+      throw new Error(`Failed to download file ${fileIds[i]}: HTTP ${code}`);
+    }
+    result.set(fileIds[i], new Uint8Array(response.getContent()));
+  });
+
+  return result;
+}
+```
+
+- [ ] **Step 5: Run all drive tests**
+
+```bash
+npx jest __tests__/drive.test.ts --no-coverage
+```
+
+Expected: all pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/server/drive.ts __tests__/drive.test.ts
+git commit -m "feat: add fetchDriveMetadata and downloadDriveFiles for parallel Drive access"
+```
+
+---
+
+## Task 3: Create `src/server/files.ts` with `uploadFilesToGemini`
+
+**Files:**
+- Create: `src/server/files.ts`
+- Create: `__tests__/files.test.ts`
+
+- [ ] **Step 1: Write failing tests in `__tests__/files.test.ts`**
+
+```typescript
+/**
+ * Tests for src/server/files.ts
+ */
+
+// ── Mock globals BEFORE imports ────────────────────────────────
+
+(globalThis as any).UrlFetchApp = {
+  fetchAll: jest.fn(),
+};
+
+// ── Import after mocks ─────────────────────────────────────────
+
+import { uploadFilesToGemini } from "../src/server/files";
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe("uploadFilesToGemini", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  function mockUploadResponse(fileId: string, uri: string, mimeType: string) {
+    return {
+      getContentText: () =>
+        JSON.stringify({ file: { name: `files/${fileId}`, uri, mimeType } }),
+    };
+  }
+
+  it("returns a map of fileId to uri and mimeType", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      mockUploadResponse("file1", "https://generativelanguage.googleapis.com/v1beta/files/abc", "application/pdf"),
+      mockUploadResponse("file2", "https://generativelanguage.googleapis.com/v1beta/files/def", "image/png"),
+    ]);
+    const files = new Map([
+      ["file1", new Uint8Array([1, 2, 3])],
+      ["file2", new Uint8Array([4, 5, 6])],
+    ]);
+    const mimeTypes = new Map([
+      ["file1", "application/pdf"],
+      ["file2", "image/png"],
+    ]);
+    const result = uploadFilesToGemini(files, mimeTypes, "test-key");
+    expect(result.get("file1")).toEqual({
+      uri: "https://generativelanguage.googleapis.com/v1beta/files/abc",
+      mimeType: "application/pdf",
+    });
+    expect(result.get("file2")).toEqual({
+      uri: "https://generativelanguage.googleapis.com/v1beta/files/def",
+      mimeType: "image/png",
+    });
+  });
+
+  it("returns empty map for empty input", () => {
+    const result = uploadFilesToGemini(new Map(), new Map(), "key");
+    expect(result.size).toBe(0);
+    expect(UrlFetchApp.fetchAll as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it("throws when Files API returns an error", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getContentText: () => JSON.stringify({ error: { message: "quota exceeded" } }) },
+    ]);
+    const files = new Map([["fileId", new Uint8Array([1])]]);
+    const mimeTypes = new Map([["fileId", "application/pdf"]]);
+    expect(() => uploadFilesToGemini(files, mimeTypes, "key")).toThrow("quota exceeded");
+  });
+
+  it("processes files in sub-batches of 10", () => {
+    const fileIds = Array.from({ length: 25 }, (_, i) => `file${i}`);
+    const files = new Map(fileIds.map((id) => [id, new Uint8Array([1])]));
+    const mimeTypes = new Map(fileIds.map((id) => [id, "application/pdf"]));
+
+    const singleResponse = (id: string) => ({
+      getContentText: () =>
+        JSON.stringify({ file: { uri: `https://example.com/${id}`, mimeType: "application/pdf" } }),
+    });
+
+    // Three batches: 10 + 10 + 5
+    (UrlFetchApp.fetchAll as jest.Mock)
+      .mockReturnValueOnce(fileIds.slice(0, 10).map(singleResponse))
+      .mockReturnValueOnce(fileIds.slice(10, 20).map(singleResponse))
+      .mockReturnValueOnce(fileIds.slice(20, 25).map(singleResponse));
+
+    const result = uploadFilesToGemini(files, mimeTypes, "key");
+    expect(UrlFetchApp.fetchAll as jest.Mock).toHaveBeenCalledTimes(3);
+    expect(result.size).toBe(25);
+  });
+
+  it("sends multipart content-type header", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      mockUploadResponse("f1", "https://example.com/f1", "application/pdf"),
+    ]);
+    uploadFilesToGemini(
+      new Map([["f1", new Uint8Array([1])]]),
+      new Map([["f1", "application/pdf"]]),
+      "key",
+    );
+    const calls = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[0][0];
+    expect(calls[0].contentType).toMatch(/multipart\/related/);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+npx jest __tests__/files.test.ts --no-coverage
+```
+
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Create `src/server/files.ts`**
+
+```typescript
+/**
+ * files.ts — Gemini Files API integration.
+ *
+ * Uploads Drive file bytes to the Gemini Files API and returns stable URI
+ * references. Files are cached on Gemini's servers for 48 hours.
+ * Using URIs instead of inline base64 eliminates GAS memory pressure and
+ * enables deduplication across rows in a chunk.
+ */
+
+/**
+ * Upload a batch of files to the Gemini Files API in parallel.
+ * Processed in sub-batches of 10 to limit peak memory.
+ *
+ * @param files     Map of driveFileId → raw bytes (Uint8Array)
+ * @param mimeTypes Map of driveFileId → MIME type string
+ * @param apiKey    Gemini API key
+ * @returns Map of driveFileId → { uri, mimeType } from the Files API response
+ */
+export function uploadFilesToGemini(
+  files: Map<string, Uint8Array>,
+  mimeTypes: Map<string, string>,
+  apiKey: string,
+): Map<string, { uri: string; mimeType: string }> {
+  const result = new Map<string, { uri: string; mimeType: string }>();
+  const fileIds = Array.from(files.keys());
+  if (fileIds.length === 0) return result;
+
+  const BATCH_SIZE = 10;
+  for (let i = 0; i < fileIds.length; i += BATCH_SIZE) {
+    const batch = fileIds.slice(i, i + BATCH_SIZE);
+    const requests = batch.map((fileId) =>
+      buildUploadRequest(
+        fileId,
+        files.get(fileId)!,
+        mimeTypes.get(fileId) ?? "application/octet-stream",
+        apiKey,
+      ),
+    );
+
+    const responses = UrlFetchApp.fetchAll(requests);
+    responses.forEach((response, j) => {
+      const fileId = batch[j];
+      const json = JSON.parse(response.getContentText()) as {
+        file?: { uri: string; mimeType: string };
+        error?: { message: string };
+      };
+      if (json.error || !json.file?.uri) {
+        throw new Error(
+          `Failed to upload file ${fileId}: ${json.error?.message ?? "missing URI in response"}`,
+        );
+      }
+      result.set(fileId, { uri: json.file.uri, mimeType: json.file.mimeType });
+    });
+  }
+
+  return result;
+}
+
+function buildUploadRequest(
+  fileId: string,
+  bytes: Uint8Array,
+  mimeType: string,
+  apiKey: string,
+): { url: string } & GoogleAppsScript.URL_Fetch.URLFetchRequestOptions {
+  const boundary = "boundary" + Math.random().toString(36).slice(2, 18);
+  const metadata = JSON.stringify({ file: { display_name: fileId } });
+
+  const pre = stringToBytes(
+    `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${metadata}\r\n--${boundary}\r\nContent-Type: ${mimeType}\r\n\r\n`,
+  );
+  const post = stringToBytes(`\r\n--${boundary}--`);
+
+  const body = new Uint8Array(pre.length + bytes.length + post.length);
+  body.set(pre, 0);
+  body.set(bytes, pre.length);
+  body.set(post, pre.length + bytes.length);
+
+  return {
+    url: `https://generativelanguage.googleapis.com/upload/v1beta/files?key=${apiKey}`,
+    method: "post",
+    contentType: `multipart/related; boundary=${boundary}`,
+    headers: { "X-Goog-Upload-Protocol": "multipart" },
+    payload: Array.from(body) as GoogleAppsScript.Byte[],
+    muteHttpExceptions: true,
+  };
+}
+
+function stringToBytes(s: string): Uint8Array {
+  return new Uint8Array(s.split("").map((c) => c.charCodeAt(0)));
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npx jest __tests__/files.test.ts --no-coverage
+```
+
+Expected: all pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/files.ts __tests__/files.test.ts
+git commit -m "feat: add uploadFilesToGemini for Gemini Files API integration"
+```
+
+---
+
+## Task 4: Refactor `inference.ts` — add `buildInferenceRequest`
+
+**Files:**
+- Modify: `src/server/inference.ts`
+- Test: `__tests__/inference.test.ts`
+
+- [ ] **Step 1: Write failing tests for `buildInferenceRequest`**
+
+Update the import line in `__tests__/inference.test.ts`:
+
+```typescript
+import { runInference, buildInferenceRequest } from "../src/server/inference";
+```
+
+Add these tests at the bottom of the file:
+
+```typescript
+describe("buildInferenceRequest", () => {
+  it("returns a GeminiRequest for a text input", () => {
+    const req = buildInferenceRequest([{ kind: "text", value: "Hello" }]);
+    expect(req).not.toBeNull();
+    expect(req!.userParts).toEqual([{ text: "Hello" }]);
+  });
+
+  it("returns null when all inputs are empty", () => {
+    expect(buildInferenceRequest([{ kind: "text", value: "" }])).toBeNull();
+    expect(buildInferenceRequest([{ kind: "text", value: null }])).toBeNull();
+  });
+
+  it("includes systemPrompt in the returned request", () => {
+    const req = buildInferenceRequest([{ kind: "text", value: "Q" }], "Be concise");
+    expect(req!.systemPrompt).toBe("Be concise");
+  });
+
+  it("includes tools in the returned request", () => {
+    const req = buildInferenceRequest(
+      [{ kind: "text", value: "Q" }],
+      undefined,
+      ["google_search"],
+    );
+    expect(req!.tools).toEqual(["google_search"]);
+  });
+
+  it("uses file URI from fileUriMap for file inputs", () => {
+    const fileUriMap = new Map([
+      ["fileId123", { uri: "https://generativelanguage.googleapis.com/v1beta/files/abc", mimeType: "application/pdf" }],
+    ]);
+    const req = buildInferenceRequest(
+      [{ kind: "file", value: "https://drive.google.com/file/d/fileId123/view" }],
+      undefined,
+      undefined,
+      fileUriMap,
+    );
+    expect(req).not.toBeNull();
+    expect(req!.userParts).toEqual([
+      {
+        file_data: {
+          file_uri: "https://generativelanguage.googleapis.com/v1beta/files/abc",
+          mime_type: "application/pdf",
+        },
+      },
+    ]);
+  });
+
+  it("skips file inputs with no URI in fileUriMap", () => {
+    const fileUriMap = new Map<string, { uri: string; mimeType: string }>();
+    const req = buildInferenceRequest(
+      [{ kind: "file", value: "https://drive.google.com/file/d/missing123/view" }],
+      undefined,
+      undefined,
+      fileUriMap,
+    );
+    // No parts — returns null
+    expect(req).toBeNull();
+  });
+
+  it("uses prepareDriveAttachments (inline path) when no fileUriMap provided", () => {
+    (DriveApp.getFileById as jest.Mock).mockReturnValue({
+      getMimeType: () => "application/pdf",
+      getSize: () => 1000,
+      getBlob: () => ({ getBytes: () => [1, 2, 3] }),
+      getName: () => "test.pdf",
+    });
+    (Utilities.base64Encode as jest.Mock).mockReturnValue("encoded==");
+
+    const req = buildInferenceRequest([
+      { kind: "file", value: "https://drive.google.com/file/d/fileId123/view" },
+    ]);
+    expect(req).not.toBeNull();
+    expect(req!.userParts[0]).toHaveProperty("inline_data");
+  });
+
+  it("prefixes text parts with label when label is set", () => {
+    const req = buildInferenceRequest([{ kind: "text", value: "content", label: "Article" }]);
+    expect(req!.userParts[0]).toEqual({ text: "Article: content" });
+  });
+
+  it("does not add apiKey (caller responsibility)", () => {
+    const req = buildInferenceRequest([{ kind: "text", value: "Q" }]);
+    expect(req).not.toHaveProperty("apiKey");
+  });
+});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+npx jest __tests__/inference.test.ts -t "buildInferenceRequest" --no-coverage
+```
+
+Expected: FAIL — `buildInferenceRequest is not a function`
+
+- [ ] **Step 3: Refactor `src/server/inference.ts`**
+
+Replace the entire file:
+
+```typescript
+/**
+ * inference.ts — Gemini request construction and single-call inference.
+ *
+ * buildInferenceRequest  — pure, no HTTP; assembles a GeminiRequest from row data
+ *                          using pre-uploaded Files API URIs (batch path) or inline
+ *                          base64 via prepareDriveAttachments (single-call path).
+ * runInference           — single-call path for SSI custom function; calls
+ *                          buildInferenceRequest then invokeGemini.
+ */
+
+import { invokeGemini } from "./api";
+import { prepareDriveAttachments } from "./drive";
+import { flattenArg, isValidDriveLink, extractId } from "./utils";
+import type {
+  GeminiRequest,
+  GeminiResponse,
+  GeminiUserPart,
+  PromptInput,
+} from "./types";
+import type { ToolId } from "../shared/types";
+
+/**
+ * Assemble user-turn parts from prompt inputs.
+ * Text inputs are flattened via flattenArg and optionally prefixed with a label.
+ * File inputs use URI references from fileUriMap (Files API path) when provided,
+ * or fall back to prepareDriveAttachments (inline base64 path) when not.
+ */
+function buildUserParts(
+  promptInputs: PromptInput[],
+  fileUriMap?: Map<string, { uri: string; mimeType: string }>,
+): GeminiUserPart[] {
+  const userParts: GeminiUserPart[] = [];
+
+  for (const input of promptInputs) {
+    if (input.kind === "text") {
+      const texts = flattenArg(input.value);
+      const parts = input.label
+        ? texts.map((text) => ({ text: `${input.label}: ${text}` }))
+        : texts.map((text) => ({ text }));
+      userParts.push(...parts);
+    } else {
+      const fileIds = flattenArg(input.value).filter(isValidDriveLink).map(extractId);
+      if (fileIds.length === 0) continue;
+
+      if (fileUriMap) {
+        for (const fileId of fileIds) {
+          const fileInfo = fileUriMap.get(fileId);
+          if (fileInfo) {
+            userParts.push({
+              file_data: { file_uri: fileInfo.uri, mime_type: fileInfo.mimeType },
+            });
+          }
+        }
+      } else {
+        const attachments = prepareDriveAttachments(fileIds);
+        userParts.push(...attachments.map((inline_data) => ({ inline_data })));
+      }
+    }
+  }
+
+  return userParts;
+}
+
+/**
+ * Build a Gemini generateContent request from row data without making an HTTP call.
+ * Returns null if no prompt inputs produce any content (signals caller to skip row).
+ *
+ * @param fileUriMap  Pre-uploaded Files API URIs (batch path). Omit to use inline
+ *                    base64 via prepareDriveAttachments (single-call path).
+ */
+export function buildInferenceRequest(
+  promptInputs: PromptInput[],
+  systemPrompt?: unknown,
+  tools?: ToolId[],
+  fileUriMap?: Map<string, { uri: string; mimeType: string }>,
+): Omit<GeminiRequest, "apiKey"> | null {
+  const userParts = buildUserParts(promptInputs, fileUriMap);
+  if (userParts.length === 0) return null;
+
+  return {
+    systemPrompt: systemPrompt !== undefined ? flattenArg(systemPrompt)[0] : undefined,
+    userParts,
+    tools: tools?.length ? tools : undefined,
+  };
+}
+
+/**
+ * Execute a single Gemini inference from raw cell values.
+ * Used by the SSI custom function. Resolves the API key from ScriptProperties.
+ *
+ * @returns The model response, an object with "Error: ..." text on failure,
+ *          or null if no prompt inputs produce any content.
+ */
+export function runInference(
+  promptInputs: PromptInput[],
+  systemPrompt?: unknown,
+  tools?: ToolId[],
+): GeminiResponse | null {
+  try {
+    const req = buildInferenceRequest(promptInputs, systemPrompt, tools);
+    if (req === null) return null;
+    return invokeGemini(req);
+  } catch (e) {
+    return { text: "Error: " + (e as Error).message };
+  }
+}
+```
+
+- [ ] **Step 4: Run all inference tests**
+
+```bash
+npx jest __tests__/inference.test.ts --no-coverage
+```
+
+Expected: all pass
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+```bash
+npm test -- --no-coverage
+```
+
+Expected: all 439+ tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/server/inference.ts __tests__/inference.test.ts
+git commit -m "refactor: extract buildInferenceRequest from runInference for batch path"
+```
+
+---
+
+## Task 5: Refactor `runBatchAI` in `index.ts`
+
+**Files:**
+- Modify: `src/server/index.ts`
+
+`index.ts` is excluded from unit test coverage (deep SpreadsheetApp coupling). Manual test instructions are at the end of this task.
+
+- [ ] **Step 1: Update imports at the top of `src/server/index.ts`**
+
+Find the existing import block and add the new functions:
+
+```typescript
+import { runBatchAI as _unused, ... } // replace the existing runInference import and add new ones
+```
+
+The full updated import block for the server modules (replace the relevant lines):
+
+```typescript
+import { callGeminiAPIBatch } from "./api";
+import { fetchDriveMetadata, downloadDriveFiles } from "./drive";
+import { uploadFilesToGemini } from "./files";
+import { buildInferenceRequest } from "./inference";
+import { CONFIG } from "./config";
+import { flattenArg, isValidDriveLink, extractId, writeJobProgress, /* keep existing */ } from "./utils";
+import type { GeminiRequest } from "./types";
+```
+
+Keep all other existing imports unchanged.
+
+- [ ] **Step 2: Replace the `runBatchAI` inner loop**
+
+Find the `for (let i = 0; i < dataValues.length; i++)` loop inside `runBatchAI` (currently lines ~334–380 in `src/server/index.ts`) and replace everything from after `const dataValues = ...` through `SpreadsheetApp.getActive().toast(...)` with the new parallel implementation:
+
+```typescript
+  const apiKey = PropertiesService.getScriptProperties().getProperty(CONFIG.API_KEY_PROPERTY);
+  if (!apiKey) {
+    ui.alert("Error", `${CONFIG.API_KEY_PROPERTY} script property not set`, ui.ButtonSet.OK);
+    return;
+  }
+
+  const cache = CacheService.getUserCache();
+  const hasFileInputs = config.promptCols.some((pc) => pc.kind === "file");
+
+  // Build all prompt input arrays (one per row) — pure, no I/O
+  const allPromptInputs = dataValues.map((row) =>
+    config.promptCols.map((pc, colIdx) => ({
+      kind: pc.kind,
+      value: row[promptIdxs[colIdx]],
+      ...(config.prefixWithColName ? { label: pc.col } : {}),
+    })),
+  );
+
+  // Wave 1 — file work (multimodal chunks only)
+  let fileUriMap = new Map<string, { uri: string; mimeType: string }>();
+
+  if (hasFileInputs) {
+    const oauthToken = ScriptApp.getOAuthToken();
+
+    // Collect unique Drive file IDs across all rows in this chunk
+    const allFileIds = new Set<string>();
+    for (const inputs of allPromptInputs) {
+      for (const input of inputs) {
+        if (input.kind === "file") {
+          flattenArg(input.value)
+            .filter(isValidDriveLink)
+            .map(extractId)
+            .forEach((id) => allFileIds.add(id));
+        }
+      }
+    }
+
+    const fileIds = Array.from(allFileIds);
+    if (fileIds.length > 0) {
+      if (jobId) {
+        writeJobProgress(cache, jobId, {
+          message: `Downloading files for chunk...`,
+        });
+      }
+      const metadata = fetchDriveMetadata(fileIds, oauthToken);
+      const bytes = downloadDriveFiles(fileIds, metadata, oauthToken);
+
+      if (jobId) {
+        writeJobProgress(cache, jobId, {
+          message: `Uploading files for chunk...`,
+        });
+      }
+      const mimeTypes = new Map(fileIds.map((id) => [id, metadata.get(id)!.mimeType]));
+      fileUriMap = uploadFilesToGemini(bytes, mimeTypes, apiKey);
+    }
+  }
+
+  // Wave 2 — build requests and fire inference in parallel
+  if (jobId) {
+    writeJobProgress(cache, jobId, { message: `Running AI on chunk...` });
+  }
+
+  const requests: GeminiRequest[] = [];
+  const rowIndices: number[] = [];
+
+  for (let i = 0; i < allPromptInputs.length; i++) {
+    const systemPrompt = systemPromptIdx >= 0 ? dataValues[i][systemPromptIdx] : undefined;
+    const req = buildInferenceRequest(allPromptInputs[i], systemPrompt, config.tools, fileUriMap);
+    if (req !== null) {
+      requests.push({ ...req, apiKey });
+      rowIndices.push(i);
+    }
+  }
+
+  if (requests.length === 0) return;
+
+  const results = callGeminiAPIBatch(requests);
+
+  // Write all results — single flush at end
+  for (let j = 0; j < results.length; j++) {
+    const i = rowIndices[j];
+    const realRowIndex = startRow + i;
+    const result = results[j];
+
+    if (config.applyMarkdown) {
+      try {
+        sheet
+          .getRange(realRowIndex, outputIdx + 1)
+          .setRichTextValue(toCellValue(buildRichInferenceCellContent(result)));
+      } catch (_e) {
+        sheet.getRange(realRowIndex, outputIdx + 1).setValue(result.text);
+      }
+    } else {
+      sheet.getRange(realRowIndex, outputIdx + 1).setValue(result.text);
+    }
+
+    if (config.includeGrounding && groundingIdx >= 0) {
+      const groundingContent = buildRichGroundingCellContent(result);
+      if (groundingContent !== null) {
+        sheet
+          .getRange(realRowIndex, groundingIdx + 1)
+          .setRichTextValue(toCellValue(groundingContent));
+      }
+    }
+  }
+
+  SpreadsheetApp.flush();
+  SpreadsheetApp.getActive().toast(`Complete! Processed ${results.length} rows.`, "Success", 5);
+```
+
+- [ ] **Step 3: Build and check for type errors**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors. Fix any type mismatches before proceeding.
+
+- [ ] **Step 4: Build the project**
+
+```bash
+npm run build
+```
+
+Expected: clean build to `dist/`
+
+- [ ] **Step 5: Manual deploy and test — text-only run**
+
+Deploy to the Apps Script project and run a text-only batch:
+
+```bash
+npm run deploy
+```
+
+1. Open the spreadsheet and sidebar
+2. Set up a sheet with a text prompt column and 10 rows of data
+3. Run AI on rows 2–11
+4. Verify: results appear in the output column, job indicator shows "Running AI on chunk...", completion toast fires
+
+- [ ] **Step 6: Manual deploy and test — multimodal run**
+
+1. Add a file column with 3–5 Drive file URLs (mix of Docs and PDFs)
+2. Run AI on those rows
+3. Verify: job indicator shows "Downloading files...", then "Uploading files...", then "Running AI...", then results appear
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/server/index.ts
+git commit -m "refactor: replace sequential runBatchAI loop with parallel fetchAll pipeline"
+```
+
+---
+
+## Task 6: Update `configure-ai-run.ts` constants and warning dialog
+
+**Files:**
+- Modify: `src/client/panels/configure-ai-run.ts`
+
+No new tests needed — `configure-ai-run.test.ts` tests `computeChunks` with an explicit chunk size argument and is unaffected by the constant changes.
+
+- [ ] **Step 1: Update constants and warning dialog copy**
+
+In `src/client/panels/configure-ai-run.ts`, make these three changes:
+
+```typescript
+// Line 12: change CHUNK_SIZE
+export const CHUNK_SIZE = 50;
+
+// Line 15: change CHUNK_WARN_THRESHOLD
+export const CHUNK_WARN_THRESHOLD = 200;
+```
+
+Find the `confirm(...)` call in `handleRun` and update the time estimate:
+
+```typescript
+// Replace:
+// const estimatedMins = Math.ceil((rowCount * 5) / 60);
+const estimatedMins = Math.ceil((rowCount * 0.5) / 60) || 1;
+
+// Replace the confirm message body:
+const ok = globalThis.confirm(
+  `You're about to process ${rowCount} rows across ${chunkCount} chunks.\n\n` +
+    `This will take roughly ${estimatedMins} minute(s). ` +
+    `The sidebar must remain open throughout — closing it will stop the run after the current chunk finishes.\n\n` +
+    `Continue?`,
+);
+```
+
+- [ ] **Step 2: Run existing configure-ai-run tests to confirm no regressions**
+
+```bash
+npx jest __tests__/configure-ai-run.test.ts --no-coverage
+```
+
+Expected: all pass
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+npm test -- --no-coverage
+```
+
+Expected: all tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/client/panels/configure-ai-run.ts
+git commit -m "feat: increase chunk size to 50 rows and update warning dialog for parallel execution"
+```
+
+---
+
+## Task 7: Add coverage threshold for `files.ts` and run full coverage check
+
+**Files:**
+- Modify: `jest.config.cjs`
+
+- [ ] **Step 1: Add threshold for `src/server/files.ts`**
+
+In `jest.config.cjs`, add to the `coverageThreshold` object (after the `api.ts` entry):
+
+```javascript
+"./src/server/files.ts": {
+  statements: 90,
+  branches: 85,
+  functions: 100,
+},
+```
+
+- [ ] **Step 2: Run coverage and confirm thresholds pass**
+
+```bash
+npm run test:coverage
+```
+
+Expected: all per-file thresholds pass. If `files.ts` falls below 90% statements, add tests in `__tests__/files.test.ts` for uncovered branches.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add jest.config.cjs
+git commit -m "test: add coverage threshold for files.ts"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec requirement | Task |
+|---|---|
+| `callGeminiAPIBatch` wraps `fetchAll` | Task 1 |
+| `file_data` parts pass through `buildGeminiPayload` | Task 1 (test) |
+| `fetchDriveMetadata` — parallel Drive API metadata | Task 2 |
+| `downloadDriveFiles` — parallel Drive export | Task 2 |
+| Google Sheets exports as CSV (first sheet only) | Task 2 (implemented, caveat documented in spec) |
+| `uploadFilesToGemini` — Files API multipart upload, sub-batches of 10 | Task 3 |
+| Extract `buildUserParts` (private), add `buildInferenceRequest` | Task 4 |
+| `runInference` simplified to `buildInferenceRequest` + `invokeGemini` | Task 4 |
+| Inline path (`prepareDriveAttachments`) preserved for `runInference` | Task 4 |
+| `runBatchAI` — text-only path (skip file waves) | Task 5 |
+| `runBatchAI` — multimodal path (Wave 1 + Wave 2) | Task 5 |
+| Within-chunk progress messages (Download/Upload/Run AI) | Task 5 |
+| Single `SpreadsheetApp.flush()` per chunk | Task 5 |
+| `CHUNK_SIZE` 10 → 50 | Task 6 |
+| `CHUNK_WARN_THRESHOLD` 50 → 200 | Task 6 |
+| Time estimate update | Task 6 |
+| Coverage threshold for `files.ts` | Task 7 |
+
+**Type consistency check:**
+
+- `buildInferenceRequest` returns `Omit<GeminiRequest, "apiKey"> | null` — matches usage in Task 5 where `apiKey` is spread in: `{ ...req, apiKey }`
+- `fileUriMap` type is `Map<string, { uri: string; mimeType: string }>` — consistent across Task 3 (return type), Task 4 (parameter type), Task 5 (usage)
+- `file_data` part uses `file_uri` and `mime_type` (snake_case) — matches existing `GeminiFileApiData` in `types.ts`
+- `uploadFilesToGemini` takes `Map<string, Uint8Array>` and `Map<string, string>` (mimeTypes) — consistent between Task 3 and Task 5 usage
+- `downloadDriveFiles` returns `Map<string, Uint8Array>` — consistent between Task 2 and Task 5 usage
+- `fetchDriveMetadata` returns `Map<string, { mimeType: string; size: number }>` — consistent between Task 2 and Task 5 usage

--- a/docs/superpowers/plans/2026-05-06-fix-coverage-thresholds.md
+++ b/docs/superpowers/plans/2026-05-06-fix-coverage-thresholds.md
@@ -1,0 +1,157 @@
+# Fix Coverage Thresholds Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Address failing coverage thresholds in `src/server/drive.ts` and `src/client/services.ts` by adding targeted unit tests.
+
+**Architecture:** Add missing test cases to existing Jest test files to exercise uncovered functions and branches. No source code changes required.
+
+**Tech Stack:** Jest, ts-jest
+
+---
+
+### Task 1: Add tests for `getActiveRangeInfo` in `services.test.ts`
+
+**Files:**
+- Modify: `__tests__/services.test.ts`
+
+- [ ] **Step 1: Add test block for `getActiveRangeInfo`**
+
+Append to the end of `__tests__/services.test.ts`:
+
+```typescript
+describe("getActiveRangeInfo", () => {
+  it("calls google.script.run.getActiveRangeInfo and resolves with range", async () => {
+    const handlers = captureHandlers();
+    const range = { start: 1, end: 5 };
+    const promise = services.getActiveRangeInfo();
+    handlers.resolve(range);
+    await expect(promise).resolves.toEqual(range);
+    expect(mockRun.getActiveRangeInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves with null when no range is active", async () => {
+    const handlers = captureHandlers();
+    const promise = services.getActiveRangeInfo();
+    handlers.resolve(null);
+    await expect(promise).resolves.toBeNull();
+  });
+
+  it("rejects on failure", async () => {
+    const handlers = captureHandlers();
+    const promise = services.getActiveRangeInfo();
+    handlers.reject(new Error("range error"));
+    await expect(promise).rejects.toThrow("range error");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify**
+
+Run: `npx jest __tests__/services.test.ts`
+Expected: All tests pass, including the 3 new ones.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add __tests__/services.test.ts
+git commit -m "test(client): add tests for getActiveRangeInfo service"
+```
+
+---
+
+### Task 2: Add branch coverage tests to `drive.test.ts`
+
+**Files:**
+- Modify: `__tests__/drive.test.ts`
+
+- [ ] **Step 1: Add error-handling and default branch tests to `fetchDriveMetadata`**
+
+Append to the `describe("fetchDriveMetadata", ...)` block in `__tests__/drive.test.ts`:
+
+```typescript
+  it("handles non-JSON error responses in fetchDriveMetadata", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      {
+        getResponseCode: () => 400,
+        getContentText: () => "Not a JSON string",
+      },
+    ]);
+    const { errors } = fetchDriveMetadata(["id"], "token");
+    expect(errors.get("id")).toBe("HTTP 400");
+  });
+
+  it("handles JSON error responses missing message in fetchDriveMetadata", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      {
+        getResponseCode: () => 400,
+        getContentText: () => JSON.stringify({ error: {} }),
+      },
+    ]);
+    const { errors } = fetchDriveMetadata(["id"], "token");
+    expect(errors.get("id")).toBe("HTTP 400");
+  });
+
+  it("uses default mimeType and size when missing in JSON response", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      {
+        getResponseCode: () => 200,
+        getContentText: () => JSON.stringify({}),
+      },
+    ]);
+    const { metadata } = fetchDriveMetadata(["id"], "token");
+    expect(metadata.get("id")).toEqual({
+      mimeType: "application/octet-stream",
+      size: 0,
+    });
+  });
+```
+
+- [ ] **Step 2: Add error-handling branch tests to `downloadDriveFiles`**
+
+Append to the `describe("downloadDriveFiles", ...)` block in `__tests__/drive.test.ts`:
+
+```typescript
+  it("handles non-JSON error responses in downloadDriveFiles", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getResponseCode: () => 500, getContentText: () => "Server Error" },
+    ]);
+    const { errors } = downloadDriveFiles(["id"], new Map(), "token");
+    expect(errors.get("id")).toBe("HTTP 500");
+  });
+
+  it("handles JSON error responses missing message in downloadDriveFiles", () => {
+    (UrlFetchApp.fetchAll as jest.Mock).mockReturnValue([
+      { getResponseCode: () => 401, getContentText: () => JSON.stringify({ error: {} }) },
+    ]);
+    const { errors } = downloadDriveFiles(["id"], new Map(), "token");
+    expect(errors.get("id")).toBe("HTTP 401");
+  });
+```
+
+- [ ] **Step 3: Run tests to verify**
+
+Run: `npx jest __tests__/drive.test.ts`
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add __tests__/drive.test.ts
+git commit -m "test(server): add edge-case branch tests for Drive API calls"
+```
+
+---
+
+### Task 3: Final Coverage Verification
+
+- [ ] **Step 1: Run full coverage suite**
+
+Run: `npm run test:coverage`
+
+- [ ] **Step 2: Verify thresholds**
+
+Expected:
+- `src/client/services.ts`: Functions: 100%
+- `src/server/drive.ts`: Branches: >= 95%
+- All tests pass, process exits with code 0.

--- a/docs/superpowers/specs/2026-05-06-fix-coverage-thresholds-design.md
+++ b/docs/superpowers/specs/2026-05-06-fix-coverage-thresholds-design.md
@@ -1,0 +1,29 @@
+# Fix Coverage Thresholds Design
+
+**Goal:** Address failing coverage thresholds in `src/server/drive.ts` (branches) and `src/client/services.ts` (functions) by adding targeted test cases.
+
+**Targeted Failures:**
+1. `src/client/services.ts`: Functions 100% threshold not met (Currently 87.5% because `getActiveRangeInfo` is untested).
+2. `src/server/drive.ts`: Branches 95% threshold not met (Currently 88.52% because error-handling branches in `fetchDriveMetadata` and `downloadDriveFiles` are not fully exercised).
+
+## Proposed Changes
+
+### 1. `__tests__/services.test.ts`
+- Add a new `describe("getActiveRangeInfo", ...)` block.
+- **Test Case 1 (Success)**: Verify it calls `google.script.run.getActiveRangeInfo` and resolves with the returned range `{ start: number, end: number }`.
+- **Test Case 2 (Failure)**: Verify it rejects with the error when the failure handler is triggered.
+
+### 2. `__tests__/drive.test.ts`
+- Add test cases to `describe("fetchDriveMetadata", ...)`:
+    - **Branch Coverage: JSON Parse Error**: Mock a response with code 400 and invalid JSON in `getContentText`.
+    - **Branch Coverage: Missing error message**: Mock a response with code 400 and JSON that doesn't contain `error.message`.
+    - **Branch Coverage: Missing mimeType/size**: Mock a response with code 200 and JSON missing `mimeType` and `size` fields to exercise the `??` defaults.
+- Add test cases to `describe("downloadDriveFiles", ...)`:
+    - **Branch Coverage: JSON Parse Error**: Mock a response with code 400 and invalid JSON.
+    - **Branch Coverage: Missing error message**: Mock a response with code 400 and JSON missing `error.message`.
+
+## Verification Plan
+1. Run `npm run test:coverage`.
+2. Confirm `src/client/services.ts` shows 100% functions.
+3. Confirm `src/server/drive.ts` shows > 95% branches.
+4. Ensure all other tests still pass.

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -41,6 +41,11 @@ module.exports = {
       branches: 90,
       functions: 100,
     },
+    "./src/server/files.ts": {
+      statements: 90,
+      branches: 80,
+      functions: 100,
+    },
     "./src/server/utils.ts": {
       statements: 83,
       branches: 93,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -96,6 +96,7 @@ function sampleRowsToEvaluation(jobId) { _GASEntry.sampleRowsToEvaluation(jobId)
 function SSI(userTexts, systemPrompt, toolNames) { return _GASEntry.SSI(userTexts, systemPrompt, toolNames); }
 function prepRecipe(params) { return _GASEntry.prepRecipe(params); }
 function getJobProgress(jobId) { return _GASEntry.getJobProgress(jobId); }
+function getActiveRangeInfo() { return _GASEntry.getActiveRangeInfo(); }
 `,
     },
     plugins: [

--- a/src/client/google.d.ts
+++ b/src/client/google.d.ts
@@ -17,6 +17,7 @@ declare global {
     extractText(config: ExtractTextConfig, jobId?: string): void;
     prepRecipe(params: PrepRecipeParams): PrepRecipeResult;
     getJobProgress(jobId: string): void;
+    getActiveRangeInfo(): void;
   }
 
   const google: {

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -5,11 +5,11 @@ import { TokenInput } from "../components/token-input";
 import { PromptColList } from "../components/prompt-col-list";
 import { RowRange } from "../components/row-range";
 import { PanelLoader } from "../components/panel-loader";
-import { getSheetHeaders, runBatchAI } from "../services";
+import { getSheetHeaders, runBatchAI, getActiveRangeInfo } from "../services";
 import { jobStore } from "../job-store";
 import { TOOL_CATALOG } from "../tools";
 
-export const CHUNK_SIZE = 50;
+export const CHUNK_SIZE = 40;
 // Warn before dispatch when the batch exceeds this many rows, regardless of chunk count.
 // Kept separate from CHUNK_SIZE so small multi-chunk runs don't trigger the dialog.
 export const CHUNK_WARN_THRESHOLD = 200;
@@ -287,11 +287,23 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
           globalThis.alert("Error: " + err.message);
         });
     } else {
-      // No explicit row range — active sheet selection, resolved server-side.
-      // Fall back to single dispatch (no chunking, no warning).
-      jobStore.dispatch(jobId, "Batch AI Run", runBatchAI(config, jobId)).catch((err: Error) => {
-        globalThis.alert("Error: " + err.message);
-      });
+      // No explicit row range — query the active sheet selection from the server,
+      // then chunk identically to the explicit rowRange path.
+      jobStore
+        .dispatch(
+          jobId,
+          "Batch AI Run",
+          getActiveRangeInfo().then((rangeInfo) => {
+            if (rangeInfo) {
+              const chunks = computeChunks(rangeInfo, CHUNK_SIZE);
+              return this.runChunks(jobId, config, chunks);
+            }
+            return runBatchAI(config, jobId);
+          }),
+        )
+        .catch((err: Error) => {
+          globalThis.alert("Error: " + err.message);
+        });
     }
     // NOTE: loadHeaders() is intentionally NOT called here.
     // Reloading after dispatch caused flicker and re-initialization mid-run.

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -9,10 +9,10 @@ import { getSheetHeaders, runBatchAI } from "../services";
 import { jobStore } from "../job-store";
 import { TOOL_CATALOG } from "../tools";
 
-export const CHUNK_SIZE = 10;
+export const CHUNK_SIZE = 50;
 // Warn before dispatch when the batch exceeds this many rows, regardless of chunk count.
 // Kept separate from CHUNK_SIZE so small multi-chunk runs don't trigger the dialog.
-export const CHUNK_WARN_THRESHOLD = 50;
+export const CHUNK_WARN_THRESHOLD = 200;
 
 export function computeChunks(
   rowRange: { start: number; end: number },
@@ -267,8 +267,8 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
       const rowCount = config.rowRange.end - config.rowRange.start + 1;
       if (rowCount > CHUNK_WARN_THRESHOLD) {
         const chunkCount = Math.ceil(rowCount / CHUNK_SIZE);
-        // ~5 s/row is a conservative estimate based on typical Gemini API latency.
-        const estimatedMins = Math.ceil((rowCount * 5) / 60);
+        // ~0.5 s/row estimate reflects ~10x speedup from parallel inference.
+        const estimatedMins = Math.ceil((rowCount * 0.5) / 60) || 1;
         const ok = globalThis.confirm(
           `You're about to process ${rowCount} rows across ${chunkCount} chunks.\n\n` +
             `This will take roughly ${estimatedMins} minutes. ` +

--- a/src/client/services.ts
+++ b/src/client/services.ts
@@ -60,6 +60,17 @@ export function extractText(config: ExtractTextConfig, jobId?: string): Promise<
   });
 }
 
+export function getActiveRangeInfo(): Promise<{ start: number; end: number } | null> {
+  return new Promise((resolve, reject) => {
+    google.script.run
+      .withSuccessHandler((result: unknown) =>
+        resolve(result as { start: number; end: number } | null),
+      )
+      .withFailureHandler((err: Error) => reject(err))
+      .getActiveRangeInfo();
+  });
+}
+
 export function getJobProgress(
   jobId: string,
 ): Promise<{ message?: string; current?: number; total?: number } | null> {

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -104,6 +104,69 @@ export function callGeminiAPI(req: GeminiRequest): GeminiResponse {
 }
 
 /**
+ * Call the Gemini generateContent endpoint for multiple requests in parallel using UrlFetchApp.fetchAll.
+ * Unlike callGeminiAPI (which throws on error), the batch version maps errors to { text: "Error: ..." }
+ * so one bad row does not abort the whole chunk.
+ */
+export function callGeminiAPIBatch(reqs: GeminiRequest[]): GeminiResponse[] {
+  if (reqs.length === 0) return [];
+
+  const requests = reqs.map((req) => {
+    const modelName = req.modelName ?? CONFIG.MODEL_NAME;
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent?key=${req.apiKey}`;
+    return {
+      url,
+      method: "post" as const,
+      contentType: "application/json",
+      payload: JSON.stringify(buildGeminiPayload(req)),
+      muteHttpExceptions: true,
+    };
+  });
+
+  const responses = UrlFetchApp.fetchAll(requests);
+
+  return responses.map((response) => {
+    const json = JSON.parse(response.getContentText()) as Record<string, unknown>;
+
+    if (json.error) {
+      return { text: `Error: ${(json.error as { message: string }).message}` };
+    }
+
+    const candidate = (json.candidates as Array<Record<string, unknown>> | undefined)?.[0];
+    const parts =
+      (candidate?.content as { parts?: Array<Record<string, unknown>> } | undefined)?.parts ?? [];
+
+    const textParts = parts
+      .filter((p): p is { text: string } => typeof p["text"] === "string")
+      .map((p) => p.text);
+    const text = textParts.join("\n\n") || "No response.";
+
+    const codePairs: GeminiCodePair[] = [];
+    for (let i = 0; i < parts.length - 1; i++) {
+      const curr = parts[i];
+      const next = parts[i + 1];
+      if (curr["executableCode"] !== undefined && next["codeExecutionResult"] !== undefined) {
+        codePairs.push({
+          code: curr["executableCode"] as GeminiCodePair["code"],
+          result: next["codeExecutionResult"] as GeminiCodePair["result"],
+        });
+        i++; // skip the result part — already consumed
+      }
+    }
+
+    const groundingMetadata = candidate?.["groundingMetadata"] as
+      | GeminiResponse["groundingMetadata"]
+      | undefined;
+
+    return {
+      text,
+      ...(groundingMetadata !== undefined && { groundingMetadata }),
+      ...(codePairs.length > 0 && { codePairs }),
+    };
+  });
+}
+
+/**
  * Resolve the Gemini API key from Script Properties and call callGeminiAPI.
  * This is the preferred entry point for all production Gemini calls.
  * Throws if the API key property is not set.

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -126,7 +126,12 @@ export function callGeminiAPIBatch(reqs: GeminiRequest[]): GeminiResponse[] {
   const responses = UrlFetchApp.fetchAll(requests);
 
   return responses.map((response) => {
-    const json = JSON.parse(response.getContentText()) as Record<string, unknown>;
+    let json: Record<string, unknown>;
+    try {
+      json = JSON.parse(response.getContentText()) as Record<string, unknown>;
+    } catch (_e) {
+      return { text: `Error: invalid response body (HTTP ${response.getResponseCode()})` };
+    }
 
     if (json.error) {
       return { text: `Error: ${(json.error as { message: string }).message}` };

--- a/src/server/drive.ts
+++ b/src/server/drive.ts
@@ -322,7 +322,14 @@ export function downloadDriveFiles(
   responses.forEach((response, i) => {
     const code = response.getResponseCode();
     if (code >= 400) {
-      errors.set(fileIds[i], `HTTP ${code}`);
+      let message = `HTTP ${code}`;
+      try {
+        const parsed = JSON.parse(response.getContentText()) as { error?: { message: string } };
+        if (parsed.error?.message) message = parsed.error.message;
+      } catch (_e) {
+        // ignore parse errors, use HTTP code in message
+      }
+      errors.set(fileIds[i], message);
       return;
     }
     bytes.set(fileIds[i], new Uint8Array(response.getContent()));

--- a/src/server/drive.ts
+++ b/src/server/drive.ts
@@ -291,7 +291,7 @@ export function downloadDriveFiles(
   fileIds: string[],
   metadata: Map<string, { mimeType: string; size: number }>,
   oauthToken: string,
-): { bytes: Map<string, Uint8Array>; errors: Map<string, string> } {
+): { bytes: Map<string, GoogleAppsScript.Base.Blob>; errors: Map<string, string> } {
   if (fileIds.length === 0) return { bytes: new Map(), errors: new Map() };
 
   const DOCS_MIME = "application/vnd.google-apps.document";
@@ -316,7 +316,7 @@ export function downloadDriveFiles(
   });
 
   const responses = UrlFetchApp.fetchAll(requests);
-  const bytes = new Map<string, Uint8Array>();
+  const bytes = new Map<string, GoogleAppsScript.Base.Blob>();
   const errors = new Map<string, string>();
 
   responses.forEach((response, i) => {
@@ -332,7 +332,7 @@ export function downloadDriveFiles(
       errors.set(fileIds[i], message);
       return;
     }
-    bytes.set(fileIds[i], new Uint8Array(response.getContent()));
+    bytes.set(fileIds[i], response.getBlob());
   });
 
   return { bytes, errors };

--- a/src/server/drive.ts
+++ b/src/server/drive.ts
@@ -240,7 +240,7 @@ export function fetchDriveMetadata(
   if (fileIds.length === 0) return new Map();
 
   const requests = fileIds.map((id) => ({
-    url: `https://www.googleapis.com/drive/v3/files/${id}?fields=id%2CmimeType%2Csize`,
+    url: `https://www.googleapis.com/drive/v3/files/${id}?fields=id%2CmimeType%2Csize&supportsAllDrives=true`,
     method: "get" as const,
     headers: { Authorization: `Bearer ${oauthToken}` },
     muteHttpExceptions: true,
@@ -300,11 +300,11 @@ export function downloadDriveFiles(
     const mimeType = metadata.get(id)?.mimeType ?? "";
     let url: string;
     if (mimeType === DOCS_MIME) {
-      url = `https://www.googleapis.com/drive/v3/files/${id}/export?mimeType=application/pdf`;
+      url = `https://www.googleapis.com/drive/v3/files/${id}/export?mimeType=application/pdf&supportsAllDrives=true`;
     } else if (mimeType === SHEETS_MIME) {
-      url = `https://www.googleapis.com/drive/v3/files/${id}/export?mimeType=text/csv`;
+      url = `https://www.googleapis.com/drive/v3/files/${id}/export?mimeType=text/csv&supportsAllDrives=true`;
     } else {
-      url = `https://www.googleapis.com/drive/v3/files/${id}?alt=media`;
+      url = `https://www.googleapis.com/drive/v3/files/${id}?alt=media&supportsAllDrives=true`;
     }
     return {
       url,

--- a/src/server/drive.ts
+++ b/src/server/drive.ts
@@ -100,6 +100,8 @@ function exportAndEncodeFile(
     // first sheet as CSV. Per-sheet export requires SpreadsheetApp to enumerate sheets
     // and get each sheet's values directly. This is a data-access use of SpreadsheetApp,
     // not a UI concern, so the index.ts-only rule does not apply here.
+    // NOTE: Multi-sheet Sheets files can only export the first sheet as CSV.
+    // Per-sheet parallelization is a known limitation (design doc deferred feature).
     const ss = SpreadsheetApp.openById(fileId);
     return ss.getSheets().map((sheet) => {
       const values = sheet.getDataRange().getValues();

--- a/src/server/drive.ts
+++ b/src/server/drive.ts
@@ -218,3 +218,110 @@ export function prepareDriveAttachments(fileIds: string[]): GeminiInlineData[] {
 
   return parts;
 }
+
+/**
+ * Fetch metadata for multiple Drive files in parallel using UrlFetchApp.fetchAll.
+ * Returns a map of fileId to { mimeType, size }.
+ *
+ * Note: Google Workspace native files (Docs, Sheets, Slides) do not have a
+ * size field in the Drive API v3 response; size will be 0 for those types.
+ *
+ * @param fileIds - Array of Drive file IDs to fetch metadata for
+ * @param oauthToken - OAuth token with Drive API access
+ * @returns Map of fileId to { mimeType, size }
+ * @throws Error if Drive API returns an error for any file
+ */
+export function fetchDriveMetadata(
+  fileIds: string[],
+  oauthToken: string,
+): Map<string, { mimeType: string; size: number }> {
+  if (fileIds.length === 0) return new Map();
+
+  const requests = fileIds.map((id) => ({
+    url: `https://www.googleapis.com/drive/v3/files/${id}?fields=id%2CmimeType%2Csize`,
+    method: "get" as const,
+    headers: { Authorization: `Bearer ${oauthToken}` },
+    muteHttpExceptions: true,
+  }));
+
+  const responses = UrlFetchApp.fetchAll(requests);
+  const result = new Map<string, { mimeType: string; size: number }>();
+
+  responses.forEach((response, i) => {
+    const code = response.getResponseCode();
+    if (code >= 400) {
+      let message = `HTTP ${code}`;
+      try {
+        const parsed = JSON.parse(response.getContentText()) as { error?: { message: string } };
+        if (parsed.error?.message) message = parsed.error.message;
+      } catch (_e) {
+        // ignore parse errors, use HTTP code in message
+      }
+      throw new Error(`Failed to fetch metadata for ${fileIds[i]}: ${message}`);
+    }
+    const json = JSON.parse(response.getContentText()) as {
+      mimeType?: string;
+      size?: string;
+      error?: { message: string };
+    };
+    result.set(fileIds[i], {
+      mimeType: json.mimeType ?? "application/octet-stream",
+      size: parseInt(json.size ?? "0", 10),
+    });
+  });
+
+  return result;
+}
+
+/**
+ * Download multiple Drive files in parallel using UrlFetchApp.fetchAll.
+ * Handles format conversion for Google Docs (→ PDF) and Sheets (→ CSV).
+ * Returns a map of fileId to Uint8Array bytes.
+ *
+ * @param fileIds - Array of Drive file IDs to download
+ * @param metadata - Map of fileId to { mimeType, size } from fetchDriveMetadata
+ * @param oauthToken - OAuth token with Drive API access
+ * @returns Map of fileId to Uint8Array bytes
+ * @throws Error if any download returns HTTP 400+
+ */
+export function downloadDriveFiles(
+  fileIds: string[],
+  metadata: Map<string, { mimeType: string; size: number }>,
+  oauthToken: string,
+): Map<string, Uint8Array> {
+  if (fileIds.length === 0) return new Map();
+
+  const DOCS_MIME = "application/vnd.google-apps.document";
+  const SHEETS_MIME = "application/vnd.google-apps.spreadsheet";
+
+  const requests = fileIds.map((id) => {
+    const mimeType = metadata.get(id)?.mimeType ?? "";
+    let url: string;
+    if (mimeType === DOCS_MIME) {
+      url = `https://www.googleapis.com/drive/v3/files/${id}/export?mimeType=application/pdf`;
+    } else if (mimeType === SHEETS_MIME) {
+      url = `https://www.googleapis.com/drive/v3/files/${id}/export?mimeType=text/csv`;
+    } else {
+      url = `https://www.googleapis.com/drive/v3/files/${id}?alt=media`;
+    }
+    return {
+      url,
+      method: "get" as const,
+      headers: { Authorization: `Bearer ${oauthToken}` },
+      muteHttpExceptions: true,
+    };
+  });
+
+  const responses = UrlFetchApp.fetchAll(requests);
+  const result = new Map<string, Uint8Array>();
+
+  responses.forEach((response, i) => {
+    const code = response.getResponseCode();
+    if (code >= 400) {
+      throw new Error(`Failed to download file ${fileIds[i]}: HTTP ${code}`);
+    }
+    result.set(fileIds[i], new Uint8Array(response.getContent()));
+  });
+
+  return result;
+}

--- a/src/server/drive.ts
+++ b/src/server/drive.ts
@@ -223,21 +223,21 @@ export function prepareDriveAttachments(fileIds: string[]): GeminiInlineData[] {
 
 /**
  * Fetch metadata for multiple Drive files in parallel using UrlFetchApp.fetchAll.
- * Returns a map of fileId to { mimeType, size }.
+ * Returns partial results — files that fail are recorded in `errors` rather than
+ * aborting the whole batch.
  *
  * Note: Google Workspace native files (Docs, Sheets, Slides) do not have a
  * size field in the Drive API v3 response; size will be 0 for those types.
  *
  * @param fileIds - Array of Drive file IDs to fetch metadata for
  * @param oauthToken - OAuth token with Drive API access
- * @returns Map of fileId to { mimeType, size }
- * @throws Error if Drive API returns an error for any file
+ * @returns { metadata: Map of fileId to { mimeType, size }, errors: Map of fileId to error message }
  */
 export function fetchDriveMetadata(
   fileIds: string[],
   oauthToken: string,
-): Map<string, { mimeType: string; size: number }> {
-  if (fileIds.length === 0) return new Map();
+): { metadata: Map<string, { mimeType: string; size: number }>; errors: Map<string, string> } {
+  if (fileIds.length === 0) return { metadata: new Map(), errors: new Map() };
 
   const requests = fileIds.map((id) => ({
     url: `https://www.googleapis.com/drive/v3/files/${id}?fields=id%2CmimeType%2Csize&supportsAllDrives=true`,
@@ -247,7 +247,8 @@ export function fetchDriveMetadata(
   }));
 
   const responses = UrlFetchApp.fetchAll(requests);
-  const result = new Map<string, { mimeType: string; size: number }>();
+  const metadata = new Map<string, { mimeType: string; size: number }>();
+  const errors = new Map<string, string>();
 
   responses.forEach((response, i) => {
     const code = response.getResponseCode();
@@ -259,39 +260,39 @@ export function fetchDriveMetadata(
       } catch (_e) {
         // ignore parse errors, use HTTP code in message
       }
-      throw new Error(`Failed to fetch metadata for ${fileIds[i]}: ${message}`);
+      errors.set(fileIds[i], message);
+      return;
     }
     const json = JSON.parse(response.getContentText()) as {
       mimeType?: string;
       size?: string;
-      error?: { message: string };
     };
-    result.set(fileIds[i], {
+    metadata.set(fileIds[i], {
       mimeType: json.mimeType ?? "application/octet-stream",
       size: parseInt(json.size ?? "0", 10),
     });
   });
 
-  return result;
+  return { metadata, errors };
 }
 
 /**
  * Download multiple Drive files in parallel using UrlFetchApp.fetchAll.
  * Handles format conversion for Google Docs (→ PDF) and Sheets (→ CSV).
- * Returns a map of fileId to Uint8Array bytes.
+ * Returns partial results — files that fail are recorded in `errors` rather than
+ * aborting the whole batch.
  *
  * @param fileIds - Array of Drive file IDs to download
  * @param metadata - Map of fileId to { mimeType, size } from fetchDriveMetadata
  * @param oauthToken - OAuth token with Drive API access
- * @returns Map of fileId to Uint8Array bytes
- * @throws Error if any download returns HTTP 400+
+ * @returns { bytes: Map of fileId to Uint8Array, errors: Map of fileId to error message }
  */
 export function downloadDriveFiles(
   fileIds: string[],
   metadata: Map<string, { mimeType: string; size: number }>,
   oauthToken: string,
-): Map<string, Uint8Array> {
-  if (fileIds.length === 0) return new Map();
+): { bytes: Map<string, Uint8Array>; errors: Map<string, string> } {
+  if (fileIds.length === 0) return { bytes: new Map(), errors: new Map() };
 
   const DOCS_MIME = "application/vnd.google-apps.document";
   const SHEETS_MIME = "application/vnd.google-apps.spreadsheet";
@@ -315,15 +316,17 @@ export function downloadDriveFiles(
   });
 
   const responses = UrlFetchApp.fetchAll(requests);
-  const result = new Map<string, Uint8Array>();
+  const bytes = new Map<string, Uint8Array>();
+  const errors = new Map<string, string>();
 
   responses.forEach((response, i) => {
     const code = response.getResponseCode();
     if (code >= 400) {
-      throw new Error(`Failed to download file ${fileIds[i]}: HTTP ${code}`);
+      errors.set(fileIds[i], `HTTP ${code}`);
+      return;
     }
-    result.set(fileIds[i], new Uint8Array(response.getContent()));
+    bytes.set(fileIds[i], new Uint8Array(response.getContent()));
   });
 
-  return result;
+  return { bytes, errors };
 }

--- a/src/server/files.ts
+++ b/src/server/files.ts
@@ -1,0 +1,92 @@
+/**
+ * files.ts — Gemini Files API integration.
+ *
+ * Uploads Drive file bytes to the Gemini Files API and returns stable URI
+ * references. Files are cached on Gemini's servers for 48 hours.
+ * Using URIs instead of inline base64 eliminates GAS memory pressure and
+ * enables deduplication across rows in a chunk.
+ */
+
+/**
+ * Upload a batch of files to the Gemini Files API in parallel.
+ * Processed in sub-batches of 10 to limit peak memory.
+ *
+ * @param files     Map of driveFileId → raw bytes (Uint8Array)
+ * @param mimeTypes Map of driveFileId → MIME type string
+ * @param apiKey    Gemini API key
+ * @returns Map of driveFileId → { uri, mimeType } from the Files API response
+ */
+export function uploadFilesToGemini(
+  files: Map<string, Uint8Array>,
+  mimeTypes: Map<string, string>,
+  apiKey: string,
+): Map<string, { uri: string; mimeType: string }> {
+  const result = new Map<string, { uri: string; mimeType: string }>();
+  const fileIds = Array.from(files.keys());
+  if (fileIds.length === 0) return result;
+
+  const BATCH_SIZE = 10;
+  for (let i = 0; i < fileIds.length; i += BATCH_SIZE) {
+    const batch = fileIds.slice(i, i + BATCH_SIZE);
+    const requests = batch.map((fileId) =>
+      buildUploadRequest(
+        fileId,
+        files.get(fileId)!,
+        mimeTypes.get(fileId) ?? "application/octet-stream",
+        apiKey,
+      ),
+    );
+
+    const responses = UrlFetchApp.fetchAll(requests);
+    responses.forEach((response, j) => {
+      const fileId = batch[j];
+      const json = JSON.parse(response.getContentText()) as {
+        file?: { uri: string; mimeType: string };
+        error?: { message: string };
+      };
+      if (json.error || !json.file?.uri) {
+        throw new Error(
+          `Failed to upload file ${fileId}: ${json.error?.message ?? "missing URI in response"}`,
+        );
+      }
+      result.set(fileId, { uri: json.file.uri, mimeType: json.file.mimeType });
+    });
+  }
+
+  return result;
+}
+
+function buildUploadRequest(
+  fileId: string,
+  bytes: Uint8Array,
+  mimeType: string,
+  apiKey: string,
+): GoogleAppsScript.URL_Fetch.URLFetchRequest {
+  const boundary = "boundary" + Math.random().toString(36).slice(2, 18);
+  const metadata = JSON.stringify({ file: { display_name: fileId } });
+
+  const pre = stringToBytes(
+    `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${metadata}\r\n--${boundary}\r\nContent-Type: ${mimeType}\r\n\r\n`,
+  );
+  const post = stringToBytes(`\r\n--${boundary}--`);
+
+  const body = new Uint8Array(pre.length + bytes.length + post.length);
+  body.set(pre, 0);
+  body.set(bytes, pre.length);
+  body.set(post, pre.length + bytes.length);
+
+  return {
+    url: `https://generativelanguage.googleapis.com/upload/v1beta/files?key=${apiKey}`,
+    method: "post",
+    contentType: `multipart/related; boundary=${boundary}`,
+    headers: { "X-Goog-Upload-Protocol": "multipart" },
+    payload: Array.from(body) as GoogleAppsScript.Byte[],
+    muteHttpExceptions: true,
+  };
+}
+
+// ASCII-only: used exclusively for multipart boundary headers and JSON metadata.
+// Drive file IDs are always alphanumeric ASCII, so this is safe.
+function stringToBytes(s: string): Uint8Array {
+  return new Uint8Array(s.split("").map((c) => c.charCodeAt(0)));
+}

--- a/src/server/files.ts
+++ b/src/server/files.ts
@@ -1,25 +1,29 @@
 /**
  * files.ts — Gemini Files API integration.
  *
- * Uploads Drive file bytes to the Gemini Files API and returns stable URI
- * references. Files are cached on Gemini's servers for 48 hours.
- * Using URIs instead of inline base64 eliminates GAS memory pressure and
- * enables deduplication across rows in a chunk.
+ * Uploads Drive file blobs to the Gemini Files API via the resumable upload
+ * protocol and returns stable URI references. Files are cached on Gemini's
+ * servers for 48 hours.
+ *
+ * Resumable upload (two fetchAll passes) is used instead of multipart upload
+ * because the Blob payload is passed directly to UrlFetchApp without ever
+ * calling getContent() / Array.from(), avoiding the ~8× memory expansion that
+ * the Uint8Array → Byte[] conversion causes in the V8 GAS runtime.
  */
 
 /**
- * Upload a batch of files to the Gemini Files API in parallel.
- * Processed in sub-batches of 10 to limit peak memory.
+ * Upload a batch of Drive file blobs to the Gemini Files API in parallel.
+ * Uses a two-phase resumable protocol: init (get session URIs) then upload (send blobs).
  * Returns partial results — files that fail are recorded in `errors` rather than
  * aborting the whole batch.
  *
- * @param files     Map of driveFileId → raw bytes (Uint8Array)
+ * @param files     Map of driveFileId → GAS Blob (from UrlFetchApp response.getBlob())
  * @param mimeTypes Map of driveFileId → MIME type string
  * @param apiKey    Gemini API key
  * @returns { uploads: Map of driveFileId → { uri, mimeType }, errors: Map of driveFileId → error message }
  */
 export function uploadFilesToGemini(
-  files: Map<string, Uint8Array>,
+  files: Map<string, GoogleAppsScript.Base.Blob>,
   mimeTypes: Map<string, string>,
   apiKey: string,
 ): { uploads: Map<string, { uri: string; mimeType: string }>; errors: Map<string, string> } {
@@ -28,75 +32,78 @@ export function uploadFilesToGemini(
   const fileIds = Array.from(files.keys());
   if (fileIds.length === 0) return { uploads, errors };
 
-  const BATCH_SIZE = 10;
-  for (let i = 0; i < fileIds.length; i += BATCH_SIZE) {
-    const batch = fileIds.slice(i, i + BATCH_SIZE);
-    const requests = batch.map((fileId) =>
-      buildUploadRequest(
-        fileId,
-        files.get(fileId)!,
-        mimeTypes.get(fileId) ?? "application/octet-stream",
-        apiKey,
-      ),
-    );
+  // Phase 1: initiate all resumable uploads in parallel — lightweight JSON requests only
+  const initRequests = fileIds.map((fileId) => ({
+    url: `https://generativelanguage.googleapis.com/upload/v1beta/files?key=${apiKey}`,
+    method: "post" as const,
+    contentType: "application/json",
+    headers: {
+      "X-Goog-Upload-Protocol": "resumable",
+      "X-Goog-Upload-Command": "start",
+      "X-Goog-Upload-Header-Content-Type": mimeTypes.get(fileId) ?? "application/octet-stream",
+    },
+    payload: JSON.stringify({ file: { display_name: fileId } }),
+    muteHttpExceptions: true,
+  }));
 
-    const responses = UrlFetchApp.fetchAll(requests);
-    responses.forEach((response, j) => {
-      const fileId = batch[j];
-      const code = response.getResponseCode();
-      if (code >= 400) {
-        errors.set(fileId, `HTTP ${code}`);
-        return;
-      }
-      let json: { file?: { uri: string; mimeType: string }; error?: { message: string } };
-      try {
-        json = JSON.parse(response.getContentText()) as typeof json;
-      } catch (_e) {
-        errors.set(fileId, "Invalid JSON in upload response");
-        return;
-      }
-      if (json.error || !json.file?.uri) {
-        errors.set(fileId, json.error?.message ?? "missing URI in response");
-        return;
-      }
-      uploads.set(fileId, { uri: json.file.uri, mimeType: json.file.mimeType });
-    });
-  }
+  const initResponses = UrlFetchApp.fetchAll(initRequests);
+
+  // Collect session URIs; record any init errors
+  const sessionPairs: Array<{ fileId: string; sessionUri: string }> = [];
+  initResponses.forEach((resp, i) => {
+    const fileId = fileIds[i];
+    if (resp.getResponseCode() >= 400) {
+      errors.set(fileId, `HTTP ${resp.getResponseCode()}`);
+      return;
+    }
+    const headers = resp.getHeaders() as Record<string, string>;
+    // GAS normalizes response header keys to lowercase; search case-insensitively.
+    const sessionUri = Object.entries(headers).find(
+      ([k]) => k.toLowerCase() === "x-goog-upload-url",
+    )?.[1];
+    if (!sessionUri) {
+      errors.set(fileId, "Missing upload session URI");
+      return;
+    }
+    sessionPairs.push({ fileId, sessionUri });
+  });
+
+  if (sessionPairs.length === 0) return { uploads, errors };
+
+  // Phase 2: upload file content in parallel — Blob passed directly, no Array.from() needed
+  const uploadRequests = sessionPairs.map(({ fileId, sessionUri }) => ({
+    url: sessionUri,
+    method: "post" as const,
+    contentType: mimeTypes.get(fileId) ?? "application/octet-stream",
+    headers: {
+      "X-Goog-Upload-Command": "upload, finalize",
+      "X-Goog-Upload-Offset": "0",
+    },
+    payload: files.get(fileId)!,
+    muteHttpExceptions: true,
+  }));
+
+  const uploadResponses = UrlFetchApp.fetchAll(uploadRequests);
+
+  uploadResponses.forEach((resp, i) => {
+    const { fileId } = sessionPairs[i];
+    if (resp.getResponseCode() >= 400) {
+      errors.set(fileId, `HTTP ${resp.getResponseCode()}`);
+      return;
+    }
+    let json: { file?: { uri: string; mimeType: string }; error?: { message: string } };
+    try {
+      json = JSON.parse(resp.getContentText()) as typeof json;
+    } catch (_e) {
+      errors.set(fileId, "Invalid JSON in upload response");
+      return;
+    }
+    if (json.error || !json.file?.uri) {
+      errors.set(fileId, json.error?.message ?? "missing URI in response");
+      return;
+    }
+    uploads.set(fileId, { uri: json.file.uri, mimeType: json.file.mimeType });
+  });
 
   return { uploads, errors };
-}
-
-function buildUploadRequest(
-  fileId: string,
-  bytes: Uint8Array,
-  mimeType: string,
-  apiKey: string,
-): GoogleAppsScript.URL_Fetch.URLFetchRequest {
-  const boundary = "boundary" + Math.random().toString(36).slice(2, 18);
-  const metadata = JSON.stringify({ file: { display_name: fileId } });
-
-  const pre = stringToBytes(
-    `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${metadata}\r\n--${boundary}\r\nContent-Type: ${mimeType}\r\n\r\n`,
-  );
-  const post = stringToBytes(`\r\n--${boundary}--`);
-
-  const body = new Uint8Array(pre.length + bytes.length + post.length);
-  body.set(pre, 0);
-  body.set(bytes, pre.length);
-  body.set(post, pre.length + bytes.length);
-
-  return {
-    url: `https://generativelanguage.googleapis.com/upload/v1beta/files?key=${apiKey}`,
-    method: "post",
-    contentType: `multipart/related; boundary=${boundary}`,
-    headers: { "X-Goog-Upload-Protocol": "multipart" },
-    payload: Array.from(body) as GoogleAppsScript.Byte[],
-    muteHttpExceptions: true,
-  };
-}
-
-// ASCII-only: used exclusively for multipart boundary headers and JSON metadata.
-// Drive file IDs are always alphanumeric ASCII, so this is safe.
-function stringToBytes(s: string): Uint8Array {
-  return new Uint8Array(s.split("").map((c) => c.charCodeAt(0)));
 }

--- a/src/server/files.ts
+++ b/src/server/files.ts
@@ -10,20 +10,23 @@
 /**
  * Upload a batch of files to the Gemini Files API in parallel.
  * Processed in sub-batches of 10 to limit peak memory.
+ * Returns partial results — files that fail are recorded in `errors` rather than
+ * aborting the whole batch.
  *
  * @param files     Map of driveFileId → raw bytes (Uint8Array)
  * @param mimeTypes Map of driveFileId → MIME type string
  * @param apiKey    Gemini API key
- * @returns Map of driveFileId → { uri, mimeType } from the Files API response
+ * @returns { uploads: Map of driveFileId → { uri, mimeType }, errors: Map of driveFileId → error message }
  */
 export function uploadFilesToGemini(
   files: Map<string, Uint8Array>,
   mimeTypes: Map<string, string>,
   apiKey: string,
-): Map<string, { uri: string; mimeType: string }> {
-  const result = new Map<string, { uri: string; mimeType: string }>();
+): { uploads: Map<string, { uri: string; mimeType: string }>; errors: Map<string, string> } {
+  const uploads = new Map<string, { uri: string; mimeType: string }>();
+  const errors = new Map<string, string>();
   const fileIds = Array.from(files.keys());
-  if (fileIds.length === 0) return result;
+  if (fileIds.length === 0) return { uploads, errors };
 
   const BATCH_SIZE = 10;
   for (let i = 0; i < fileIds.length; i += BATCH_SIZE) {
@@ -45,15 +48,14 @@ export function uploadFilesToGemini(
         error?: { message: string };
       };
       if (json.error || !json.file?.uri) {
-        throw new Error(
-          `Failed to upload file ${fileId}: ${json.error?.message ?? "missing URI in response"}`,
-        );
+        errors.set(fileId, json.error?.message ?? "missing URI in response");
+        return;
       }
-      result.set(fileId, { uri: json.file.uri, mimeType: json.file.mimeType });
+      uploads.set(fileId, { uri: json.file.uri, mimeType: json.file.mimeType });
     });
   }
 
-  return result;
+  return { uploads, errors };
 }
 
 function buildUploadRequest(

--- a/src/server/files.ts
+++ b/src/server/files.ts
@@ -43,10 +43,18 @@ export function uploadFilesToGemini(
     const responses = UrlFetchApp.fetchAll(requests);
     responses.forEach((response, j) => {
       const fileId = batch[j];
-      const json = JSON.parse(response.getContentText()) as {
-        file?: { uri: string; mimeType: string };
-        error?: { message: string };
-      };
+      const code = response.getResponseCode();
+      if (code >= 400) {
+        errors.set(fileId, `HTTP ${code}`);
+        return;
+      }
+      let json: { file?: { uri: string; mimeType: string }; error?: { message: string } };
+      try {
+        json = JSON.parse(response.getContentText()) as typeof json;
+      } catch (_e) {
+        errors.set(fileId, "Invalid JSON in upload response");
+        return;
+      }
       if (json.error || !json.file?.uri) {
         errors.set(fileId, json.error?.message ?? "missing URI in response");
         return;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -255,6 +255,12 @@ function toCellValue(content: CellContent): GoogleAppsScript.Spreadsheet.RichTex
   return builder.build();
 }
 
+// Max files to download + upload per sub-batch in Wave 1.
+// Blobs are passed directly to UrlFetchApp without Array.from(), so JS heap pressure
+// per file is minimal. Bounded by UrlFetchApp.fetchAll's ~20-request limit (two passes
+// per sub-batch = init + upload), so 10 keeps each fetchAll well within that limit.
+const FILE_PIPELINE_BATCH_SIZE = 10;
+
 export function runBatchAI(config: RunConfig, jobId?: string): void {
   const ss = SpreadsheetApp.getActiveSpreadsheet();
   const sheet = ss.getActiveSheet();
@@ -356,7 +362,7 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
   );
 
   // Wave 1 — file work (multimodal chunks only)
-  let fileUriMap = new Map<string, { uri: string; mimeType: string }>();
+  const fileUriMap = new Map<string, { uri: string; mimeType: string }>();
   let fileErrors = new Map<string, string>();
 
   if (hasFileInputs) {
@@ -386,37 +392,53 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
 
       // Only attempt to download files whose metadata was successfully fetched
       const downloadIds = fileIds.filter((id) => metadata.has(id));
-      const { bytes, errors: downloadErrors } = downloadDriveFiles(
-        downloadIds,
-        metadata,
-        oauthToken,
-      );
 
-      if (jobId) {
-        writeJobProgress(cache, jobId, {
-          message: `Uploading files for rows ${startRow}–${startRow + numRows - 1}...`,
-        });
-      }
       // Translate Drive native MIME types to exported MIME types.
-      // downloadDriveFiles exports Docs as PDF and Sheets as CSV, so we must use those
-      // MIME types when uploading to Gemini, not the native Drive types.
+      // downloadDriveFiles exports Docs as PDF and Sheets as CSV.
       const DOCS_DRIVE_MIME = "application/vnd.google-apps.document";
       const SHEETS_DRIVE_MIME = "application/vnd.google-apps.spreadsheet";
-      const uploadIds = downloadIds.filter((id) => bytes.has(id));
-      const mimeTypes = new Map(
-        uploadIds.map((id) => {
-          const driveMime = metadata.get(id)!.mimeType;
-          let effectiveMime = driveMime;
-          if (driveMime === DOCS_DRIVE_MIME) effectiveMime = "application/pdf";
-          else if (driveMime === SHEETS_DRIVE_MIME) effectiveMime = "text/csv";
-          return [id, effectiveMime];
-        }),
-      );
-      // Pass bytes directly — its keys equal uploadIds by construction.
-      const { uploads, errors: uploadErrors } = uploadFilesToGemini(bytes, mimeTypes, apiKey);
-      bytes.clear(); // release downloaded file bytes — no longer needed after upload
-      fileUriMap = uploads;
-      fileErrors = new Map([...metadataErrors, ...downloadErrors, ...uploadErrors]);
+
+      // Process files in sub-batches: download → upload → clear → next sub-batch.
+      // Peak memory is bounded to FILE_PIPELINE_BATCH_SIZE files at a time rather
+      // than all files in the chunk, preventing JS runtime crashes from the
+      // Uint8Array→Byte[] expansion that UrlFetchApp payloads require (~8× overhead).
+      const allDownloadErrors = new Map<string, string>();
+      const allUploadErrors = new Map<string, string>();
+      for (let bStart = 0; bStart < downloadIds.length; bStart += FILE_PIPELINE_BATCH_SIZE) {
+        const batchIds = downloadIds.slice(bStart, bStart + FILE_PIPELINE_BATCH_SIZE);
+        if (jobId) {
+          writeJobProgress(cache, jobId, {
+            message: `Processing files ${bStart + 1}–${Math.min(bStart + FILE_PIPELINE_BATCH_SIZE, downloadIds.length)} of ${downloadIds.length}...`,
+          });
+        }
+        const batchMetadata = new Map(batchIds.map((id) => [id, metadata.get(id)!]));
+        const { bytes: batchBytes, errors: batchDownloadErrors } = downloadDriveFiles(
+          batchIds,
+          batchMetadata,
+          oauthToken,
+        );
+        for (const [id, err] of batchDownloadErrors) allDownloadErrors.set(id, err);
+
+        const batchUploadIds = batchIds.filter((id) => batchBytes.has(id));
+        const batchMimeTypes = new Map(
+          batchUploadIds.map((id) => {
+            const driveMime = metadata.get(id)!.mimeType;
+            let effectiveMime = driveMime;
+            if (driveMime === DOCS_DRIVE_MIME) effectiveMime = "application/pdf";
+            else if (driveMime === SHEETS_DRIVE_MIME) effectiveMime = "text/csv";
+            return [id, effectiveMime];
+          }),
+        );
+        const { uploads: batchUploads, errors: batchUploadErrors } = uploadFilesToGemini(
+          batchBytes,
+          batchMimeTypes,
+          apiKey,
+        );
+        batchBytes.clear(); // release immediately — only one sub-batch in memory at a time
+        for (const [id, info] of batchUploads) fileUriMap.set(id, info);
+        for (const [id, err] of batchUploadErrors) allUploadErrors.set(id, err);
+      }
+      fileErrors = new Map([...metadataErrors, ...allDownloadErrors, ...allUploadErrors]);
     }
   }
 
@@ -594,4 +616,10 @@ export function getJobProgress(
   const raw = CacheService.getUserCache().get(jobId);
   if (!raw) return null;
   return JSON.parse(raw) as { message?: string; current?: number; total?: number };
+}
+
+export function getActiveRangeInfo(): { start: number; end: number } | null {
+  const range = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet().getActiveRange();
+  if (!range) return null;
+  return { start: range.getRow(), end: range.getRow() + range.getNumRows() - 1 };
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -389,7 +389,20 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
           message: `Uploading files for chunk...`,
         });
       }
-      const mimeTypes = new Map(fileIds.map((id) => [id, metadata.get(id)!.mimeType]));
+      // Translate Drive native MIME types to exported MIME types.
+      // downloadDriveFiles exports Docs as PDF and Sheets as CSV, so we must use those
+      // MIME types when uploading to Gemini, not the native Drive types.
+      const DOCS_DRIVE_MIME = "application/vnd.google-apps.document";
+      const SHEETS_DRIVE_MIME = "application/vnd.google-apps.spreadsheet";
+      const mimeTypes = new Map(
+        fileIds.map((id) => {
+          const driveMime = metadata.get(id)!.mimeType;
+          let effectiveMime = driveMime;
+          if (driveMime === DOCS_DRIVE_MIME) effectiveMime = "application/pdf";
+          else if (driveMime === SHEETS_DRIVE_MIME) effectiveMime = "text/csv";
+          return [id, effectiveMime];
+        }),
+      );
       fileUriMap = uploadFilesToGemini(bytes, mimeTypes, apiKey);
     }
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -357,6 +357,7 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
 
   // Wave 1 — file work (multimodal chunks only)
   let fileUriMap = new Map<string, { uri: string; mimeType: string }>();
+  let fileErrors = new Map<string, string>();
 
   if (hasFileInputs) {
     const oauthToken = ScriptApp.getOAuthToken();
@@ -381,8 +382,15 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
           message: `Downloading files for rows ${startRow}–${startRow + numRows - 1}...`,
         });
       }
-      const metadata = fetchDriveMetadata(fileIds, oauthToken);
-      const bytes = downloadDriveFiles(fileIds, metadata, oauthToken);
+      const { metadata, errors: metadataErrors } = fetchDriveMetadata(fileIds, oauthToken);
+
+      // Only attempt to download files whose metadata was successfully fetched
+      const downloadIds = fileIds.filter((id) => metadata.has(id));
+      const { bytes, errors: downloadErrors } = downloadDriveFiles(
+        downloadIds,
+        metadata,
+        oauthToken,
+      );
 
       if (jobId) {
         writeJobProgress(cache, jobId, {
@@ -394,8 +402,9 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
       // MIME types when uploading to Gemini, not the native Drive types.
       const DOCS_DRIVE_MIME = "application/vnd.google-apps.document";
       const SHEETS_DRIVE_MIME = "application/vnd.google-apps.spreadsheet";
+      const uploadIds = downloadIds.filter((id) => bytes.has(id));
       const mimeTypes = new Map(
-        fileIds.map((id) => {
+        uploadIds.map((id) => {
           const driveMime = metadata.get(id)!.mimeType;
           let effectiveMime = driveMime;
           if (driveMime === DOCS_DRIVE_MIME) effectiveMime = "application/pdf";
@@ -403,7 +412,10 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
           return [id, effectiveMime];
         }),
       );
-      fileUriMap = uploadFilesToGemini(bytes, mimeTypes, apiKey);
+      const uploadBytes = new Map(uploadIds.map((id) => [id, bytes.get(id)!]));
+      const { uploads, errors: uploadErrors } = uploadFilesToGemini(uploadBytes, mimeTypes, apiKey);
+      fileUriMap = uploads;
+      fileErrors = new Map([...metadataErrors, ...downloadErrors, ...uploadErrors]);
     }
   }
 
@@ -418,6 +430,21 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
   const rowIndices: number[] = [];
 
   for (let i = 0; i < allPromptInputs.length; i++) {
+    // If any file input for this row failed to fetch/download/upload, write the
+    // error directly to the output cell and skip inference for this row.
+    if (fileErrors.size > 0) {
+      const failedIds = allPromptInputs[i]
+        .filter((inp) => inp.kind === "file")
+        .flatMap((inp) => flattenArg(inp.value).filter(isValidDriveLink).map(extractId))
+        .filter((id) => fileErrors.has(id));
+      if (failedIds.length > 0) {
+        sheet
+          .getRange(startRow + i, outputIdx + 1)
+          .setValue(`[File error: ${fileErrors.get(failedIds[0])}]`);
+        continue;
+      }
+    }
+
     const systemPrompt = systemPromptIdx >= 0 ? dataValues[i][systemPromptIdx] : undefined;
     const req = buildInferenceRequest(
       allPromptInputs[i],

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -9,13 +9,20 @@
  */
 
 export { SSI } from "./customFunctions";
-import { runInference } from "./inference";
+import { callGeminiAPIBatch } from "./api";
+import {
+  fetchDriveMetadata,
+  downloadDriveFiles,
+  checkDriveService,
+  extractTextUniversal,
+} from "./drive";
+import { uploadFilesToGemini } from "./files";
+import { buildInferenceRequest } from "./inference";
 import {
   buildRichInferenceCellContent,
   buildRichGroundingCellContent,
   type CellContent,
 } from "./rich-text";
-import { checkDriveService, extractTextUniversal } from "./drive";
 import {
   extractId,
   isValidDriveLink,
@@ -27,7 +34,9 @@ import {
   writeColumn,
   writeJobProgress,
   interpolateTemplate,
+  flattenArg,
 } from "./utils";
+import { CONFIG } from "./config";
 import type {
   RunConfig,
   PrepRecipeParams,
@@ -35,7 +44,7 @@ import type {
   ImportDriveLinksConfig,
   ExtractTextConfig,
 } from "../shared/types";
-import type { DriveFileInfo, PromptInput } from "./types";
+import type { DriveFileInfo, PromptInput, GeminiRequest } from "./types";
 
 // ==========================================
 // 🚀 MENU & INITIALIZATION
@@ -328,30 +337,97 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
 
   const dataValues = sheet.getRange(startRow, 1, numRows, sheet.getLastColumn()).getValues();
 
-  const totalRows = dataValues.length;
-  let processed = 0;
+  const apiKey = PropertiesService.getScriptProperties().getProperty(CONFIG.API_KEY_PROPERTY);
+  if (!apiKey) {
+    ui.alert("Error", `${CONFIG.API_KEY_PROPERTY} script property not set`, ui.ButtonSet.OK);
+    return;
+  }
 
-  for (let i = 0; i < dataValues.length; i++) {
-    const row = dataValues[i];
-    const realRowIndex = startRow + i;
+  const cache = CacheService.getUserCache();
+  const hasFileInputs = config.promptCols.some((pc) => pc.kind === "file");
 
-    if (jobId) {
-      writeJobProgress(CacheService.getUserCache(), jobId, {
-        message: `Processing row ${i + 1} of ${totalRows}`,
-        current: i + 1,
-        total: totalRows,
-      });
+  // Build all prompt input arrays (one per row) — pure, no I/O
+  const allPromptInputs: PromptInput[][] = dataValues.map((row) =>
+    config.promptCols.map((pc, colIdx) => ({
+      kind: pc.kind,
+      value: row[promptIdxs[colIdx]],
+      ...(config.prefixWithColName ? { label: pc.col } : {}),
+    })),
+  );
+
+  // Wave 1 — file work (multimodal chunks only)
+  let fileUriMap = new Map<string, { uri: string; mimeType: string }>();
+
+  if (hasFileInputs) {
+    const oauthToken = ScriptApp.getOAuthToken();
+
+    // Collect unique Drive file IDs across all rows in this chunk
+    const allFileIds = new Set<string>();
+    for (const inputs of allPromptInputs) {
+      for (const input of inputs) {
+        if (input.kind === "file") {
+          flattenArg(input.value)
+            .filter(isValidDriveLink)
+            .map(extractId)
+            .forEach((id) => allFileIds.add(id));
+        }
+      }
     }
 
-    const promptInputs: PromptInput[] = config.promptCols.map((pc, i) => ({
-      kind: pc.kind,
-      value: row[promptIdxs[i]],
-      ...(config.prefixWithColName ? { label: pc.col } : {}),
-    }));
-    const systemPrompt = systemPromptIdx >= 0 ? row[systemPromptIdx] : undefined;
+    const fileIds = Array.from(allFileIds);
+    if (fileIds.length > 0) {
+      if (jobId) {
+        writeJobProgress(cache, jobId, {
+          message: `Downloading files for chunk...`,
+        });
+      }
+      const metadata = fetchDriveMetadata(fileIds, oauthToken);
+      const bytes = downloadDriveFiles(fileIds, metadata, oauthToken);
 
-    const result = runInference(promptInputs, systemPrompt, config.tools);
-    if (result === null) continue;
+      if (jobId) {
+        writeJobProgress(cache, jobId, {
+          message: `Uploading files for chunk...`,
+        });
+      }
+      const mimeTypes = new Map(fileIds.map((id) => [id, metadata.get(id)!.mimeType]));
+      fileUriMap = uploadFilesToGemini(bytes, mimeTypes, apiKey);
+    }
+  }
+
+  // Wave 2 — build requests and fire inference in parallel
+  if (jobId) {
+    writeJobProgress(cache, jobId, { message: `Running AI on chunk...` });
+  }
+
+  const requests: GeminiRequest[] = [];
+  const rowIndices: number[] = [];
+
+  for (let i = 0; i < allPromptInputs.length; i++) {
+    const systemPrompt = systemPromptIdx >= 0 ? dataValues[i][systemPromptIdx] : undefined;
+    const req = buildInferenceRequest(
+      allPromptInputs[i],
+      systemPrompt,
+      config.tools,
+      hasFileInputs ? fileUriMap : undefined,
+    );
+    if (req !== null) {
+      requests.push({ ...req, apiKey });
+      rowIndices.push(i);
+    }
+  }
+
+  if (requests.length === 0) {
+    SpreadsheetApp.getActive().toast("No rows to process.", "Info", 5);
+    return;
+  }
+
+  const results = callGeminiAPIBatch(requests);
+
+  // Write all results — single flush at end of chunk
+  for (let j = 0; j < results.length; j++) {
+    const i = rowIndices[j];
+    const realRowIndex = startRow + i;
+    const result = results[j];
 
     if (config.applyMarkdown) {
       try {
@@ -359,7 +435,6 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
           .getRange(realRowIndex, outputIdx + 1)
           .setRichTextValue(toCellValue(buildRichInferenceCellContent(result)));
       } catch (_e) {
-        // Fall back to plain text if rich text rendering fails for this row.
         sheet.getRange(realRowIndex, outputIdx + 1).setValue(result.text);
       }
     } else {
@@ -374,12 +449,17 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
           .setRichTextValue(toCellValue(groundingContent));
       }
     }
-
-    processed++;
-    SpreadsheetApp.flush();
   }
 
-  SpreadsheetApp.getActive().toast(`Complete! Processed ${processed} rows.`, "Success", 5);
+  SpreadsheetApp.flush();
+  const successCount = results.filter((r) => !r.text.startsWith("Error:")).length;
+  SpreadsheetApp.getActive().toast(
+    successCount === results.length
+      ? `Complete! Processed ${results.length} rows.`
+      : `Complete! Processed ${successCount} of ${results.length} rows (${results.length - successCount} errors).`,
+    "Success",
+    5,
+  );
 }
 
 // ==========================================

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -412,8 +412,9 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
           return [id, effectiveMime];
         }),
       );
-      const uploadBytes = new Map(uploadIds.map((id) => [id, bytes.get(id)!]));
-      const { uploads, errors: uploadErrors } = uploadFilesToGemini(uploadBytes, mimeTypes, apiKey);
+      // Pass bytes directly — its keys equal uploadIds by construction.
+      const { uploads, errors: uploadErrors } = uploadFilesToGemini(bytes, mimeTypes, apiKey);
+      bytes.clear(); // release downloaded file bytes — no longer needed after upload
       fileUriMap = uploads;
       fileErrors = new Map([...metadataErrors, ...downloadErrors, ...uploadErrors]);
     }
@@ -428,19 +429,20 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
 
   const requests: GeminiRequest[] = [];
   const rowIndices: number[] = [];
+  // File-error rows are deferred here and written in the same post-batch loop as
+  // inference results, so the entire chunk lands in a single SpreadsheetApp.flush().
+  const directWrites = new Map<number, string>();
 
   for (let i = 0; i < allPromptInputs.length; i++) {
-    // If any file input for this row failed to fetch/download/upload, write the
-    // error directly to the output cell and skip inference for this row.
+    // If any file input for this row failed to fetch/download/upload, defer an
+    // error string for the post-batch write loop and skip inference.
     if (fileErrors.size > 0) {
       const failedIds = allPromptInputs[i]
         .filter((inp) => inp.kind === "file")
         .flatMap((inp) => flattenArg(inp.value).filter(isValidDriveLink).map(extractId))
         .filter((id) => fileErrors.has(id));
       if (failedIds.length > 0) {
-        sheet
-          .getRange(startRow + i, outputIdx + 1)
-          .setValue(`[File error: ${fileErrors.get(failedIds[0])}]`);
+        directWrites.set(i, `[File error: ${fileErrors.get(failedIds[0])}]`);
         continue;
       }
     }
@@ -458,14 +460,14 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
     }
   }
 
-  if (requests.length === 0) {
+  if (requests.length === 0 && directWrites.size === 0) {
     SpreadsheetApp.getActive().toast("No rows to process.", "Info", 5);
     return;
   }
 
-  const results = callGeminiAPIBatch(requests);
+  const results = requests.length > 0 ? callGeminiAPIBatch(requests) : [];
 
-  // Write all results — single flush at end of chunk
+  // Write all results and file errors in a single batch — one flush at end of chunk.
   for (let j = 0; j < results.length; j++) {
     const i = rowIndices[j];
     const realRowIndex = startRow + i;
@@ -493,12 +495,17 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
     }
   }
 
+  for (const [i, errorText] of directWrites) {
+    sheet.getRange(startRow + i, outputIdx + 1).setValue(errorText);
+  }
+
   SpreadsheetApp.flush();
   const successCount = results.filter((r) => !r.text.startsWith("Error:")).length;
+  const errorCount = results.length - successCount + directWrites.size;
   SpreadsheetApp.getActive().toast(
-    successCount === results.length
+    errorCount === 0
       ? `Complete! Processed ${results.length} rows.`
-      : `Complete! Processed ${successCount} of ${results.length} rows (${results.length - successCount} errors).`,
+      : `Complete! Processed ${successCount} of ${results.length + directWrites.size} rows (${errorCount} errors).`,
     "Success",
     5,
   );

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -378,7 +378,7 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
     if (fileIds.length > 0) {
       if (jobId) {
         writeJobProgress(cache, jobId, {
-          message: `Downloading files for chunk...`,
+          message: `Downloading files for rows ${startRow}–${startRow + numRows - 1}...`,
         });
       }
       const metadata = fetchDriveMetadata(fileIds, oauthToken);
@@ -386,7 +386,7 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
 
       if (jobId) {
         writeJobProgress(cache, jobId, {
-          message: `Uploading files for chunk...`,
+          message: `Uploading files for rows ${startRow}–${startRow + numRows - 1}...`,
         });
       }
       // Translate Drive native MIME types to exported MIME types.
@@ -409,7 +409,9 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
 
   // Wave 2 — build requests and fire inference in parallel
   if (jobId) {
-    writeJobProgress(cache, jobId, { message: `Running AI on chunk...` });
+    writeJobProgress(cache, jobId, {
+      message: `Running AI on rows ${startRow}–${startRow + numRows - 1}...`,
+    });
   }
 
   const requests: GeminiRequest[] = [];

--- a/src/server/inference.ts
+++ b/src/server/inference.ts
@@ -4,13 +4,83 @@
  * runInference normalizes raw cell values into a Gemini request and executes
  * it via invokeGemini. It has no SpreadsheetApp dependency — callers are
  * responsible for writing the returned value to the sheet.
+ *
+ * buildInferenceRequest is the pure request-builder. Exported so callers can build
+ * a request without executing it — used by runInference; also available for the
+ * batch path (runBatchAI) in the upcoming parallel pipeline refactor.
  */
 
 import { invokeGemini } from "./api";
 import { prepareDriveAttachments } from "./drive";
 import { flattenArg, isValidDriveLink, extractId } from "./utils";
-import type { GeminiResponse, GeminiUserPart, PromptInput } from "./types";
+import type { GeminiRequest, GeminiResponse, GeminiUserPart, PromptInput } from "./types";
 import type { ToolId } from "../shared/types";
+
+function buildUserParts(
+  promptInputs: PromptInput[],
+  fileUriMap?: Map<string, { uri: string; mimeType: string }>,
+): GeminiUserPart[] {
+  const userParts: GeminiUserPart[] = [];
+
+  for (const input of promptInputs) {
+    if (input.kind === "text") {
+      const texts = flattenArg(input.value);
+      const parts = input.label
+        ? texts.map((text) => ({ text: `${input.label}: ${text}` }))
+        : texts.map((text) => ({ text }));
+      userParts.push(...parts);
+    } else {
+      const fileIds = flattenArg(input.value).filter(isValidDriveLink).map(extractId);
+      if (fileIds.length === 0) continue;
+
+      if (fileUriMap) {
+        for (const fileId of fileIds) {
+          const fileInfo = fileUriMap.get(fileId);
+          if (fileInfo) {
+            userParts.push({
+              file_data: { file_uri: fileInfo.uri, mime_type: fileInfo.mimeType },
+            });
+          }
+        }
+      } else {
+        const attachments = prepareDriveAttachments(fileIds);
+        userParts.push(...attachments.map((inline_data) => ({ inline_data })));
+      }
+    }
+  }
+
+  return userParts;
+}
+
+/**
+ * Build a GeminiRequest (without apiKey) from raw prompt inputs.
+ *
+ * @param promptInputs  Ordered prompt inputs, each carrying a kind ("text" or
+ *                      "file") and a raw cell value.
+ * @param systemPrompt  Cell value for the system instruction. First non-empty
+ *                      string is used. Omit or pass `undefined` to use the model default.
+ * @param tools         Tool IDs to enable for this inference call.
+ * @param fileUriMap    Optional map from Drive file ID to Gemini Files API URI +
+ *                      mimeType. When provided, file inputs use the file_data path
+ *                      (Files API); when absent, the inline_data path is used instead.
+ * @returns The request object (without apiKey), or null if no prompt inputs
+ *          produce any content (signals caller to skip the row).
+ */
+export function buildInferenceRequest(
+  promptInputs: PromptInput[],
+  systemPrompt?: unknown,
+  tools?: ToolId[],
+  fileUriMap?: Map<string, { uri: string; mimeType: string }>,
+): Omit<GeminiRequest, "apiKey"> | null {
+  const userParts = buildUserParts(promptInputs, fileUriMap);
+  if (userParts.length === 0) return null;
+
+  return {
+    systemPrompt: systemPrompt !== undefined ? flattenArg(systemPrompt)[0] : undefined,
+    userParts,
+    tools: tools?.length ? tools : undefined,
+  };
+}
 
 /**
  * Execute a single Gemini inference from raw cell values.
@@ -33,31 +103,9 @@ export function runInference(
   tools?: ToolId[],
 ): GeminiResponse | null {
   try {
-    const userParts: GeminiUserPart[] = [];
-
-    for (const input of promptInputs) {
-      if (input.kind === "text") {
-        const texts = flattenArg(input.value);
-        const parts = input.label
-          ? texts.map((text) => ({ text: `${input.label}: ${text}` }))
-          : texts.map((text) => ({ text }));
-        userParts.push(...parts);
-      } else {
-        const fileIds = flattenArg(input.value).filter(isValidDriveLink).map(extractId);
-        if (fileIds.length > 0) {
-          const attachments = prepareDriveAttachments(fileIds);
-          userParts.push(...attachments.map((inline_data) => ({ inline_data })));
-        }
-      }
-    }
-
-    if (userParts.length === 0) return null;
-
-    return invokeGemini({
-      systemPrompt: systemPrompt !== undefined ? flattenArg(systemPrompt)[0] : undefined,
-      userParts,
-      tools: tools?.length ? tools : undefined,
-    });
+    const req = buildInferenceRequest(promptInputs, systemPrompt, tools);
+    if (req === null) return null;
+    return invokeGemini(req);
   } catch (e) {
     return { text: "Error: " + (e as Error).message };
   }


### PR DESCRIPTION
## Summary

- Replace sequential per-row `runBatchAI` loop with a two-wave parallel pipeline using `UrlFetchApp.fetchAll`, reducing 1,000-row runs from ~83 min to ~8–10 min
- Add `callGeminiAPIBatch` (parallel Gemini inference), `fetchDriveMetadata` + `downloadDriveFiles` (parallel Drive access), and new `uploadFilesToGemini` module (Gemini Files API integration)
- Extract `buildInferenceRequest` from `runInference` for use by the batch path; preserve inline `prepareDriveAttachments` path for SSI and future Test Row feature
- Increase chunk size 10→50 rows and update warning dialog time estimate to reflect ~10× speedup

## Architecture

**Text-only chunk:** build N request payloads → `fetchAll` N Gemini calls → batch write → single `SpreadsheetApp.flush()`

**Multimodal chunk:** Wave 1: `fetchAll` Drive metadata + download + Gemini Files API upload (deduplicated per chunk). Wave 2: same as text-only.

## Test Plan
- [ ] All 470 unit tests pass (`npm test`)
- [ ] Coverage thresholds pass including new `files.ts` threshold (`npm run test:coverage`)
- [ ] Typecheck clean (`npm run typecheck`)
- [ ] Build clean (`npm run build`)
- [ ] Manual: text-only run on 10+ rows — verify results appear and job indicator shows "Running AI on chunk..."
- [ ] Manual: multimodal run with Docs/PDFs — verify "Downloading files...", "Uploading files...", "Running AI on chunk..." progress sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)