### PR TITLE
feat: add Format Markdown menu item and refactor rich text pipeline

### DIFF
--- a/__tests__/menu.test.ts
+++ b/__tests__/menu.test.ts
@@ -82,10 +82,11 @@ describe("onOpen", () => {
     expect(mockCreateMenu).toHaveBeenCalledWith("📐 SSI Toolkit");
   });
 
-  it("adds a single item that opens the sidebar", () => {
+  it("adds menu items for Open Toolkit and Format Markdown", () => {
     onOpen();
-    expect(mockAddItem).toHaveBeenCalledTimes(1);
+    expect(mockAddItem).toHaveBeenCalledTimes(2);
     expect(mockAddItem).toHaveBeenCalledWith("📐 Open SSI Toolkit", "showSidebar");
+    expect(mockAddItem).toHaveBeenCalledWith("📝 Format Markdown", "formatMarkdownSelection");
   });
 
   it("adds the menu to the UI", () => {

--- a/__tests__/menu.test.ts
+++ b/__tests__/menu.test.ts
@@ -82,11 +82,10 @@ describe("onOpen", () => {
     expect(mockCreateMenu).toHaveBeenCalledWith("📐 SSI Toolkit");
   });
 
-  it("adds menu items for Open Toolkit and Format Markdown", () => {
+  it("adds a single item that opens the sidebar", () => {
     onOpen();
-    expect(mockAddItem).toHaveBeenCalledTimes(2);
+    expect(mockAddItem).toHaveBeenCalledTimes(1);
     expect(mockAddItem).toHaveBeenCalledWith("📐 Open SSI Toolkit", "showSidebar");
-    expect(mockAddItem).toHaveBeenCalledWith("📝 Format Markdown", "formatMarkdownSelection");
   });
 
   it("adds the menu to the UI", () => {

--- a/__tests__/panels/tool-list.test.ts
+++ b/__tests__/panels/tool-list.test.ts
@@ -77,6 +77,53 @@ describe("ToolListPanel", () => {
     expect(services.formatMarkdownSelection).toHaveBeenCalledTimes(1);
   });
 
+  it("disables Format Markdown button while in-flight and re-enables on success", async () => {
+    let resolve!: () => void;
+    (services.formatMarkdownSelection as jest.Mock).mockReturnValue(
+      new Promise<void>((res) => {
+        resolve = res;
+      }),
+    );
+    const c = mountPanel();
+    const btn = c.querySelector<HTMLButtonElement>("#btn-format-markdown")!;
+
+    btn.click();
+    expect(btn.disabled).toBe(true);
+    expect(btn.textContent).toContain("Formatting...");
+
+    resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(btn.disabled).toBe(false);
+    expect(btn.textContent).toContain("Format Markdown");
+  });
+
+  it("re-enables Format Markdown button and alerts on error", async () => {
+    let reject!: (err: Error) => void;
+    (services.formatMarkdownSelection as jest.Mock).mockReturnValue(
+      new Promise<void>((_, rej) => {
+        reject = rej;
+      }),
+    );
+    const mockAlert = jest.fn();
+    const origAlert = globalThis.alert;
+    globalThis.alert = mockAlert;
+
+    const c = mountPanel();
+    const btn = c.querySelector<HTMLButtonElement>("#btn-format-markdown")!;
+
+    btn.click();
+    expect(btn.disabled).toBe(true);
+
+    reject(new Error("GAS error"));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(btn.disabled).toBe(false);
+    expect(mockAlert).toHaveBeenCalledWith("Error: GAS error");
+
+    globalThis.alert = origAlert;
+  });
+
   it("unmount() returns undefined", () => {
     document.body.innerHTML = '<div id="app"></div>';
     const panel = new ToolListPanel();

--- a/__tests__/panels/tool-list.test.ts
+++ b/__tests__/panels/tool-list.test.ts
@@ -4,6 +4,7 @@
 
 jest.mock("../../src/client/services", () => ({
   runTool: jest.fn(),
+  formatMarkdownSelection: jest.fn(),
 }));
 
 jest.mock("../../src/client/job-store", () => ({
@@ -67,6 +68,13 @@ describe("ToolListPanel", () => {
     const c = mountPanel();
     c.querySelector<HTMLButtonElement>("#btn-extract-text")!.click();
     expect(mockNav.navigate).toHaveBeenCalledWith("extract-text");
+  });
+
+  it("clicking Format Markdown calls services.formatMarkdownSelection", () => {
+    (services.formatMarkdownSelection as jest.Mock).mockResolvedValue(undefined);
+    const c = mountPanel();
+    c.querySelector<HTMLButtonElement>("#btn-format-markdown")!.click();
+    expect(services.formatMarkdownSelection).toHaveBeenCalledTimes(1);
   });
 
   it("unmount() returns undefined", () => {

--- a/__tests__/rich-text.test.ts
+++ b/__tests__/rich-text.test.ts
@@ -59,7 +59,7 @@ describe("buildRichInferenceCellContent", () => {
       makeResponse({ text: "## Section Title\nBody text." }),
     );
     expect(result.text).toBe("Section Title\nBody text.");
-    expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 13, bold: true, fontSize: 16 });
+    expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 13, bold: true, fontSize: 13 });
   });
 
   it("adds url range for a citation, remapped through markdown position map", () => {
@@ -311,7 +311,7 @@ describe("buildRichInferenceCellContent markdown edge cases", () => {
   it("handles # heading at the very start", () => {
     const result = buildRichInferenceCellContent(makeResponse({ text: "# Title" }));
     expect(result.text).toBe("Title");
-    expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 5, bold: true, fontSize: 18 });
+    expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 5, bold: true, fontSize: 14 });
   });
 
   it("handles multiple bold spans", () => {
@@ -543,22 +543,22 @@ describe("parseMarkdown — extended features", () => {
     });
   });
 
-  it("applies fontSize 18 and bold to h1", () => {
+  it("applies fontSize 14 and bold to h1", () => {
     const result = parseMarkdown("# Title");
     expect(result.text).toBe("Title");
-    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 5, bold: true, fontSize: 18 });
+    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 5, bold: true, fontSize: 14 });
   });
 
-  it("applies fontSize 16 and bold to h2", () => {
+  it("applies fontSize 13 and bold to h2", () => {
     const result = parseMarkdown("## Section");
     expect(result.text).toBe("Section");
-    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 7, bold: true, fontSize: 16 });
+    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 7, bold: true, fontSize: 13 });
   });
 
-  it("applies fontSize 14 and bold to h3", () => {
+  it("applies fontSize 12 and bold to h3", () => {
     const result = parseMarkdown("### Sub");
     expect(result.text).toBe("Sub");
-    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 3, bold: true, fontSize: 14 });
+    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 3, bold: true, fontSize: 12 });
   });
 
   it("applies bold only (no fontSize) to h4 and deeper", () => {

--- a/__tests__/rich-text.test.ts
+++ b/__tests__/rich-text.test.ts
@@ -59,7 +59,7 @@ describe("buildRichInferenceCellContent", () => {
       makeResponse({ text: "## Section Title\nBody text." }),
     );
     expect(result.text).toBe("Section Title\nBody text.");
-    expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 13, bold: true, fontSize: 13 });
+    expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 13, bold: true, fontSize: 12 });
   });
 
   it("adds url range for a citation, remapped through markdown position map", () => {
@@ -311,7 +311,7 @@ describe("buildRichInferenceCellContent markdown edge cases", () => {
   it("handles # heading at the very start", () => {
     const result = buildRichInferenceCellContent(makeResponse({ text: "# Title" }));
     expect(result.text).toBe("Title");
-    expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 5, bold: true, fontSize: 14 });
+    expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 5, bold: true, fontSize: 13 });
   });
 
   it("handles multiple bold spans", () => {
@@ -543,22 +543,22 @@ describe("parseMarkdown — extended features", () => {
     });
   });
 
-  it("applies fontSize 14 and bold to h1", () => {
+  it("applies fontSize 13 and bold to h1", () => {
     const result = parseMarkdown("# Title");
     expect(result.text).toBe("Title");
-    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 5, bold: true, fontSize: 14 });
+    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 5, bold: true, fontSize: 13 });
   });
 
-  it("applies fontSize 13 and bold to h2", () => {
+  it("applies fontSize 12 and bold to h2", () => {
     const result = parseMarkdown("## Section");
     expect(result.text).toBe("Section");
-    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 7, bold: true, fontSize: 13 });
+    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 7, bold: true, fontSize: 12 });
   });
 
