### PR TITLE
feat: intent-led homepage UX redesign

### DIFF
--- a/__tests__/panels/tool-list.test.ts
+++ b/__tests__/panels/tool-list.test.ts
@@ -10,6 +10,19 @@ jest.mock("../../src/client/job-store", () => ({
   jobStore: { dispatch: jest.fn().mockResolvedValue(undefined) },
 }));
 
+jest.mock("../../src/client/recipes", () => ({
+  RECIPES: [
+    {
+      id: "document-summarization",
+      name: "Document Summarization",
+      icon: "📄",
+      description: "Summarize files in a Google Drive folder",
+      inputs: [],
+      prepTemplate: [],
+    },
+  ],
+}));
+
 import { ToolListPanel } from "../../src/client/panels/tool-list";
 import * as services from "../../src/client/services";
 import * as jobStoreModule from "../../src/client/job-store";
@@ -35,22 +48,41 @@ beforeEach(() => {
 });
 
 describe("ToolListPanel", () => {
+  it("renders the 'I want to...' sentence stem", () => {
+    const c = mountPanel();
+    expect(c.querySelector(".home-prompt")?.textContent?.trim()).toBe("I want to...");
+  });
+
+  it("clicking Summarize a Drive folder navigates to recipe panel with document-summarization definition", () => {
+    const c = mountPanel();
+    c.querySelector<HTMLButtonElement>("#btn-document-summarization")!.click();
+    expect(mockNav.navigate).toHaveBeenCalledWith(
+      "recipe",
+      expect.objectContaining({ id: "document-summarization" }),
+    );
+  });
+
+  it("does not render a Recipes submenu button", () => {
+    const c = mountPanel();
+    expect(c.querySelector("#btn-recipes")).toBeNull();
+  });
+
   it("clicking Run AI navigates to configure-ai-run", () => {
     const c = mountPanel();
     c.querySelector<HTMLButtonElement>("#btn-run-ai")!.click();
     expect(mockNav.navigate).toHaveBeenCalledWith("configure-ai-run");
   });
 
-  it("clicking Recipes navigates to recipes-list", () => {
-    const c = mountPanel();
-    c.querySelector<HTMLButtonElement>("#btn-recipes")!.click();
-    expect(mockNav.navigate).toHaveBeenCalledWith("recipes-list");
-  });
-
   it("clicking Import Drive Links navigates to import-drive-links panel", () => {
     const c = mountPanel();
     c.querySelector<HTMLButtonElement>("#btn-import-drive-links")!.click();
     expect(mockNav.navigate).toHaveBeenCalledWith("import-drive-links");
+  });
+
+  it("clicking Extract Text navigates to extract-text panel", () => {
+    const c = mountPanel();
+    c.querySelector<HTMLButtonElement>("#btn-extract-text")!.click();
+    expect(mockNav.navigate).toHaveBeenCalledWith("extract-text");
   });
 
   it("clicking Sample Rows calls runTool with 'sampleRowsToEvaluation' and a jobId", () => {
@@ -61,12 +93,6 @@ describe("ToolListPanel", () => {
       "sampleRowsToEvaluation",
       expect.stringMatching(/^sampleRowsToEvaluation-\d+$/),
     );
-  });
-
-  it("clicking Extract Text navigates to extract-text panel", () => {
-    const c = mountPanel();
-    c.querySelector<HTMLButtonElement>("#btn-extract-text")!.click();
-    expect(mockNav.navigate).toHaveBeenCalledWith("extract-text");
   });
 
   it("unmount() returns undefined", () => {

--- a/docs/superpowers/specs/2026-05-07-homepage-ux-redesign.md
+++ b/docs/superpowers/specs/2026-05-07-homepage-ux-redesign.md
@@ -24,7 +24,7 @@ I want to...
    For FOIA drops, court filings, doc sets
 
 ▶  Run AI across my spreadsheet
-   Prompts, data, tools — totally freeform
+   Your prompts, your data, your tools — totally freeform
 
 📂 Import files from a Drive folder
    Track progress through doc dumps

--- a/src/client/panels/tool-list.ts
+++ b/src/client/panels/tool-list.ts
@@ -16,7 +16,7 @@ export class ToolListPanel implements Panel {
   private wireEvents(container: HTMLElement, nav: NavigationContext): void {
     const documentSummarization = RECIPES.find((r) => r.id === "document-summarization");
     container.querySelector("#btn-document-summarization")?.addEventListener("click", () => {
-      nav.navigate("recipe", documentSummarization);
+      if (documentSummarization) nav.navigate("recipe", documentSummarization);
     });
     container.querySelector("#btn-run-ai")?.addEventListener("click", () => {
       nav.navigate("configure-ai-run");
@@ -35,7 +35,10 @@ export class ToolListPanel implements Panel {
   private dispatchTool(e: MouseEvent, fn: string): void {
     const btn = e.currentTarget as HTMLButtonElement;
     const jobId = `${fn}-${Date.now()}`;
-    const label = btn.textContent?.trim() ?? fn;
+    const label =
+      btn
+        .querySelector<HTMLSpanElement>(".tool-btn-text > span:first-child")
+        ?.textContent?.trim() ?? fn;
     jobStore
       .dispatch(jobId, label, runTool(fn, jobId))
       .catch((err: Error) => globalThis.alert("Error: " + err.message));

--- a/src/client/panels/tool-list.ts
+++ b/src/client/panels/tool-list.ts
@@ -1,6 +1,7 @@
 import type { NavigationContext, Panel } from "../types";
 import { runTool } from "../services";
 import { jobStore } from "../job-store";
+import { RECIPES } from "../recipes";
 
 export class ToolListPanel implements Panel {
   mount(container: HTMLElement, nav: NavigationContext): void {
@@ -13,20 +14,21 @@ export class ToolListPanel implements Panel {
   }
 
   private wireEvents(container: HTMLElement, nav: NavigationContext): void {
+    const documentSummarization = RECIPES.find((r) => r.id === "document-summarization");
+    container.querySelector("#btn-document-summarization")?.addEventListener("click", () => {
+      nav.navigate("recipe", documentSummarization);
+    });
     container.querySelector("#btn-run-ai")?.addEventListener("click", () => {
       nav.navigate("configure-ai-run");
-    });
-    container.querySelector("#btn-recipes")?.addEventListener("click", () => {
-      nav.navigate("recipes-list");
     });
     container.querySelector("#btn-import-drive-links")?.addEventListener("click", () => {
       nav.navigate("import-drive-links");
     });
-    container.querySelector("#btn-sample-rows")?.addEventListener("click", (e) => {
-      this.dispatchTool(e as MouseEvent, "sampleRowsToEvaluation");
-    });
     container.querySelector("#btn-extract-text")?.addEventListener("click", () => {
       nav.navigate("extract-text");
+    });
+    container.querySelector("#btn-sample-rows")?.addEventListener("click", (e) => {
+      this.dispatchTool(e as MouseEvent, "sampleRowsToEvaluation");
     });
   }
 
@@ -41,27 +43,42 @@ export class ToolListPanel implements Panel {
 
   private template(): string {
     return `
-      <div class="section">
-        <h3>Main Tools</h3>
-        <button id="btn-recipes" class="tool-btn">
-          <span class="icon">🥞</span> Recipes
-        </button>
-        <button id="btn-run-ai" class="tool-btn">
-          <span class="icon">▶️</span> Run AI Inference
-        </button>
-      </div>
-      <div class="section">
-        <h3>Extras</h3>
-        <button id="btn-import-drive-links" class="tool-btn">
-          <span class="icon">📂</span> Import Drive Links
-        </button>
-        <button id="btn-sample-rows" class="tool-btn">
-          <span class="icon">🎲</span> Sample Rows
-        </button>
-        <button id="btn-extract-text" class="tool-btn">
-          <span class="icon">📜</span> Extract Text
-        </button>
-      </div>
+      <p class="home-prompt">I want to...</p>
+      <button id="btn-document-summarization" class="tool-btn">
+        <span class="icon">📄</span>
+        <span class="tool-btn-text">
+          <span>Summarize a Drive folder</span>
+          <span class="tool-btn-sub">For FOIA drops, court filings, doc sets</span>
+        </span>
+      </button>
+      <button id="btn-run-ai" class="tool-btn">
+        <span class="icon">▶️</span>
+        <span class="tool-btn-text">
+          <span>Run AI across my spreadsheet</span>
+          <span class="tool-btn-sub">Your prompts, your data, your tools — totally freeform</span>
+        </span>
+      </button>
+      <button id="btn-import-drive-links" class="tool-btn">
+        <span class="icon">📂</span>
+        <span class="tool-btn-text">
+          <span>Import files from a Drive folder</span>
+          <span class="tool-btn-sub">Track progress through doc dumps</span>
+        </span>
+      </button>
+      <button id="btn-extract-text" class="tool-btn">
+        <span class="icon">📜</span>
+        <span class="tool-btn-text">
+          <span>Extract text from files</span>
+          <span class="tool-btn-sub">Import text from PDFs, images, and Docs</span>
+        </span>
+      </button>
+      <button id="btn-sample-rows" class="tool-btn">
+        <span class="icon">🎲</span>
+        <span class="tool-btn-text">
+          <span>Pull a random sample</span>
+          <span class="tool-btn-sub">Get a sense of what you have</span>
+        </span>
+      </button>
       <div class="status-footer">
         <strong>SSI Tools v2.1</strong><br>
         Powered by Gemini 3.1 Flash Lite Preview<br>

--- a/src/client/sidebar.css
+++ b/src/client/sidebar.css
@@ -40,6 +40,13 @@
 
         .section { margin-bottom: 28px; }
 
+        .home-prompt {
+            font-size: var(--font-size-300);
+            font-style: italic;
+            color: var(--text-secondary);
+            margin: 0 0 16px 4px;
+        }
+
         h3 {
             font-size: var(--font-size-100);
             font-style: italic;


### PR DESCRIPTION
## Summary

- Replaces feature-named buttons and arbitrary section headers with a flat, intent-led list under an "I want to..." sentence stem
- Buttons now use two-line copy: a direct action title + a journalist-context subtitle (e.g. "Summarize a Drive folder" / "For FOIA drops, court filings, doc sets")
- "Summarize a Drive folder\" navigates directly to the recipe panel, removing the intermediate recipes-list submenu hop
- Adds `.home-prompt` CSS class for the sentence stem

## Test Plan
- [ ] All 491 tests pass (`npm test`)
- [ ] Open sidebar in Sheets — verify "I want to..." prompt renders above buttons
- [ ] Click each button — verify correct panel opens
- [ ] Click "Summarize a Drive folder" — verify recipe panel opens directly (no recipes-list screen)
- [ ] Click "Pull a random sample" — verify job strip shows label "Pull a random sample" (not the full nested text)