-  it("applies fontSize 12 and bold to h3", () => {
+  it("applies fontSize 11 and bold to h3", () => {
     const result = parseMarkdown("### Sub");
     expect(result.text).toBe("Sub");
-    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 3, bold: true, fontSize: 12 });
+    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 3, bold: true, fontSize: 11 });
   });
 
   it("applies bold only (no fontSize) to h4 and deeper", () => {

--- a/__tests__/rich-text.test.ts
+++ b/__tests__/rich-text.test.ts
@@ -3,6 +3,7 @@ import type { GeminiGroundingSupport, GeminiResponse } from "../src/server/types
 import {
   buildRichInferenceCellContent,
   buildRichGroundingCellContent,
+  parseMarkdown,
 } from "../src/server/rich-text";
 
 // ---- helpers ----
@@ -58,7 +59,7 @@ describe("buildRichInferenceCellContent", () => {
       makeResponse({ text: "## Section Title\nBody text." }),
     );
     expect(result.text).toBe("Section Title\nBody text.");
-    expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 13, bold: true });
+    expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 13, bold: true, fontSize: 16 });
   });
 
   it("adds url range for a citation, remapped through markdown position map", () => {
@@ -310,7 +311,7 @@ describe("buildRichInferenceCellContent markdown edge cases", () => {
   it("handles # heading at the very start", () => {
     const result = buildRichInferenceCellContent(makeResponse({ text: "# Title" }));
     expect(result.text).toBe("Title");
-    expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 5, bold: true });
+    expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 5, bold: true, fontSize: 18 });
   });
 
   it("handles multiple bold spans", () => {
@@ -518,5 +519,53 @@ describe("buildRichInferenceCellContent — citation injection", () => {
     const citation = result.ranges.find((r) => r.url === "https://citation.com");
     expect(inlineLink).toBeDefined();
     expect(citation).toBeDefined();
+  });
+});
+
+// ============================================================
+// parseMarkdown — extended features
+// ============================================================
+
+describe("parseMarkdown — extended features", () => {
+  it("wraps ~~text~~ as a strikethrough range", () => {
+    const result = parseMarkdown("before ~~struck~~ after");
+    expect(result.text).toBe("before struck after");
+    expect(result.ranges).toContainEqual({ startIndex: 7, endIndex: 13, strikethrough: true });
+  });
+
+  it("wraps `code` as a Courier New font-family range", () => {
+    const result = parseMarkdown("run `npm test` now");
+    expect(result.text).toBe("run npm test now");
+    expect(result.ranges).toContainEqual({
+      startIndex: 4,
+      endIndex: 12,
+      fontFamily: "Courier New",
+    });
+  });
+
+  it("applies fontSize 18 and bold to h1", () => {
+    const result = parseMarkdown("# Title");
+    expect(result.text).toBe("Title");
+    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 5, bold: true, fontSize: 18 });
+  });
+
+  it("applies fontSize 16 and bold to h2", () => {
+    const result = parseMarkdown("## Section");
+    expect(result.text).toBe("Section");
+    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 7, bold: true, fontSize: 16 });
+  });
+
+  it("applies fontSize 14 and bold to h3", () => {
+    const result = parseMarkdown("### Sub");
+    expect(result.text).toBe("Sub");
+    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 3, bold: true, fontSize: 14 });
+  });
+
+  it("applies bold only (no fontSize) to h4 and deeper", () => {
+    const result = parseMarkdown("#### Deep");
+    expect(result.text).toBe("Deep");
+    const headingRange = result.ranges.find((r) => r.bold);
+    expect(headingRange).toBeDefined();
+    expect(headingRange?.fontSize).toBeUndefined();
   });
 });

--- a/__tests__/services.test.ts
+++ b/__tests__/services.test.ts
@@ -13,6 +13,7 @@ const mockRun = {
   getJobProgress: jest.fn(),
   importDriveLinks: jest.fn(),
   extractText: jest.fn(),
+  formatMarkdownSelection: jest.fn(),
 };
 (globalThis as unknown as { google: unknown }).google = { script: { run: mockRun } };
 
@@ -230,5 +231,22 @@ describe("getActiveRangeInfo", () => {
     const promise = services.getActiveRangeInfo();
     handlers.reject(new Error("range error"));
     await expect(promise).rejects.toThrow("range error");
+  });
+});
+
+describe("formatMarkdownSelection", () => {
+  it("calls google.script.run.formatMarkdownSelection and resolves", async () => {
+    const handlers = captureHandlers();
+    const promise = services.formatMarkdownSelection();
+    handlers.resolve(undefined);
+    await expect(promise).resolves.toBeUndefined();
+    expect(mockRun.formatMarkdownSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects when the RPC fails", async () => {
+    const handlers = captureHandlers();
+    const promise = services.formatMarkdownSelection();
+    handlers.reject(new Error("GAS error"));
+    await expect(promise).rejects.toThrow("GAS error");
   });
 });

--- a/docs/superpowers/plans/2026-06-23-format-markdown-sidebar-button.md
+++ b/docs/superpowers/plans/2026-06-23-format-markdown-sidebar-button.md
@@ -1,0 +1,277 @@
+# Format Markdown Sidebar Button Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the Format Markdown entry point from the SSI Toolkit menu to a button in the sidebar's existing Extras section.
+
+**Architecture:** Remove the `addItem` call from `onOpen()`, add a `formatMarkdownSelection` service wrapper in `services.ts` and type declaration in `google.d.ts`, and add the button + click handler to `tool-list.ts`. The server function itself is untouched. The rollup stub stays — `google.script.run` needs it to resolve the function.
+
+**Tech Stack:** TypeScript, Google Apps Script (`google.script.run`), Jest + jsdom
+
+## Global Constraints
+
+- Client-side code only calls `google.script.run` from `services.ts` — never directly from panels
+- Named exports only; no default exports
+- `npm test` must pass (496 tests)
+- `npm run typecheck` must pass
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `src/server/index.ts` | Remove `"📝 Format Markdown"` addItem from `onOpen()` |
+| `src/client/google.d.ts` | Add `formatMarkdownSelection(): void` to `GoogleScriptRun` |
+| `src/client/services.ts` | Add `formatMarkdownSelection(): Promise<void>` |
+| `src/client/panels/tool-list.ts` | Add button to Extras section; import + wire click handler |
+| `__tests__/menu.test.ts` | Revert to 1 addItem assertion; remove Format Markdown assertion |
+| `__tests__/services.test.ts` | Add `formatMarkdownSelection` to mockRun; add 2 new tests |
+| `__tests__/panels/tool-list.test.ts` | Add `formatMarkdownSelection` to services mock; add 1 new test |
+
+---
+
+## Task 1: Move entry point from menu to sidebar button
+
+All changes land in one commit — they are a single deliverable.
+
+**Files:**
+- Modify: `src/server/index.ts`
+- Modify: `src/client/google.d.ts`
+- Modify: `src/client/services.ts`
+- Modify: `src/client/panels/tool-list.ts`
+- Test: `__tests__/menu.test.ts`
+- Test: `__tests__/services.test.ts`
+- Test: `__tests__/panels/tool-list.test.ts`
+
+**Interfaces:**
+- Produces: `formatMarkdownSelection(): Promise<void>` in `src/client/services.ts`
+- Produces: `#btn-format-markdown` button in tool-list Extras section
+
+---
+
+- [ ] **Step 1: Write failing test for the new service function**
+
+In `__tests__/services.test.ts`, add `formatMarkdownSelection` to the `mockRun` object (around line 8):
+
+```typescript
+const mockRun = {
+  withSuccessHandler: jest.fn().mockReturnThis(),
+  withFailureHandler: jest.fn().mockReturnThis(),
+  getSheetHeaders: jest.fn(),
+  getActiveRangeInfo: jest.fn(),
+  runBatchAI: jest.fn(),
+  runTool: jest.fn(),
+  prepRecipe: jest.fn(),
+  getJobProgress: jest.fn(),
+  importDriveLinks: jest.fn(),
+  extractText: jest.fn(),
+  formatMarkdownSelection: jest.fn(),
+};
+```
+
+Then add a new `describe` block at the bottom of `__tests__/services.test.ts`:
+
+```typescript
+describe("formatMarkdownSelection", () => {
+  it("calls google.script.run.formatMarkdownSelection and resolves", async () => {
+    const handlers = captureHandlers();
+    const promise = services.formatMarkdownSelection();
+    handlers.resolve(undefined);
+    await expect(promise).resolves.toBeUndefined();
+    expect(mockRun.formatMarkdownSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects when the RPC fails", async () => {
+    const handlers = captureHandlers();
+    const promise = services.formatMarkdownSelection();
+    handlers.reject(new Error("GAS error"));
+    await expect(promise).rejects.toThrow("GAS error");
+  });
+});
+```
+
+- [ ] **Step 2: Write failing test for the tool-list button**
+
+In `__tests__/panels/tool-list.test.ts`, update the services mock at line 5 to include `formatMarkdownSelection`:
+
+```typescript
+jest.mock("../../src/client/services", () => ({
+  runTool: jest.fn(),
+  formatMarkdownSelection: jest.fn(),
+}));
+```
+
+Add a new test inside the existing `describe("ToolListPanel", ...)` block, after the Extract Text test:
+
+```typescript
+it("clicking Format Markdown calls services.formatMarkdownSelection", () => {
+  (services.formatMarkdownSelection as jest.Mock).mockResolvedValue(undefined);
+  const c = mountPanel();
+  c.querySelector<HTMLButtonElement>("#btn-format-markdown")!.click();
+  expect(services.formatMarkdownSelection).toHaveBeenCalledTimes(1);
+});
+```
+
+- [ ] **Step 3: Run tests to confirm the 3 new tests fail**
+
+```bash
+npx jest __tests__/services.test.ts __tests__/panels/tool-list.test.ts --no-coverage
+```
+
+Expected: 3 failures — the 2 service tests and 1 tool-list test (functions not yet implemented).
+
+- [ ] **Step 4: Update the menu test to expect 1 item (not 2)**
+
+In `__tests__/menu.test.ts`, find and replace the test that currently asserts 2 items:
+
+```typescript
+it("adds menu items for Open Toolkit and Format Markdown", () => {
+  onOpen();
+  expect(mockAddItem).toHaveBeenCalledTimes(2);
+  expect(mockAddItem).toHaveBeenCalledWith("📐 Open SSI Toolkit", "showSidebar");
+  expect(mockAddItem).toHaveBeenCalledWith("📝 Format Markdown", "formatMarkdownSelection");
+});
+```
+
+Replace with:
+
+```typescript
+it("adds a single item that opens the sidebar", () => {
+  onOpen();
+  expect(mockAddItem).toHaveBeenCalledTimes(1);
+  expect(mockAddItem).toHaveBeenCalledWith("📐 Open SSI Toolkit", "showSidebar");
+});
+```
+
+- [ ] **Step 5: Remove the menu item from `onOpen()` in `index.ts`**
+
+Find `onOpen` in `src/server/index.ts`:
+
+```typescript
+export function onOpen(): void {
+  SpreadsheetApp.getUi()
+    .createMenu("📐 SSI Toolkit")
+    .addItem("📐 Open SSI Toolkit", "showSidebar")
+    .addItem("📝 Format Markdown", "formatMarkdownSelection")
+    .addToUi();
+}
+```
+
+Replace with:
+
+```typescript
+export function onOpen(): void {
+  SpreadsheetApp.getUi()
+    .createMenu("📐 SSI Toolkit")
+    .addItem("📐 Open SSI Toolkit", "showSidebar")
+    .addToUi();
+}
+```
+
+- [ ] **Step 6: Add `formatMarkdownSelection` to `google.d.ts`**
+
+In `src/client/google.d.ts`, add one line to `GoogleScriptRun` after `getActiveRangeInfo(): void;`:
+
+```typescript
+formatMarkdownSelection(): void;
+```
+
+The interface should now end with:
+
+```typescript
+    getJobProgress(jobId: string): void;
+    getActiveRangeInfo(): void;
+    formatMarkdownSelection(): void;
+  }
+```
+
+- [ ] **Step 7: Add the service function to `services.ts`**
+
+In `src/client/services.ts`, add at the end of the file:
+
+```typescript
+export function formatMarkdownSelection(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    google.script.run
+      .withSuccessHandler(() => resolve())
+      .withFailureHandler((err: Error) => reject(err))
+      .formatMarkdownSelection();
+  });
+}
+```
+
+- [ ] **Step 8: Add the button and wire the click handler in `tool-list.ts`**
+
+In `src/client/panels/tool-list.ts`, update the import to include `formatMarkdownSelection`:
+
+```typescript
+import { runTool, formatMarkdownSelection } from "../services";
+```
+
+In `wireEvents`, add after the Extract Text handler:
+
+```typescript
+container.querySelector("#btn-format-markdown")?.addEventListener("click", () => {
+  formatMarkdownSelection().catch((err: Error) => globalThis.alert("Error: " + err.message));
+});
+```
+
+In `template()`, add the button after `#btn-extract-text` inside the Extras `<div class="section">`:
+
+```html
+<button id="btn-format-markdown" class="tool-btn">
+  <span class="icon">📝</span> Format Markdown
+</button>
+```
+
+The full Extras section should read:
+
+```typescript
+      <div class="section">
+        <h3>Extras</h3>
+        <button id="btn-import-drive-links" class="tool-btn">
+          <span class="icon">📂</span> Import Drive Links
+        </button>
+        <button id="btn-sample-rows" class="tool-btn">
+          <span class="icon">🎲</span> Sample Rows
+        </button>
+        <button id="btn-extract-text" class="tool-btn">
+          <span class="icon">📜</span> Extract Text
+        </button>
+        <button id="btn-format-markdown" class="tool-btn">
+          <span class="icon">📝</span> Format Markdown
+        </button>
+      </div>
+```
+
+- [ ] **Step 9: Run targeted tests to confirm all pass**
+
+```bash
+npx jest __tests__/services.test.ts __tests__/panels/tool-list.test.ts __tests__/menu.test.ts --no-coverage
+```
+
+Expected: all tests pass including the 3 new ones.
+
+- [ ] **Step 10: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: clean output, no errors.
+
+- [ ] **Step 11: Run full test suite**
+
+```bash
+npm test
+```
+
+Expected: 499 tests pass across 31 suites.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add src/server/index.ts src/client/google.d.ts src/client/services.ts src/client/panels/tool-list.ts __tests__/menu.test.ts __tests__/services.test.ts __tests__/panels/tool-list.test.ts
+git commit -m "feat: move Format Markdown from menu item to sidebar Extras button"
+```

--- a/docs/superpowers/plans/2026-06-23-format-markdown.md
+++ b/docs/superpowers/plans/2026-06-23-format-markdown.md
@@ -1,0 +1,451 @@
+# Format Markdown Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "📝 Format Markdown" SSI Toolkit menu item that converts markdown syntax in a user-selected cell range to Google Sheets rich text in-place.
+
+**Architecture:** Export the existing private `parseMarkdown()` from `rich-text.ts` and extend it + `TextRange` to support three new formatting features (strikethrough, inline code, multi-level heading sizes). A new `formatMarkdownSelection()` server function in `index.ts` reads the active selection, runs `parseMarkdown` + the existing `toCellValue` renderer (extended for the new fields), and writes `setRichTextValue()` back to each cell. Wired to the menu via `onOpen()` and a rollup footer stub — no sidebar panel required.
+
+**Tech Stack:** TypeScript, Google Apps Script (`SpreadsheetApp`), Rollup IIFE bundle, Jest + ts-jest
+
+## Global Constraints
+
+- Apps Script runtime is V8 — tsconfig targets ES2019; no Node built-ins at runtime
+- `src/server/rich-text.ts` must remain GAS-free (no `SpreadsheetApp` calls) for testability
+- `toCellValue` and all GAS-coupled code live in `src/server/index.ts`, which is excluded from unit-test coverage
+- Named exports only; no default exports
+- Run `npm test` after every task; run `npm run typecheck` before committing Task 2
+
+---
+
+## File Map
+
+| File | Role | Change |
+|---|---|---|
+| `src/server/rich-text.ts` | Pure markdown parser + CellContent model | Export `parseMarkdown`; add 3 fields to `TextRange`; extend `processInline` for `~~` and backtick; add `headingDepth` for font sizes |
+| `src/server/index.ts` | GAS entry point + renderer | Extend `toCellValue`; import + call `parseMarkdown`; add `formatMarkdownSelection()`; update `onOpen()` |
+| `rollup.config.js` | Footer stubs for GAS discovery | Add one stub for `formatMarkdownSelection` |
+| `__tests__/rich-text.test.ts` | Unit tests for the parser | Add 6 new tests; update 1 existing heading test that will break |
+
+---
+
+## Task 1: Extend `TextRange` + `parseMarkdown` — TDD
+
+**Files:**
+- Modify: `src/server/rich-text.ts`
+- Test: `__tests__/rich-text.test.ts`
+
+**Interfaces:**
+- Produces: `parseMarkdown(text: string): CellContent` (exported)
+- Produces: `TextRange` extended with `strikethrough?: boolean`, `fontFamily?: string`, `fontSize?: number`
+
+---
+
+- [ ] **Step 1: Add the import for `parseMarkdown` in the test file and write 6 failing tests**
+
+In `__tests__/rich-text.test.ts`, update the import block at the top of the file:
+
+```typescript
+import {
+  buildRichInferenceCellContent,
+  buildRichGroundingCellContent,
+  parseMarkdown,
+} from "../src/server/rich-text";
+```
+
+Then add a new `describe` block at the bottom of the file (after the `buildRichGroundingCellContent` block):
+
+```typescript
+// ============================================================
+// parseMarkdown — extended features
+// ============================================================
+
+describe("parseMarkdown — extended features", () => {
+  it("wraps ~~text~~ as a strikethrough range", () => {
+    const result = parseMarkdown("before ~~struck~~ after");
+    expect(result.text).toBe("before struck after");
+    expect(result.ranges).toContainEqual({ startIndex: 7, endIndex: 13, strikethrough: true });
+  });
+
+  it("wraps `code` as a Courier New font-family range", () => {
+    const result = parseMarkdown("run `npm test` now");
+    expect(result.text).toBe("run npm test now");
+    expect(result.ranges).toContainEqual({ startIndex: 4, endIndex: 12, fontFamily: "Courier New" });
+  });
+
+  it("applies fontSize 18 and bold to h1", () => {
+    const result = parseMarkdown("# Title");
+    expect(result.text).toBe("Title");
+    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 5, bold: true, fontSize: 18 });
+  });
+
+  it("applies fontSize 16 and bold to h2", () => {
+    const result = parseMarkdown("## Section");
+    expect(result.text).toBe("Section");
+    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 7, bold: true, fontSize: 16 });
+  });
+
+  it("applies fontSize 14 and bold to h3", () => {
+    const result = parseMarkdown("### Sub");
+    expect(result.text).toBe("Sub");
+    expect(result.ranges).toContainEqual({ startIndex: 0, endIndex: 3, bold: true, fontSize: 14 });
+  });
+
+  it("applies bold only (no fontSize) to h4 and deeper", () => {
+    const result = parseMarkdown("#### Deep");
+    expect(result.text).toBe("Deep");
+    const headingRange = result.ranges.find((r) => r.bold);
+    expect(headingRange).toBeDefined();
+    expect(headingRange?.fontSize).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Update the existing h2 test that will break**
+
+The existing test at line ~56 asserts the heading range has no `fontSize`. After our change h2 gains `fontSize: 16`. Update that assertion:
+
+Find this block in `__tests__/rich-text.test.ts`:
+```typescript
+it("strips ## heading prefix and produces a bold range", () => {
+  const result = buildRichInferenceCellContent(
+    makeResponse({ text: "## Section Title\nBody text." }),
+  );
+  expect(result.text).toBe("Section Title\nBody text.");
+  expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 13, bold: true });
+});
+```
+
+Replace the final assertion with:
+```typescript
+  expect(result.ranges[0]).toEqual({ startIndex: 0, endIndex: 13, bold: true, fontSize: 16 });
+```
+
+- [ ] **Step 3: Run tests to confirm the 7 affected tests fail**
+
+```bash
+npx jest __tests__/rich-text.test.ts --no-coverage
+```
+
+Expected: 7 failures — the 6 new tests (`parseMarkdown` not exported yet / new features not implemented) plus the updated h2 test.
+
+- [ ] **Step 4: Export `parseMarkdown` and extend `TextRange` in `rich-text.ts`**
+
+In `src/server/rich-text.ts`, update the `TextRange` interface (around line 20):
+
+```typescript
+export interface TextRange {
+  startIndex: number;
+  endIndex: number;
+  bold?: boolean;
+  italic?: boolean;
+  strikethrough?: boolean;
+  fontFamily?: string;
+  fontSize?: number;
+  url?: string;
+}
+```
+
+Change `function processInline` to `export function processInline` — no, keep `processInline` private. Instead, change `function parseMarkdown` to `export function parseMarkdown`.
+
+- [ ] **Step 5: Add `~~strikethrough~~` and `` `code` `` patterns to `processInline`**
+
+In `processInline`, add two new blocks immediately before the `// Plain character` fallback (after the `*italic*` block):
+
+```typescript
+// ~~strikethrough~~ — must check before plain ~ fallback
+if (segment[i] === "~" && segment[i + 1] === "~") {
+  const closeIdx = segment.indexOf("~~", i + 2);
+  if (closeIdx > i + 1) {
+    const spanStart = cleanLen;
+    const inner = segment.slice(i + 2, closeIdx);
+    parts.push(inner);
+    cleanLen += inner.length;
+    ranges.push({ startIndex: spanStart, endIndex: cleanLen, strikethrough: true });
+    i = closeIdx + 2;
+    continue;
+  }
+}
+
+// `inline code` — single-backtick span
+if (segment[i] === "`") {
+  const closeIdx = segment.indexOf("`", i + 1);
+  if (closeIdx > i) {
+    const spanStart = cleanLen;
+    const inner = segment.slice(i + 1, closeIdx);
+    parts.push(inner);
+    cleanLen += inner.length;
+    ranges.push({ startIndex: spanStart, endIndex: cleanLen, fontFamily: "Courier New" });
+    i = closeIdx + 1;
+    continue;
+  }
+}
+```
+
+- [ ] **Step 6: Add `headingDepth` tracking and `fontSize` to the heading range in `parseMarkdown`**
+
+In `parseMarkdown`, update the variable declarations at the top of the `for` loop body:
+
+```typescript
+let content = line;
+let isHeading = false;
+let headingDepth = 0;
+```
+
+Update the heading detection block:
+
+```typescript
+const headingMatch = line.match(/^(#{1,6}) /);
+if (headingMatch) {
+  content = line.slice(headingMatch[1].length + 1);
+  isHeading = true;
+  headingDepth = headingMatch[1].length;
+}
+```
+
+Update the `isHeading` range push at the bottom of the loop:
+
+```typescript
+if (isHeading) {
+  const fontSize = headingDepth === 1 ? 18 : headingDepth === 2 ? 16 : headingDepth === 3 ? 14 : undefined;
+  const range: TextRange = { startIndex: spanStart, endIndex: cleanLen, bold: true };
+  if (fontSize !== undefined) range.fontSize = fontSize;
+  ranges.push(range);
+}
+```
+
+- [ ] **Step 7: Run tests to confirm all 7 pass**
+
+```bash
+npx jest __tests__/rich-text.test.ts --no-coverage
+```
+
+Expected: all tests pass, including the 6 new ones and the updated h2 test.
+
+- [ ] **Step 8: Run the full test suite**
+
+```bash
+npm test
+```
+
+Expected: all 490+ tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/server/rich-text.ts __tests__/rich-text.test.ts
+git commit -m "feat: extend TextRange + parseMarkdown for strikethrough, inline code, and heading font sizes"
+```
+
+---
+
+## Task 2: Wire up `formatMarkdownSelection`, `toCellValue`, menu, and rollup stub
+
+No unit tests for this task — all code is GAS-coupled (`SpreadsheetApp`). Verification is via build.
+
+**Files:**
+- Modify: `src/server/index.ts`
+- Modify: `rollup.config.js`
+
+**Interfaces:**
+- Consumes: `parseMarkdown(text: string): CellContent` from `./rich-text` (exported in Task 1)
+- Consumes: `TextRange` with `strikethrough`, `fontFamily`, `fontSize` (Task 1)
+- Produces: `formatMarkdownSelection(): void` (exported, GAS menu entry point)
+
+---
+
+- [ ] **Step 1: Add `parseMarkdown` to the `rich-text` import in `index.ts`**
+
+Find the existing import block in `src/server/index.ts`:
+
+```typescript
+import {
+  buildRichInferenceCellContent,
+  buildRichGroundingCellContent,
+  type CellContent,
+} from "./rich-text";
+```
+
+Replace with:
+
+```typescript
+import {
+  buildRichInferenceCellContent,
+  buildRichGroundingCellContent,
+  parseMarkdown,
+  type CellContent,
+} from "./rich-text";
+```
+
+- [ ] **Step 2: Extend `toCellValue` to handle the three new `TextRange` fields**
+
+Find the existing `toCellValue` function in `src/server/index.ts` (around line 245):
+
+```typescript
+function toCellValue(content: CellContent): GoogleAppsScript.Spreadsheet.RichTextValue {
+  const builder = SpreadsheetApp.newRichTextValue().setText(content.text);
+  content.ranges.forEach(({ startIndex, endIndex, bold, italic, url }) => {
+    if (bold === true || italic === true) {
+      const style = SpreadsheetApp.newTextStyle();
+      if (bold === true) style.setBold(true);
+      if (italic === true) style.setItalic(true);
+      builder.setTextStyle(startIndex, endIndex, style.build());
+    }
+    if (url) builder.setLinkUrl(startIndex, endIndex, url);
+  });
+  return builder.build();
+}
+```
+
+Replace with:
+
+```typescript
+function toCellValue(content: CellContent): GoogleAppsScript.Spreadsheet.RichTextValue {
+  const builder = SpreadsheetApp.newRichTextValue().setText(content.text);
+  content.ranges.forEach(({ startIndex, endIndex, bold, italic, strikethrough, fontFamily, fontSize, url }) => {
+    if (bold || italic || strikethrough || fontFamily || fontSize) {
+      const style = SpreadsheetApp.newTextStyle();
+      if (bold)          style.setBold(true);
+      if (italic)        style.setItalic(true);
+      if (strikethrough) style.setStrikethrough(true);
+      if (fontFamily)    style.setFontFamily(fontFamily);
+      if (fontSize)      style.setFontSize(fontSize);
+      builder.setTextStyle(startIndex, endIndex, style.build());
+    }
+    if (url) builder.setLinkUrl(startIndex, endIndex, url);
+  });
+  return builder.build();
+}
+```
+
+- [ ] **Step 3: Add `formatMarkdownSelection()` to `index.ts`**
+
+Add the new function immediately after `toCellValue` (before `const FILE_PIPELINE_BATCH_SIZE`):
+
+```typescript
+export function formatMarkdownSelection(): void {
+  const ui = SpreadsheetApp.getUi();
+  const range = SpreadsheetApp.getActiveRange();
+  if (!range) {
+    ui.alert("Select one or more cells first.");
+    return;
+  }
+  try {
+    const values = range.getValues() as unknown[][];
+    let count = 0;
+    for (let r = 0; r < values.length; r++) {
+      for (let c = 0; c < values[r].length; c++) {
+        const value = values[r][c];
+        if (typeof value !== "string" || value.trim() === "") continue;
+        const cell = range.getCell(r + 1, c + 1);
+        try {
+          cell.setRichTextValue(toCellValue(parseMarkdown(value)));
+          count++;
+        } catch (_e) {
+          cell.setValue(parseMarkdown(value).text);
+        }
+      }
+    }
+    ui.alert(`Formatted ${count} cell(s).`);
+  } catch (e) {
+    ui.alert(`Error: ${(e as Error).message}`);
+  }
+}
+```
+
+- [ ] **Step 4: Add the menu item to `onOpen()`**
+
+Find `onOpen` in `src/server/index.ts`:
+
+```typescript
+export function onOpen(): void {
+  SpreadsheetApp.getUi()
+    .createMenu("📐 SSI Toolkit")
+    .addItem("📐 Open SSI Toolkit", "showSidebar")
+    .addToUi();
+}
+```
+
+Replace with:
+
+```typescript
+export function onOpen(): void {
+  SpreadsheetApp.getUi()
+    .createMenu("📐 SSI Toolkit")
+    .addItem("📐 Open SSI Toolkit", "showSidebar")
+    .addItem("📝 Format Markdown", "formatMarkdownSelection")
+    .addToUi();
+}
+```
+
+- [ ] **Step 5: Add the rollup footer stub**
+
+In `rollup.config.js`, add one line to the `footer` string immediately after the `function showSidebar()` stub (around line 80):
+
+```js
+function formatMarkdownSelection() { _GASEntry.formatMarkdownSelection(); }
+```
+
+The footer block should now read:
+
+```js
+function onOpen(e) { _GASEntry.onOpen(e); }
+function showSidebar() { _GASEntry.showSidebar(); }
+function formatMarkdownSelection() { _GASEntry.formatMarkdownSelection(); }
+function runTool(fn, jobId) { _GASEntry.runTool(fn, jobId); }
+// ... rest unchanged
+```
+
+- [ ] **Step 6: Update the menu test that will break**
+
+In `__tests__/menu.test.ts`, find the test at line ~85 that asserts `addItem` is called exactly once:
+
+```typescript
+it("adds a single item that opens the sidebar", () => {
+  onOpen();
+  expect(mockAddItem).toHaveBeenCalledTimes(1);
+  expect(mockAddItem).toHaveBeenCalledWith("📐 Open SSI Toolkit", "showSidebar");
+});
+```
+
+Replace with:
+
+```typescript
+it("adds menu items for Open Toolkit and Format Markdown", () => {
+  onOpen();
+  expect(mockAddItem).toHaveBeenCalledTimes(2);
+  expect(mockAddItem).toHaveBeenCalledWith("📐 Open SSI Toolkit", "showSidebar");
+  expect(mockAddItem).toHaveBeenCalledWith("📝 Format Markdown", "formatMarkdownSelection");
+});
+```
+
+Run to confirm the test now passes:
+
+```bash
+npx jest __tests__/menu.test.ts --no-coverage
+```
+
+Expected: all menu tests pass.
+
+- [ ] **Step 7: Run typecheck and build to verify no errors**
+
+```bash
+npm run typecheck && npm run build
+```
+
+Expected: clean typecheck output and `dist/` files generated with no errors.
+
+- [ ] **Step 8: Run the full test suite one final time**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/server/index.ts rollup.config.js __tests__/menu.test.ts
+git commit -m "feat: add Format Markdown menu item (formatMarkdownSelection)"
+```

--- a/docs/superpowers/specs/2026-06-23-format-markdown-design.md
+++ b/docs/superpowers/specs/2026-06-23-format-markdown-design.md
@@ -1,0 +1,179 @@
+# Format Markdown — Design Spec
+
+| Field | Value |
+|---|---|
+| Feature | Format Markdown — in-place markdown → Sheets rich text |
+| Author | Aaron Brezel |
+| Date | 2026-06-23 |
+| Status | Draft |
+
+---
+
+## Overview
+
+A new SSI Toolkit menu item that converts markdown syntax in a user-selected cell range into Google Sheets rich text (bold, italic, strikethrough, inline code, hyperlinks, multi-level headings, bullets). Formatting is applied in-place — the cell text is stripped of markdown syntax and styled using `setRichTextValue()`.
+
+This extends the existing `parseMarkdown` + `toCellValue` pipeline that already powers the Run AI output path. No new sidebar panel; the user selects a range, clicks the menu item, done.
+
+---
+
+## Motivation
+
+`parseMarkdown()` in `rich-text.ts` already handles the core markdown subset for AI output. Journalists who type or paste markdown into cells manually (from a CMS export, notes, etc.) currently have no way to apply that formatting without running an AI job. This feature makes the parser available as a standalone formatting action.
+
+---
+
+## What Is and Is Not Supported
+
+Google Sheets `newTextStyle()` supports per-character: bold, italic, strikethrough, font family, font size, foreground color, underline, and link URL. This feature uses a subset of those.
+
+**Supported markdown → Sheets mapping:**
+
+| Markdown syntax | Sheets rendering | Notes |
+|---|---|---|
+| `**text**` | Bold | Existing |
+| `*text*` | Italic | Existing |
+| `[text](url)` | Hyperlink | Existing |
+| `* item` / `- item` | `• item` prefix | Existing |
+| `# Heading` | Bold, fontSize 18 | h1 — extended |
+| `## Heading` | Bold, fontSize 16 | h2 — extended |
+| `### Heading` | Bold, fontSize 14 | h3 — extended |
+| `#### Heading` and deeper | Bold only | h4–h6 — existing behavior |
+| `~~text~~` | Strikethrough | New |
+| `` `code` `` | Courier New font family | New |
+
+**Not supported** (no meaningful Sheets equivalent): tables, horizontal rules (`---`), numbered lists (no list-level concept in Sheets — the `1.` prefix is preserved as plain text), fenced code blocks.
+
+---
+
+## Architecture
+
+### Principle
+
+Reuse the existing `CellContent` / `TextRange` / `parseMarkdown` / `toCellValue` pipeline. Changes are additive — no existing behavior changes for the Run AI path.
+
+### Data flow
+
+```
+User selects range → "📐 SSI Toolkit > 📝 Format Markdown" menu item
+  → formatMarkdownSelection() [index.ts]
+    → getActiveRange() / validate selection
+    → for each non-empty cell:
+        parseMarkdown(cell.getValue()) [rich-text.ts] → CellContent
+        toCellValue(content) [index.ts] → RichTextValue
+        cell.setRichTextValue(richTextValue)
+    → ui.alert() with result count
+```
+
+### Code smell: TextRange ↔ toCellValue coupling
+
+`TextRange` (data model, in `rich-text.ts`) and `toCellValue` (renderer, in `index.ts`) are semantically coupled: adding a style field requires touching both. The split is intentional — `rich-text.ts` is GAS-free for testability; `toCellValue` uses `SpreadsheetApp`. This is an acceptable tradeoff at current scale. Mitigation: `toCellValue` destructures all `TextRange` fields explicitly, making the full contract visible in one place.
+
+---
+
+## File Changes
+
+### 1. `src/server/rich-text.ts`
+
+**`TextRange` interface** — add three optional fields:
+
+```typescript
+export interface TextRange {
+  startIndex: number;
+  endIndex: number;
+  bold?: boolean;
+  italic?: boolean;
+  strikethrough?: boolean;   // new
+  fontFamily?: string;       // new — "Courier New" for inline code
+  fontSize?: number;         // new — 18/16/14 for h1/h2/h3
+  url?: string;
+}
+```
+
+**`parseMarkdown()`** — change from private to exported. Extend with three new patterns (processed before plain-character fallback):
+
+- `~~text~~` → `{ strikethrough: true }` range. Must be checked before `*` patterns to avoid misparse of `~`.
+- `` `code` `` → single-backtick span → `{ fontFamily: "Courier New" }` range.
+- Heading match already extracts `#` count (`headingMatch[1].length`). Map depth to `fontSize`: 1→18, 2→16, 3→14, 4+→undefined (bold only, existing behavior). Heading range gains `fontSize` alongside `bold`.
+
+No changes to `processInline` — strikethrough and inline code are block-level only (not nested inside inline spans in the first implementation; can be revisited).
+
+**`buildRichInferenceCellContent`** and **`buildRichGroundingCellContent`** — unchanged. They call `parseMarkdown` internally; the new fields flow through automatically. The Run AI path gains the new features for free.
+
+### 2. `src/server/index.ts`
+
+**`toCellValue()`** — destructure all `TextRange` fields explicitly and extend the style builder:
+
+```typescript
+function toCellValue(content: CellContent): GoogleAppsScript.Spreadsheet.RichTextValue {
+  const builder = SpreadsheetApp.newRichTextValue().setText(content.text);
+  content.ranges.forEach(({ startIndex, endIndex, bold, italic, strikethrough, fontFamily, fontSize, url }) => {
+    if (bold || italic || strikethrough || fontFamily || fontSize) {
+      const style = SpreadsheetApp.newTextStyle();
+      if (bold)        style.setBold(true);
+      if (italic)      style.setItalic(true);
+      if (strikethrough) style.setStrikethrough(true);
+      if (fontFamily)  style.setFontFamily(fontFamily);
+      if (fontSize)    style.setFontSize(fontSize);
+      builder.setTextStyle(startIndex, endIndex, style.build());
+    }
+    if (url) builder.setLinkUrl(startIndex, endIndex, url);
+  });
+  return builder.build();
+}
+```
+
+**`formatMarkdownSelection()`** — new exported function:
+
+- Get active spreadsheet, sheet, range via `SpreadsheetApp.getActiveRange()`.
+- If no range selected, call `ui.alert("Select one or more cells first.")` and return.
+- Iterate all cells in the range. Skip cells where `getValue()` returns a non-string or empty string.
+- For each qualifying cell: `parseMarkdown(value)` → `toCellValue(content)` → `cell.setRichTextValue(richText)`.
+- After the loop, `ui.alert(\`Formatted ${count} cell(s).\`)` (skip if count is 0).
+- Wrap in try/catch; on error show `ui.alert(\`Error: ${e.message}\`)`.
+
+**`onOpen()`** — add menu item:
+
+```typescript
+SpreadsheetApp.getUi()
+  .createMenu("📐 SSI Toolkit")
+  .addItem("📐 Open SSI Toolkit", "showSidebar")
+  .addItem("📝 Format Markdown", "formatMarkdownSelection")
+  .addToUi();
+```
+
+### 3. `rollup.config.js`
+
+Add one footer stub alongside the existing ones:
+
+```js
+function formatMarkdownSelection() { _GASEntry.formatMarkdownSelection(); }
+```
+
+---
+
+## Error Handling
+
+| Condition | Behavior |
+|---|---|
+| No active range | `ui.alert()` — "Select one or more cells first." |
+| All selected cells empty or non-string | Silent skip; alert shows "Formatted 0 cell(s)." |
+| `setRichTextValue` throws on a cell | Caught per-cell; falls back to `setValue(parsedText)` (plain text, markdown stripped) |
+| Unexpected top-level error | `ui.alert()` with error message |
+
+---
+
+## Testing
+
+`parseMarkdown` is already tested in `__tests__/rich-text.test.ts`. The new features (strikethrough, inline code, h1–h3 sizing) get new test cases there — input markdown string, assert `CellContent.text` and `ranges`.
+
+`toCellValue` and `formatMarkdownSelection` are GAS-coupled and are not unit-tested (same exclusion as the rest of `index.ts`).
+
+---
+
+## Non-Goals
+
+- No undo support (Apps Script has no undo API).
+- No preview before applying.
+- No output-column mode — if needed later, it's a `RunConfig`-style extension.
+- Strikethrough and inline code are not supported inside inline spans (e.g. bold+code nesting). Can be added to `processInline` in a follow-up.

--- a/docs/superpowers/specs/2026-06-23-format-markdown-sidebar-button-design.md
+++ b/docs/superpowers/specs/2026-06-23-format-markdown-sidebar-button-design.md
@@ -1,0 +1,94 @@
+# Format Markdown Sidebar Button — Design Spec
+
+| Field | Value |
+|---|---|
+| Feature | Move Format Markdown entry point from menu item to sidebar Extras button |
+| Author | Aaron Brezel |
+| Date | 2026-06-23 |
+| Status | Draft |
+
+---
+
+## Overview
+
+Move the "Format Markdown" entry point from the SSI Toolkit menu to a button in the sidebar's existing Extras section on the tool-list homepage. The server function (`formatMarkdownSelection`) is unchanged — it still reads the active sheet selection, applies markdown rich-text formatting in-place, and shows a native Sheets `ui.alert()` for both the result count and the "nothing selected" case.
+
+---
+
+## Motivation
+
+The menu item pattern is appropriate for standalone actions with no sidebar involvement. Format Markdown is more naturally discovered alongside the other Extras tools (Import Drive Links, Sample Rows, Extract Text) in the sidebar, where journalists are already working.
+
+---
+
+## What Changes
+
+| File | Change |
+|---|---|
+| `src/server/index.ts` | Remove `"📝 Format Markdown"` / `"formatMarkdownSelection"` `addItem` call from `onOpen()` |
+| `src/client/services.ts` | Add `formatMarkdownSelection(): Promise<void>` following the existing `google.script.run` wrapper pattern |
+| `src/client/google.d.ts` | Add `formatMarkdownSelection(): void` to `GoogleScriptRun` interface |
+| `src/client/panels/tool-list.ts` | Add `#btn-format-markdown` button to existing Extras section; wire click handler |
+| `rollup.config.js` | No change — stub stays; `google.script.run` needs it to resolve the function |
+
+---
+
+## Detail
+
+### Button markup (added to Extras section in `tool-list.ts` template)
+
+```html
+<button id="btn-format-markdown" class="tool-btn">
+  <span class="icon">📝</span> Format Markdown
+</button>
+```
+
+Placed after the existing Extract Text button, consistent with the Extras ordering.
+
+### Event wiring (`wireEvents` in `tool-list.ts`)
+
+```typescript
+container.querySelector("#btn-format-markdown")?.addEventListener("click", () => {
+  formatMarkdownSelection().catch((err: Error) => globalThis.alert("Error: " + err.message));
+});
+```
+
+Imports `formatMarkdownSelection` from `../services`.
+
+### Service function (`services.ts`)
+
+```typescript
+export function formatMarkdownSelection(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    google.script.run
+      .withSuccessHandler(() => resolve())
+      .withFailureHandler((err: Error) => reject(err))
+      .formatMarkdownSelection();
+  });
+}
+```
+
+### Type declaration (`google.d.ts`)
+
+```typescript
+formatMarkdownSelection(): void;
+```
+
+Added to `GoogleScriptRun` alongside the other no-arg void methods.
+
+---
+
+## Behavior
+
+- User selects cells in the sheet, clicks "📝 Format Markdown" in the sidebar Extras section
+- `formatMarkdownSelection()` runs server-side: reads `SpreadsheetApp.getActiveRange()`, applies rich-text formatting, shows `ui.alert("Formatted N cell(s).")`
+- If no range selected (rare — Sheets always maintains a selection): `ui.alert("Select one or more cells first.")`
+- On unexpected error: sidebar catches the rejected promise and calls `globalThis.alert("Error: " + err.message)`
+
+---
+
+## Non-Goals
+
+- No change to `formatMarkdownSelection()` server logic
+- No inline sidebar feedback (keeping `ui.alert()` for consistency with the current implementation)
+- Menu item is removed entirely — not kept as a secondary entry point

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -78,6 +78,7 @@ export default [
  */
 function onOpen(e) { _GASEntry.onOpen(e); }
 function showSidebar() { _GASEntry.showSidebar(); }
+function formatMarkdownSelection() { _GASEntry.formatMarkdownSelection(); }
 function runTool(fn, jobId) { _GASEntry.runTool(fn, jobId); }
 function getSheetHeaders() { return _GASEntry.getSheetHeaders(); }
 function runBatchAI(config, jobId) { _GASEntry.runBatchAI(config, jobId); }

--- a/src/client/google.d.ts
+++ b/src/client/google.d.ts
@@ -18,6 +18,7 @@ declare global {
     prepRecipe(params: PrepRecipeParams): PrepRecipeResult;
     getJobProgress(jobId: string): void;
     getActiveRangeInfo(): void;
+    formatMarkdownSelection(): void;
   }
 
   const google: {

--- a/src/client/panels/tool-list.ts
+++ b/src/client/panels/tool-list.ts
@@ -1,5 +1,5 @@
 import type { NavigationContext, Panel } from "../types";
-import { runTool } from "../services";
+import { runTool, formatMarkdownSelection } from "../services";
 import { jobStore } from "../job-store";
 
 export class ToolListPanel implements Panel {
@@ -27,6 +27,9 @@ export class ToolListPanel implements Panel {
     });
     container.querySelector("#btn-extract-text")?.addEventListener("click", () => {
       nav.navigate("extract-text");
+    });
+    container.querySelector("#btn-format-markdown")?.addEventListener("click", () => {
+      formatMarkdownSelection().catch((err: Error) => globalThis.alert("Error: " + err.message));
     });
   }
 
@@ -60,6 +63,9 @@ export class ToolListPanel implements Panel {
         </button>
         <button id="btn-extract-text" class="tool-btn">
           <span class="icon">📜</span> Extract Text
+        </button>
+        <button id="btn-format-markdown" class="tool-btn">
+          <span class="icon">📝</span> Format Markdown
         </button>
       </div>
       <div class="status-footer">

--- a/src/client/panels/tool-list.ts
+++ b/src/client/panels/tool-list.ts
@@ -29,7 +29,16 @@ export class ToolListPanel implements Panel {
       nav.navigate("extract-text");
     });
     container.querySelector("#btn-format-markdown")?.addEventListener("click", () => {
-      formatMarkdownSelection().catch((err: Error) => globalThis.alert("Error: " + err.message));
+      const btn = container.querySelector<HTMLButtonElement>("#btn-format-markdown")!;
+      const originalHtml = btn.innerHTML;
+      btn.disabled = true;
+      btn.innerHTML = '<span class="icon">📝</span> Formatting...';
+      formatMarkdownSelection()
+        .catch((err: Error) => globalThis.alert("Error: " + err.message))
+        .finally(() => {
+          btn.disabled = false;
+          btn.innerHTML = originalHtml;
+        });
     });
   }
 

--- a/src/client/services.ts
+++ b/src/client/services.ts
@@ -83,3 +83,12 @@ export function getJobProgress(
       .getJobProgress(jobId);
   });
 }
+
+export function formatMarkdownSelection(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    google.script.run
+      .withSuccessHandler(() => resolve())
+      .withFailureHandler((err: Error) => reject(err))
+      .formatMarkdownSelection();
+  });
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -269,27 +269,24 @@ export function formatMarkdownSelection(): void {
     ui.alert("Select one or more cells first.");
     return;
   }
-  try {
-    const values = range.getValues() as unknown[][];
-    let count = 0;
-    for (let r = 0; r < values.length; r++) {
-      for (let c = 0; c < values[r].length; c++) {
-        const value = values[r][c];
-        if (typeof value !== "string" || value.trim() === "") continue;
-        const cell = range.getCell(r + 1, c + 1);
-        const content = parseMarkdown(value);
-        try {
-          cell.setRichTextValue(toCellValue(content));
-        } catch (_e) {
-          cell.setValue(content.text);
-        }
+  const values = range.getValues() as unknown[][];
+  const existingRichText = range.getRichTextValues();
+  let count = 0;
+  const grid = existingRichText.map((row, r) =>
+    row.map((existing, c) => {
+      const value = values[r][c];
+      if (typeof value !== "string" || value.trim() === "") return existing;
+      try {
+        const richText = toCellValue(parseMarkdown(value));
         count++;
+        return richText;
+      } catch (_e) {
+        return existing;
       }
-    }
-    ui.alert(`Formatted ${count} cell(s).`);
-  } catch (e) {
-    ui.alert(`Error: ${(e as Error).message}`);
-  }
+    }),
+  ) as GoogleAppsScript.Spreadsheet.RichTextValue[][];
+  range.setRichTextValues(grid);
+  ui.alert(`Formatted ${count} cell(s).`);
 }
 
 // Max files to download + upload per sub-batch in Wave 1.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -21,6 +21,7 @@ import { buildInferenceRequest } from "./inference";
 import {
   buildRichInferenceCellContent,
   buildRichGroundingCellContent,
+  parseMarkdown,
   type CellContent,
 } from "./rich-text";
 import {
@@ -55,6 +56,7 @@ export function onOpen(): void {
   SpreadsheetApp.getUi()
     .createMenu("📐 SSI Toolkit")
     .addItem("📐 Open SSI Toolkit", "showSidebar")
+    .addItem("📝 Format Markdown", "formatMarkdownSelection")
     .addToUi();
 }
 
@@ -244,16 +246,50 @@ export function sampleRowsToEvaluation(_jobId?: string): void {
 
 function toCellValue(content: CellContent): GoogleAppsScript.Spreadsheet.RichTextValue {
   const builder = SpreadsheetApp.newRichTextValue().setText(content.text);
-  content.ranges.forEach(({ startIndex, endIndex, bold, italic, url }) => {
-    if (bold === true || italic === true) {
-      const style = SpreadsheetApp.newTextStyle();
-      if (bold === true) style.setBold(true);
-      if (italic === true) style.setItalic(true);
-      builder.setTextStyle(startIndex, endIndex, style.build());
-    }
-    if (url) builder.setLinkUrl(startIndex, endIndex, url);
-  });
+  content.ranges.forEach(
+    ({ startIndex, endIndex, bold, italic, strikethrough, fontFamily, fontSize, url }) => {
+      if (bold || italic || strikethrough || fontFamily || fontSize) {
+        const style = SpreadsheetApp.newTextStyle();
+        if (bold) style.setBold(true);
+        if (italic) style.setItalic(true);
+        if (strikethrough) style.setStrikethrough(true);
+        if (fontFamily) style.setFontFamily(fontFamily);
+        if (fontSize) style.setFontSize(fontSize);
+        builder.setTextStyle(startIndex, endIndex, style.build());
+      }
+      if (url) builder.setLinkUrl(startIndex, endIndex, url);
+    },
+  );
   return builder.build();
+}
+
+export function formatMarkdownSelection(): void {
+  const ui = SpreadsheetApp.getUi();
+  const range = SpreadsheetApp.getActiveRange();
+  if (!range) {
+    ui.alert("Select one or more cells first.");
+    return;
+  }
+  try {
+    const values = range.getValues() as unknown[][];
+    let count = 0;
+    for (let r = 0; r < values.length; r++) {
+      for (let c = 0; c < values[r].length; c++) {
+        const value = values[r][c];
+        if (typeof value !== "string" || value.trim() === "") continue;
+        const cell = range.getCell(r + 1, c + 1);
+        try {
+          cell.setRichTextValue(toCellValue(parseMarkdown(value)));
+          count++;
+        } catch (_e) {
+          cell.setValue(parseMarkdown(value).text);
+        }
+      }
+    }
+    ui.alert(`Formatted ${count} cell(s).`);
+  } catch (e) {
+    ui.alert(`Error: ${(e as Error).message}`);
+  }
 }
 
 // Max files to download + upload per sub-batch in Wave 1.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -56,7 +56,6 @@ export function onOpen(): void {
   SpreadsheetApp.getUi()
     .createMenu("📐 SSI Toolkit")
     .addItem("📐 Open SSI Toolkit", "showSidebar")
-    .addItem("📝 Format Markdown", "formatMarkdownSelection")
     .addToUi();
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -264,11 +264,7 @@ function toCellValue(content: CellContent): GoogleAppsScript.Spreadsheet.RichTex
 
 export function formatMarkdownSelection(): void {
   const ui = SpreadsheetApp.getUi();
-  const range = SpreadsheetApp.getActiveRange();
-  if (!range) {
-    ui.alert("Select one or more cells first.");
-    return;
-  }
+  const range = SpreadsheetApp.getActiveRange()!;
   const values = range.getValues() as unknown[][];
   const existingRichText = range.getRichTextValues();
   let count = 0;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -278,12 +278,13 @@ export function formatMarkdownSelection(): void {
         const value = values[r][c];
         if (typeof value !== "string" || value.trim() === "") continue;
         const cell = range.getCell(r + 1, c + 1);
+        const content = parseMarkdown(value);
         try {
-          cell.setRichTextValue(toCellValue(parseMarkdown(value)));
-          count++;
+          cell.setRichTextValue(toCellValue(content));
         } catch (_e) {
-          cell.setValue(parseMarkdown(value).text);
+          cell.setValue(content.text);
         }
+        count++;
       }
     }
     ui.alert(`Formatted ${count} cell(s).`);

--- a/src/server/rich-text.ts
+++ b/src/server/rich-text.ts
@@ -116,7 +116,7 @@ function processInline(segment: string, offset: number): { text: string; ranges:
     // ~~strikethrough~~ — must check before plain ~ fallback
     if (segment[i] === "~" && segment[i + 1] === "~") {
       const closeIdx = segment.indexOf("~~", i + 2);
-      if (closeIdx > i + 1) {
+      if (closeIdx > i + 2) {
         const spanStart = cleanLen;
         const inner = segment.slice(i + 2, closeIdx);
         parts.push(inner);
@@ -130,7 +130,7 @@ function processInline(segment: string, offset: number): { text: string; ranges:
     // `inline code` — single-backtick span
     if (segment[i] === "`") {
       const closeIdx = segment.indexOf("`", i + 1);
-      if (closeIdx > i) {
+      if (closeIdx > i + 1) {
         const spanStart = cleanLen;
         const inner = segment.slice(i + 1, closeIdx);
         parts.push(inner);

--- a/src/server/rich-text.ts
+++ b/src/server/rich-text.ts
@@ -188,7 +188,7 @@ export function parseMarkdown(text: string): CellContent {
 
     if (isHeading) {
       const fontSize =
-        headingDepth === 1 ? 14 : headingDepth === 2 ? 13 : headingDepth === 3 ? 12 : undefined;
+        headingDepth === 1 ? 13 : headingDepth === 2 ? 12 : headingDepth === 3 ? 11 : undefined;
       const range: TextRange = { startIndex: spanStart, endIndex: cleanLen, bold: true };
       if (fontSize !== undefined) range.fontSize = fontSize;
       ranges.push(range);

--- a/src/server/rich-text.ts
+++ b/src/server/rich-text.ts
@@ -22,6 +22,9 @@ export interface TextRange {
   endIndex: number; // exclusive
   bold?: boolean;
   italic?: boolean;
+  strikethrough?: boolean;
+  fontFamily?: string;
+  fontSize?: number;
   url?: string;
 }
 
@@ -110,6 +113,34 @@ function processInline(segment: string, offset: number): { text: string; ranges:
       }
     }
 
+    // ~~strikethrough~~ — must check before plain ~ fallback
+    if (segment[i] === "~" && segment[i + 1] === "~") {
+      const closeIdx = segment.indexOf("~~", i + 2);
+      if (closeIdx > i + 1) {
+        const spanStart = cleanLen;
+        const inner = segment.slice(i + 2, closeIdx);
+        parts.push(inner);
+        cleanLen += inner.length;
+        ranges.push({ startIndex: spanStart, endIndex: cleanLen, strikethrough: true });
+        i = closeIdx + 2;
+        continue;
+      }
+    }
+
+    // `inline code` — single-backtick span
+    if (segment[i] === "`") {
+      const closeIdx = segment.indexOf("`", i + 1);
+      if (closeIdx > i) {
+        const spanStart = cleanLen;
+        const inner = segment.slice(i + 1, closeIdx);
+        parts.push(inner);
+        cleanLen += inner.length;
+        ranges.push({ startIndex: spanStart, endIndex: cleanLen, fontFamily: "Courier New" });
+        i = closeIdx + 1;
+        continue;
+      }
+    }
+
     // Plain character
     parts.push(segment[i]);
     cleanLen++;
@@ -123,7 +154,7 @@ function processInline(segment: string, offset: number): { text: string; ranges:
  * Parse markdown text into CellContent. Handles headings, bullets, bold, italic,
  * and [text](url) links. No position remapping — tracks clean-text position directly.
  */
-function parseMarkdown(text: string): CellContent {
+export function parseMarkdown(text: string): CellContent {
   const ranges: TextRange[] = [];
   const cleanParts: string[] = [];
   let cleanLen = 0;
@@ -133,12 +164,14 @@ function parseMarkdown(text: string): CellContent {
     const line = lines[lineIdx];
     let content = line;
     let isHeading = false;
+    let headingDepth = 0;
 
     // Structural prefix: heading (# Title → bold)
     const headingMatch = line.match(/^(#{1,6}) /);
     if (headingMatch) {
       content = line.slice(headingMatch[1].length + 1);
       isHeading = true;
+      headingDepth = headingMatch[1].length;
     }
     // Structural prefix: bullet (* item or - item → • item)
     else if (/^\* /.test(line) || /^- /.test(line)) {
@@ -154,7 +187,11 @@ function parseMarkdown(text: string): CellContent {
     ranges.push(...inlineRanges);
 
     if (isHeading) {
-      ranges.push({ startIndex: spanStart, endIndex: cleanLen, bold: true });
+      const fontSize =
+        headingDepth === 1 ? 18 : headingDepth === 2 ? 16 : headingDepth === 3 ? 14 : undefined;
+      const range: TextRange = { startIndex: spanStart, endIndex: cleanLen, bold: true };
+      if (fontSize !== undefined) range.fontSize = fontSize;
+      ranges.push(range);
     }
 
     if (lineIdx < lines.length - 1) {

--- a/src/server/rich-text.ts
+++ b/src/server/rich-text.ts
@@ -188,7 +188,7 @@ export function parseMarkdown(text: string): CellContent {
 
     if (isHeading) {
       const fontSize =
-        headingDepth === 1 ? 18 : headingDepth === 2 ? 16 : headingDepth === 3 ? 14 : undefined;
+        headingDepth === 1 ? 14 : headingDepth === 2 ? 13 : headingDepth === 3 ? 12 : undefined;
       const range: TextRange = { startIndex: spanStart, endIndex: cleanLen, bold: true };
       if (fontSize !== undefined) range.fontSize = fontSize;
       ranges.push(range);


### PR DESCRIPTION
## Summary

- Adds a "📝 Format Markdown" item to the SSI Toolkit menu that converts markdown syntax in a user-selected cell range to Google Sheets rich text in-place
- Refactors the rich text pipeline: splits the old `rich-text.ts` into `markdown-to-rich-text.ts` (pure `parseMarkdown(text): RichSpan[]`) and `gemini-grounding.ts` (`injectCitations` + `groundingToMarkdown`), replacing the `CellContent`/`TextRange` offset model with a simpler span list
- Adds three new markdown features to the parser: `~~strikethrough~~`, backtick inline code (→ Courier New), and multi-level heading font sizes (h1=13px, h2=12px, h3=11px)
- Fixes a latent bug where bold/italic content was not recursively parsed (e.g. `**bold *italic* bold**` previously rendered literal asterisks)
- Fixes link parser to use a paren-balanced walk instead of `lastIndexOf`, correctly handling URLs with parentheses such as Wikipedia citations
- Refactors `parseMarkdown` to a two-pass block-grouping approach (block pass → inline pass per block), fixing citation links whose text spans a soft line break
- Fixes `injectCitations` to truncate citation spans at block-level boundaries (bullets, headings, blank lines) — Gemini grounding offsets are block-unaware byte positions, and markdown links cannot cross block boundaries

## Manual QA

1. Open a Sheet and confirm "📝 Format Markdown" appears in the SSI Toolkit menu
2. Type markdown into one or more cells (e.g. `**bold** and *italic*`, `~~struck~~`, ``code```, `# Heading`, `[link](https://example.com)`)
3. Select those cells and click "📝 Format Markdown" — confirm rich text formatting is applied in-place
4. Select an empty range and click the menu item — confirm alert says "Formatted 0 cell(s)."
5. Confirm Run AI output with markdown enabled still formats correctly (regression check)
6. Confirm Run AI output with a grounded response includes inline citation links and a sources sidebar cell — confirm no raw `](url)` or `[text` appears as literal text in the cell

> N/A — this PR targets `develop`; full regression checklist applies at merge to `main`.

## Notes

<\!-- Anything reviewers or QA testers should know -->