### PR TITLE
feat: add model selection to Run AI sidebar

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -233,11 +233,11 @@ describe("callGeminiAPI", () => {
     expect(url).toContain("gemini-1.5-pro");
   });
 
-  it("falls back to CONFIG.MODEL_NAME when modelName is omitted", () => {
+  it("falls back to CONFIG.DEFAULT_MODEL when modelName is omitted", () => {
     mockFetchResponse({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
     callGeminiAPI(baseReq);
     const url = (UrlFetchApp.fetch as jest.Mock).mock.calls[0][0] as string;
-    expect(url).toContain(CONFIG.MODEL_NAME);
+    expect(url).toContain(CONFIG.DEFAULT_MODEL);
   });
 
   it("assembles text from multiple text parts (code execution interleaving)", () => {
@@ -459,11 +459,11 @@ describe("callGeminiAPIBatch", () => {
     expect(calls[0].url).toContain("gemini-1.5-pro");
   });
 
-  it("falls back to CONFIG.MODEL_NAME when modelName is omitted", () => {
+  it("falls back to CONFIG.DEFAULT_MODEL when modelName is omitted", () => {
     mockFetchAllResponses([{ candidates: [{ content: { parts: [{ text: "ok" }] } }] }]);
     callGeminiAPIBatch([{ apiKey: "key", userParts: [{ text: "Q" }] }]);
     const calls = (UrlFetchApp.fetchAll as jest.Mock).mock.calls[0][0];
-    expect(calls[0].url).toContain(CONFIG.MODEL_NAME);
+    expect(calls[0].url).toContain(CONFIG.DEFAULT_MODEL);
   });
 
   it("returns 'No response.' when candidates are empty", () => {

--- a/__tests__/client/models.test.ts
+++ b/__tests__/client/models.test.ts
@@ -6,11 +6,7 @@ import type { ModelId } from "../../src/shared/types";
 
 describe("MODEL_CATALOG", () => {
   it("contains an entry for every ModelId", () => {
-    const knownIds: ModelId[] = [
-      "gemini-3.1-flash-lite",
-      "gemini-3.5-flash",
-      "gemini-3.1-pro-preview",
-    ];
+    const knownIds: ModelId[] = ["gemini-3.1-flash-lite", "gemini-3.1-pro-preview"];
     const catalogIds = MODEL_CATALOG.map((m) => m.id);
     expect(catalogIds).toEqual(expect.arrayContaining(knownIds));
     expect(MODEL_CATALOG).toHaveLength(knownIds.length);

--- a/__tests__/client/models.test.ts
+++ b/__tests__/client/models.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+import { MODEL_CATALOG } from "../../src/client/models";
+import type { ModelId } from "../../src/shared/types";
+
+describe("MODEL_CATALOG", () => {
+  it("contains an entry for every ModelId", () => {
+    const knownIds: ModelId[] = [
+      "gemini-3.1-flash-lite",
+      "gemini-3.5-flash",
+      "gemini-3.1-pro-preview",
+    ];
+    const catalogIds = MODEL_CATALOG.map((m) => m.id);
+    expect(catalogIds).toEqual(expect.arrayContaining(knownIds));
+    expect(MODEL_CATALOG).toHaveLength(knownIds.length);
+  });
+
+  it("each entry has id, name, and description", () => {
+    for (const entry of MODEL_CATALOG) {
+      expect(typeof entry.id).toBe("string");
+      expect(typeof entry.name).toBe("string");
+      expect(typeof entry.description).toBe("string");
+      expect(entry.name.length).toBeGreaterThan(0);
+      expect(entry.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("first entry is the default model", () => {
+    expect(MODEL_CATALOG[0].id).toBe("gemini-3.1-flash-lite");
+    expect(MODEL_CATALOG[0].name).toBe("Gemini 3.1 Flash Lite");
+  });
+});

--- a/__tests__/panels/configure-ai-run.test.ts
+++ b/__tests__/panels/configure-ai-run.test.ts
@@ -552,3 +552,92 @@ describe("prefixWithColName checkbox", () => {
     expect(container.querySelector<HTMLInputElement>("#prefix-col-name-cb")!.checked).toBe(true);
   });
 });
+
+describe("ConfigureAIRunPanel — model selector", () => {
+  it("renders a chip for each model in MODEL_CATALOG", async () => {
+    const { container } = await mountAndLoad();
+    const chips = container.querySelectorAll<HTMLButtonElement>("#model-list .tag");
+    expect(chips).toHaveLength(3);
+    const ids = Array.from(chips).map((c) => c.getAttribute("data-value"));
+    expect(ids).toContain("gemini-3.1-flash-lite");
+    expect(ids).toContain("gemini-3.5-flash");
+    expect(ids).toContain("gemini-3.1-pro-preview");
+  });
+
+  it("selects gemini-3.1-flash-lite by default", async () => {
+    const { container } = await mountAndLoad();
+    const selected = container.querySelector<HTMLButtonElement>("#model-list .tag.selected");
+    expect(selected?.getAttribute("data-value")).toBe("gemini-3.1-flash-lite");
+  });
+
+  it("updates selected chip on click", async () => {
+    const { container } = await mountAndLoad();
+    const flashChip = container.querySelector<HTMLButtonElement>(
+      '#model-list .tag[data-value="gemini-3.5-flash"]',
+    )!;
+    flashChip.click();
+    const selected = container.querySelector<HTMLButtonElement>("#model-list .tag.selected");
+    expect(selected?.getAttribute("data-value")).toBe("gemini-3.5-flash");
+  });
+
+  it("updates model summary on selection change", async () => {
+    const { container } = await mountAndLoad();
+    container
+      .querySelector<HTMLButtonElement>('#model-list .tag[data-value="gemini-3.1-pro-preview"]')!
+      .click();
+    const summary = container.querySelector<HTMLElement>("#model-summary");
+    expect(summary?.textContent).toBe("Gemini 3.1 Pro Preview");
+  });
+
+  it("updates model description on selection change", async () => {
+    const { container } = await mountAndLoad();
+    container
+      .querySelector<HTMLButtonElement>('#model-list .tag[data-value="gemini-3.5-flash"]')!
+      .click();
+    const desc = container.querySelector<HTMLElement>("#model-description");
+    expect(desc?.textContent).toContain("agentic");
+  });
+
+  it("includes selected model in assembleRunConfig output", async () => {
+    (services.runBatchAI as jest.Mock).mockResolvedValue(undefined);
+    const { container } = await mountAndLoad({
+      promptCols: [{ col: "col_a", kind: "text" }],
+      outputCol: "ai_inference",
+    });
+    container
+      .querySelector<HTMLButtonElement>('#model-list .tag[data-value="gemini-3.5-flash"]')!
+      .click();
+    container.querySelector<HTMLButtonElement>("#run-btn")!.click();
+    await Promise.resolve(); // flush getActiveRangeInfo promise
+    expect(services.runBatchAI).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "gemini-3.5-flash" }),
+      expect.any(String),
+    );
+  });
+
+  it("restores model from savedState", async () => {
+    const { container } = await mountAndLoad({}, { model: "gemini-3.1-pro-preview" } as any);
+    const selected = container.querySelector<HTMLButtonElement>("#model-list .tag.selected");
+    expect(selected?.getAttribute("data-value")).toBe("gemini-3.1-pro-preview");
+  });
+
+  it("restores model from params when no savedState", async () => {
+    const { container } = await mountAndLoad({ model: "gemini-3.5-flash" });
+    const selected = container.querySelector<HTMLButtonElement>("#model-list .tag.selected");
+    expect(selected?.getAttribute("data-value")).toBe("gemini-3.5-flash");
+  });
+
+  it("unmount saves model and modelExpanded to SavedState", async () => {
+    const { container, panel } = await mountAndLoad({
+      promptCols: [{ col: "col_a", kind: "text" }],
+      outputCol: "ai_inference",
+    });
+    container
+      .querySelector<HTMLButtonElement>('#model-list .tag[data-value="gemini-3.5-flash"]')!
+      .click();
+    container.querySelector<HTMLButtonElement>("#model-toggle")!.click();
+    const state = panel.unmount();
+    expect(state?.model).toBe("gemini-3.5-flash");
+    expect(state?.modelExpanded).toBe(true);
+  });
+});

--- a/__tests__/panels/configure-ai-run.test.ts
+++ b/__tests__/panels/configure-ai-run.test.ts
@@ -554,48 +554,52 @@ describe("prefixWithColName checkbox", () => {
 });
 
 describe("ConfigureAIRunPanel — model selector", () => {
-  it("renders a chip for each model in MODEL_CATALOG", async () => {
+  it("renders a row for each model in MODEL_CATALOG", async () => {
     const { container } = await mountAndLoad();
-    const chips = container.querySelectorAll<HTMLButtonElement>("#model-list .tag");
-    expect(chips).toHaveLength(3);
-    const ids = Array.from(chips).map((c) => c.getAttribute("data-value"));
+    const rows = container.querySelectorAll<HTMLButtonElement>("#model-list .model-option");
+    expect(rows).toHaveLength(3);
+    const ids = Array.from(rows).map((r) => r.getAttribute("data-value"));
     expect(ids).toContain("gemini-3.1-flash-lite");
     expect(ids).toContain("gemini-3.5-flash");
     expect(ids).toContain("gemini-3.1-pro-preview");
   });
 
+  it("each row shows name and description inline", async () => {
+    const { container } = await mountAndLoad();
+    const firstRow = container.querySelector<HTMLButtonElement>("#model-list .model-option")!;
+    expect(firstRow.querySelector(".model-option-name")?.textContent).toBe("Gemini 3.1 Flash Lite");
+    expect(firstRow.querySelector(".model-option-desc")?.textContent?.length).toBeGreaterThan(0);
+  });
+
   it("selects gemini-3.1-flash-lite by default", async () => {
     const { container } = await mountAndLoad();
-    const selected = container.querySelector<HTMLButtonElement>("#model-list .tag.selected");
+    const selected = container.querySelector<HTMLButtonElement>(
+      "#model-list .model-option.selected",
+    );
     expect(selected?.getAttribute("data-value")).toBe("gemini-3.1-flash-lite");
   });
 
-  it("updates selected chip on click", async () => {
+  it("updates selected row on click", async () => {
     const { container } = await mountAndLoad();
-    const flashChip = container.querySelector<HTMLButtonElement>(
-      '#model-list .tag[data-value="gemini-3.5-flash"]',
+    const flashRow = container.querySelector<HTMLButtonElement>(
+      '#model-list .model-option[data-value="gemini-3.5-flash"]',
     )!;
-    flashChip.click();
-    const selected = container.querySelector<HTMLButtonElement>("#model-list .tag.selected");
+    flashRow.click();
+    const selected = container.querySelector<HTMLButtonElement>(
+      "#model-list .model-option.selected",
+    );
     expect(selected?.getAttribute("data-value")).toBe("gemini-3.5-flash");
   });
 
   it("updates model summary on selection change", async () => {
     const { container } = await mountAndLoad();
     container
-      .querySelector<HTMLButtonElement>('#model-list .tag[data-value="gemini-3.1-pro-preview"]')!
+      .querySelector<HTMLButtonElement>(
+        '#model-list .model-option[data-value="gemini-3.1-pro-preview"]',
+      )!
       .click();
     const summary = container.querySelector<HTMLElement>("#model-summary");
     expect(summary?.textContent).toBe("Gemini 3.1 Pro Preview");
-  });
-
-  it("updates model description on selection change", async () => {
-    const { container } = await mountAndLoad();
-    container
-      .querySelector<HTMLButtonElement>('#model-list .tag[data-value="gemini-3.5-flash"]')!
-      .click();
-    const desc = container.querySelector<HTMLElement>("#model-description");
-    expect(desc?.textContent).toContain("agentic");
   });
 
   it("includes selected model in assembleRunConfig output", async () => {
@@ -605,7 +609,7 @@ describe("ConfigureAIRunPanel — model selector", () => {
       outputCol: "ai_inference",
     });
     container
-      .querySelector<HTMLButtonElement>('#model-list .tag[data-value="gemini-3.5-flash"]')!
+      .querySelector<HTMLButtonElement>('#model-list .model-option[data-value="gemini-3.5-flash"]')!
       .click();
     container.querySelector<HTMLButtonElement>("#run-btn")!.click();
     await Promise.resolve(); // flush getActiveRangeInfo promise
@@ -617,13 +621,17 @@ describe("ConfigureAIRunPanel — model selector", () => {
 
   it("restores model from savedState", async () => {
     const { container } = await mountAndLoad({}, { model: "gemini-3.1-pro-preview" } as any);
-    const selected = container.querySelector<HTMLButtonElement>("#model-list .tag.selected");
+    const selected = container.querySelector<HTMLButtonElement>(
+      "#model-list .model-option.selected",
+    );
     expect(selected?.getAttribute("data-value")).toBe("gemini-3.1-pro-preview");
   });
 
   it("restores model from params when no savedState", async () => {
     const { container } = await mountAndLoad({ model: "gemini-3.5-flash" });
-    const selected = container.querySelector<HTMLButtonElement>("#model-list .tag.selected");
+    const selected = container.querySelector<HTMLButtonElement>(
+      "#model-list .model-option.selected",
+    );
     expect(selected?.getAttribute("data-value")).toBe("gemini-3.5-flash");
   });
 
@@ -633,7 +641,7 @@ describe("ConfigureAIRunPanel — model selector", () => {
       outputCol: "ai_inference",
     });
     container
-      .querySelector<HTMLButtonElement>('#model-list .tag[data-value="gemini-3.5-flash"]')!
+      .querySelector<HTMLButtonElement>('#model-list .model-option[data-value="gemini-3.5-flash"]')!
       .click();
     container.querySelector<HTMLButtonElement>("#model-toggle")!.click();
     const state = panel.unmount();

--- a/__tests__/panels/configure-ai-run.test.ts
+++ b/__tests__/panels/configure-ai-run.test.ts
@@ -557,10 +557,9 @@ describe("ConfigureAIRunPanel — model selector", () => {
   it("renders a row for each model in MODEL_CATALOG", async () => {
     const { container } = await mountAndLoad();
     const rows = container.querySelectorAll<HTMLButtonElement>("#model-list .model-option");
-    expect(rows).toHaveLength(3);
+    expect(rows).toHaveLength(2);
     const ids = Array.from(rows).map((r) => r.getAttribute("data-value"));
     expect(ids).toContain("gemini-3.1-flash-lite");
-    expect(ids).toContain("gemini-3.5-flash");
     expect(ids).toContain("gemini-3.1-pro-preview");
   });
 
@@ -582,13 +581,13 @@ describe("ConfigureAIRunPanel — model selector", () => {
   it("updates selected row on click", async () => {
     const { container } = await mountAndLoad();
     const flashRow = container.querySelector<HTMLButtonElement>(
-      '#model-list .model-option[data-value="gemini-3.5-flash"]',
+      '#model-list .model-option[data-value="gemini-3.1-pro-preview"]',
     )!;
     flashRow.click();
     const selected = container.querySelector<HTMLButtonElement>(
       "#model-list .model-option.selected",
     );
-    expect(selected?.getAttribute("data-value")).toBe("gemini-3.5-flash");
+    expect(selected?.getAttribute("data-value")).toBe("gemini-3.1-pro-preview");
   });
 
   it("updates model summary on selection change", async () => {
@@ -609,12 +608,14 @@ describe("ConfigureAIRunPanel — model selector", () => {
       outputCol: "ai_inference",
     });
     container
-      .querySelector<HTMLButtonElement>('#model-list .model-option[data-value="gemini-3.5-flash"]')!
+      .querySelector<HTMLButtonElement>(
+        '#model-list .model-option[data-value="gemini-3.1-pro-preview"]',
+      )!
       .click();
     container.querySelector<HTMLButtonElement>("#run-btn")!.click();
     await Promise.resolve(); // flush getActiveRangeInfo promise
     expect(services.runBatchAI).toHaveBeenCalledWith(
-      expect.objectContaining({ model: "gemini-3.5-flash" }),
+      expect.objectContaining({ model: "gemini-3.1-pro-preview" }),
       expect.any(String),
     );
   });
@@ -628,11 +629,11 @@ describe("ConfigureAIRunPanel — model selector", () => {
   });
 
   it("restores model from params when no savedState", async () => {
-    const { container } = await mountAndLoad({ model: "gemini-3.5-flash" });
+    const { container } = await mountAndLoad({ model: "gemini-3.1-pro-preview" });
     const selected = container.querySelector<HTMLButtonElement>(
       "#model-list .model-option.selected",
     );
-    expect(selected?.getAttribute("data-value")).toBe("gemini-3.5-flash");
+    expect(selected?.getAttribute("data-value")).toBe("gemini-3.1-pro-preview");
   });
 
   it("unmount saves model and modelExpanded to SavedState", async () => {
@@ -641,11 +642,13 @@ describe("ConfigureAIRunPanel — model selector", () => {
       outputCol: "ai_inference",
     });
     container
-      .querySelector<HTMLButtonElement>('#model-list .model-option[data-value="gemini-3.5-flash"]')!
+      .querySelector<HTMLButtonElement>(
+        '#model-list .model-option[data-value="gemini-3.1-pro-preview"]',
+      )!
       .click();
     container.querySelector<HTMLButtonElement>("#model-toggle")!.click();
     const state = panel.unmount();
-    expect(state?.model).toBe("gemini-3.5-flash");
+    expect(state?.model).toBe("gemini-3.1-pro-preview");
     expect(state?.modelExpanded).toBe(true);
   });
 });

--- a/docs/superpowers/specs/2026-06-29-model-selection-design.md
+++ b/docs/superpowers/specs/2026-06-29-model-selection-design.md
@@ -68,7 +68,7 @@ requests.push({ ...req, apiKey, modelName: config.model });
 
 ### UI (`src/client/panels/configure-ai-run.ts`)
 
-A new collapsible "Model" field group is added above the Tools section, following the same pattern as the Tools collapsible. When collapsed, a summary line shows the currently selected model name (e.g. "Gemini 3.1 Flash Lite"). When expanded, a `SingleTagList` renders the three model chips for exclusive selection, with a `field-helper` paragraph below that updates to show the selected model's description when the selection changes.
+A new collapsible "Model" field group is added above the Tools section, following the same pattern as the Tools collapsible. When collapsed, a summary line shows the currently selected model name (e.g. "Gemini 3.1 Flash Lite"). When expanded, three chips are rendered directly from `MODEL_CATALOG.map()` (not via `SingleTagList` — `SingleTagList` only supports strings as both display text and data-value, but model chips need separate IDs and display names). Click handlers enforce exclusive selection by toggling the `.selected` class, with a `field-helper` paragraph below that updates to show the selected model's description when the selection changes.
 
 `SavedState` gains `model?: ModelId` and `modelExpanded?: boolean` fields. On mount, the preset is restored from `savedState?.model ?? params?.model`, defaulting to `gemini-3.1-flash-lite` if neither is set. `assembleRunConfig` reads the selected model and includes it in the returned `RunConfig`.
 

--- a/docs/superpowers/specs/2026-06-29-model-selection-design.md
+++ b/docs/superpowers/specs/2026-06-29-model-selection-design.md
@@ -1,0 +1,98 @@
+# Model Selection Design
+
+**Date:** 2026-06-29
+**Branch:** feature/model-selection
+**Related issue:** none (companion Interactions API migration tracked in #119)
+
+## Overview
+
+Users currently have no way to choose which Gemini model runs their AI inference — the model is hardcoded in `CONFIG.MODEL_NAME`. This PR adds a model selector to the ConfigureAIRunPanel sidebar and threads the selection through `RunConfig` to the Gemini API call. Recipes can also pre-set a model via `settings.model`.
+
+The feature is intentionally narrow: no per-model configuration knobs, no user-editable generation config. Model selection is the only new surface.
+
+## Models supported
+
+| ID | Display name | Best for |
+|----|-------------|----------|
+| `gemini-3.1-flash-lite` | Flash Lite | Translation, transcription, lightweight data extraction, document processing at scale. Use when cost and speed matter most. |
+| `gemini-3.5-flash` | Flash | Rapid agentic loops, complex coding cycles, and iterative multi-step tasks. A great all-rounder. |
+| `gemini-3.1-pro-preview` | Pro Preview | Precise tool usage and reliable multi-step execution where accuracy and reasoning depth matter most. |
+
+`gemini-3.1-flash-lite` is the default (matches current `CONFIG.MODEL_NAME`). When `RunConfig.model` is absent, `callGeminiAPI` already falls back to `CONFIG.MODEL_NAME` — no change needed there.
+
+## Architecture
+
+### Types (`src/shared/types.ts`)
+
+Add `ModelId` alongside `ToolId` — both cross the RPC boundary:
+
+```typescript
+export type ModelId = "gemini-3.1-flash-lite" | "gemini-3.5-flash" | "gemini-3.1-pro-preview";
+```
+
+Add `model?: ModelId` to `RunConfig`. Add `"model"` to the `RecipeSettings` Pick — recipes get model presetting at no extra cost.
+
+### Client catalog (`src/client/models.ts`)
+
+New file, same pattern as `src/client/tools.ts`:
+
+```typescript
+export interface ModelCatalogEntry {
+  id: ModelId;
+  name: string;
+  description: string;
+}
+
+export const MODEL_CATALOG: ModelCatalogEntry[] = [
+  { id: "gemini-3.1-flash-lite", name: "Flash Lite", description: "..." },
+  { id: "gemini-3.5-flash",      name: "Flash",      description: "..." },
+  { id: "gemini-3.1-pro-preview", name: "Pro Preview", description: "..." },
+];
+```
+
+No RPC needed — the catalog is static compiled-in data.
+
+### Server thread-through (`src/server/index.ts`)
+
+`GeminiRequest.modelName?: string` already exists and is already used by `callGeminiAPI` / `callGeminiAPIBatch`. The only change is at the request assembly site in `runBatchAI` (currently line ~481):
+
+```typescript
+// Before
+requests.push({ ...req, apiKey });
+
+// After
+requests.push({ ...req, apiKey, modelName: config.model });
+```
+
+`callGeminiAPI` already handles `req.modelName ?? CONFIG.MODEL_NAME`, so the fallback to the default model is automatic. No changes to `api.ts`, `inference.ts`, or `server/types.ts`.
+
+### UI (`src/client/panels/configure-ai-run.ts`)
+
+A new non-collapsible "Model" field group is added above the Tools section. It uses `SingleTagList` for exclusive chip selection across the three models, with a `field-helper` paragraph below that updates to show the selected model's description when the selection changes.
+
+`SavedState` gains a `model?: ModelId` field. On mount, the preset is restored from `savedState?.model ?? params?.model`, defaulting to `gemini-3.1-flash-lite` if neither is set. `assembleRunConfig` reads the selected model and includes it in the returned `RunConfig`.
+
+### Recipes
+
+Since `RecipeSettings` is `Pick<RunConfig, "tools" | "applyMarkdown" | "includeGrounding" | "prefixWithColName">`, adding `"model"` to that union is the only change. Any recipe can then set `settings: { model: "gemini-3.1-pro-preview" }` and it flows through `buildRunConfig()` into the preppedRunConfig automatically.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `src/shared/types.ts` | Add `ModelId`; add `model?: ModelId` to `RunConfig`; add `"model"` to `RecipeSettings` Pick |
+| `src/client/models.ts` | New file — `ModelCatalogEntry` interface + `MODEL_CATALOG` array |
+| `src/client/panels/configure-ai-run.ts` | Model selector UI; `SavedState` update; preset restore; `assembleRunConfig` update |
+| `src/server/index.ts` | Spread `modelName: config.model` onto `GeminiRequest` at request assembly site |
+
+## Testing
+
+- `configure-ai-run` tests: verify model chip renders, selection flows into `assembleRunConfig` output, savedState round-trips correctly
+- Update any `RunConfig` fixtures in existing tests to account for the new optional `model` field (no breakage expected — field is optional)
+- No server-side test changes needed (the one-line change in `index.ts` is covered by the existing integration surface)
+
+## Out of scope
+
+- Per-model generation config (temperature, token limits) — deferred
+- Inline citation injection for grounding (tracked separately, see #119)
+- Interactions API migration (tracked in #119)

--- a/docs/superpowers/specs/2026-06-29-model-selection-design.md
+++ b/docs/superpowers/specs/2026-06-29-model-selection-design.md
@@ -14,11 +14,11 @@ The feature is intentionally narrow: no per-model configuration knobs, no user-e
 
 | ID | Display name | Best for |
 |----|-------------|----------|
-| `gemini-3.1-flash-lite` | Flash Lite | Translation, transcription, lightweight data extraction, document processing at scale. Use when cost and speed matter most. |
-| `gemini-3.5-flash` | Flash | Rapid agentic loops, complex coding cycles, and iterative multi-step tasks. A great all-rounder. |
-| `gemini-3.1-pro-preview` | Pro Preview | Precise tool usage and reliable multi-step execution where accuracy and reasoning depth matter most. |
+| `gemini-3.1-flash-lite` | Gemini 3.1 Flash Lite | Translation, transcription, lightweight data extraction, document processing at scale. Use when cost and speed matter most. |
+| `gemini-3.5-flash` | Gemini 3.5 Flash | Rapid agentic loops, complex coding cycles, and iterative multi-step tasks. A great all-rounder. |
+| `gemini-3.1-pro-preview` | Gemini 3.1 Pro Preview | Precise tool usage and reliable multi-step execution where accuracy and reasoning depth matter most. |
 
-`gemini-3.1-flash-lite` is the default (matches current `CONFIG.MODEL_NAME`). When `RunConfig.model` is absent, `callGeminiAPI` already falls back to `CONFIG.MODEL_NAME` — no change needed there.
+`gemini-3.1-flash-lite` is the default (matches current `CONFIG.MODEL_NAME`, which is renamed to `CONFIG.DEFAULT_MODEL` to reflect its new role as a fallback). When `RunConfig.model` is absent, `callGeminiAPI` falls back to `CONFIG.DEFAULT_MODEL`.
 
 ## Architecture
 
@@ -44,9 +44,9 @@ export interface ModelCatalogEntry {
 }
 
 export const MODEL_CATALOG: ModelCatalogEntry[] = [
-  { id: "gemini-3.1-flash-lite", name: "Flash Lite", description: "..." },
-  { id: "gemini-3.5-flash",      name: "Flash",      description: "..." },
-  { id: "gemini-3.1-pro-preview", name: "Pro Preview", description: "..." },
+  { id: "gemini-3.1-flash-lite",  name: "Gemini 3.1 Flash Lite",  description: "..." },
+  { id: "gemini-3.5-flash",       name: "Gemini 3.5 Flash",       description: "..." },
+  { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview", description: "..." },
 ];
 ```
 
@@ -68,9 +68,9 @@ requests.push({ ...req, apiKey, modelName: config.model });
 
 ### UI (`src/client/panels/configure-ai-run.ts`)
 
-A new non-collapsible "Model" field group is added above the Tools section. It uses `SingleTagList` for exclusive chip selection across the three models, with a `field-helper` paragraph below that updates to show the selected model's description when the selection changes.
+A new collapsible "Model" field group is added above the Tools section, following the same pattern as the Tools collapsible. When collapsed, a summary line shows the currently selected model name (e.g. "Gemini 3.1 Flash Lite"). When expanded, a `SingleTagList` renders the three model chips for exclusive selection, with a `field-helper` paragraph below that updates to show the selected model's description when the selection changes.
 
-`SavedState` gains a `model?: ModelId` field. On mount, the preset is restored from `savedState?.model ?? params?.model`, defaulting to `gemini-3.1-flash-lite` if neither is set. `assembleRunConfig` reads the selected model and includes it in the returned `RunConfig`.
+`SavedState` gains `model?: ModelId` and `modelExpanded?: boolean` fields. On mount, the preset is restored from `savedState?.model ?? params?.model`, defaulting to `gemini-3.1-flash-lite` if neither is set. `assembleRunConfig` reads the selected model and includes it in the returned `RunConfig`.
 
 ### Recipes
 
@@ -81,8 +81,11 @@ Since `RecipeSettings` is `Pick<RunConfig, "tools" | "applyMarkdown" | "includeG
 | File | Change |
 |------|--------|
 | `src/shared/types.ts` | Add `ModelId`; add `model?: ModelId` to `RunConfig`; add `"model"` to `RecipeSettings` Pick |
+| `src/server/types.ts` | Rename `AppConfig.MODEL_NAME` → `AppConfig.DEFAULT_MODEL` |
+| `src/server/config.ts` | Rename `MODEL_NAME` → `DEFAULT_MODEL` in the `CONFIG` object |
+| `src/server/api.ts` | Update `CONFIG.MODEL_NAME` reference → `CONFIG.DEFAULT_MODEL` |
 | `src/client/models.ts` | New file — `ModelCatalogEntry` interface + `MODEL_CATALOG` array |
-| `src/client/panels/configure-ai-run.ts` | Model selector UI; `SavedState` update; preset restore; `assembleRunConfig` update |
+| `src/client/panels/configure-ai-run.ts` | Collapsible model selector UI; `SavedState` update; preset restore; `assembleRunConfig` update |
 | `src/server/index.ts` | Spread `modelName: config.model` onto `GeminiRequest` at request assembly site |
 
 ## Testing

--- a/src/client/models.ts
+++ b/src/client/models.ts
@@ -27,18 +27,12 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     id: "gemini-3.1-flash-lite",
     name: "Gemini 3.1 Flash Lite",
     description:
-      "Best for translation, transcription, lightweight data extraction, and document processing at scale. Use when cost and speed matter most.",
-  },
-  {
-    id: "gemini-3.5-flash",
-    name: "Gemini 3.5 Flash",
-    description:
-      "Best for rapid agentic loops, complex coding cycles, and iterative multi-step tasks. A great all-rounder for most AI runs.",
+      "Good for almost all tasks — summarizing documents, pulling out key facts, translation, and categorizing records in bulk.",
   },
   {
     id: "gemini-3.1-pro-preview",
     name: "Gemini 3.1 Pro Preview",
     description:
-      "Best for precise tool usage and reliable multi-step execution where accuracy and reasoning depth matter most.",
+      "Best for tasks that require real reasoning — weighing competing claims, navigating ambiguous sources, or thinking through complex documents rather than just extracting from them.",
   },
 ];

--- a/src/client/models.ts
+++ b/src/client/models.ts
@@ -1,0 +1,44 @@
+/**
+ * client/models.ts — Client-side model catalog.
+ *
+ * Provides display metadata for models shown in the sidebar model selector.
+ * Hardcoded at build time — the model list is static compiled code,
+ * not user data, so no RPC is needed to populate it.
+ *
+ * When adding a new model:
+ * 1. Add its ID to ModelId in src/shared/types.ts
+ * 2. Add a display entry here
+ */
+
+import type { ModelId } from "../shared/types";
+
+/**
+ * Display metadata for a model shown in the sidebar.
+ * Contains only what the client needs — no API details or configuration.
+ */
+export interface ModelCatalogEntry {
+  id: ModelId;
+  name: string;
+  description: string;
+}
+
+export const MODEL_CATALOG: ModelCatalogEntry[] = [
+  {
+    id: "gemini-3.1-flash-lite",
+    name: "Gemini 3.1 Flash Lite",
+    description:
+      "Best for translation, transcription, lightweight data extraction, and document processing at scale. Use when cost and speed matter most.",
+  },
+  {
+    id: "gemini-3.5-flash",
+    name: "Gemini 3.5 Flash",
+    description:
+      "Best for rapid agentic loops, complex coding cycles, and iterative multi-step tasks. A great all-rounder for most AI runs.",
+  },
+  {
+    id: "gemini-3.1-pro-preview",
+    name: "Gemini 3.1 Pro Preview",
+    description:
+      "Best for precise tool usage and reliable multi-step execution where accuracy and reasoning depth matter most.",
+  },
+];

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -219,7 +219,6 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
       includeGrounding: this.includeGroundingCb?.checked ?? false,
       applyMarkdown: this.applyMarkdownCb?.checked ?? false,
       prefixWithColName: this.prefixWithColNameCb?.checked ?? false,
-      model: undefined,
       toolsExpanded: this.toolsExpanded,
     };
   }

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -140,18 +140,12 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
     // Model selection
     const initialModel: ModelId = preset.model ?? "gemini-3.1-flash-lite";
     this.modelListEl = container.querySelector<HTMLElement>("#model-list");
-    const modelButtons = this.modelListEl?.querySelectorAll<HTMLButtonElement>(".tag");
+    const modelButtons = this.modelListEl?.querySelectorAll<HTMLButtonElement>(".model-option");
 
     const updateModelSummary = (): void => {
       const entry = MODEL_CATALOG.find((m) => m.id === this.getSelectedModel());
       const summary = container.querySelector<HTMLElement>("#model-summary");
       if (summary) summary.textContent = entry?.name ?? "";
-    };
-
-    const updateModelDescription = (): void => {
-      const entry = MODEL_CATALOG.find((m) => m.id === this.getSelectedModel());
-      const desc = container.querySelector<HTMLElement>("#model-description");
-      if (desc) desc.textContent = entry?.description ?? "";
     };
 
     modelButtons?.forEach((btn) => {
@@ -160,12 +154,10 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
         modelButtons.forEach((b) => b.classList.remove("selected"));
         btn.classList.add("selected");
         updateModelSummary();
-        updateModelDescription();
       });
     });
 
     updateModelSummary();
-    updateModelDescription();
 
     this.modelExpanded = savedState?.modelExpanded ?? false;
     this.applyModelExpandState(container);
@@ -282,7 +274,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
   }
 
   private getSelectedModel(): ModelId {
-    const selected = this.modelListEl?.querySelector<HTMLButtonElement>(".tag.selected");
+    const selected = this.modelListEl?.querySelector<HTMLButtonElement>(".model-option.selected");
     return (selected?.getAttribute("data-value") as ModelId) ?? "gemini-3.1-flash-lite";
   }
 
@@ -461,11 +453,9 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
           <span class="collapsible-chevron">▶</span>
         </button>
         <div id="model-content" class="collapsible-content" hidden>
-          <p class="field-helper">Choose the Gemini model for this run. Each model has different strengths.</p>
-          <div id="model-list" class="tag-list">
-            ${MODEL_CATALOG.map((m) => `<button type="button" class="tag" data-value="${m.id}">${m.name}</button>`).join("")}
+          <div id="model-list" class="model-option-list">
+            ${MODEL_CATALOG.map((m) => `<button type="button" class="model-option" data-value="${m.id}"><span class="model-option-name">${m.name}</span><span class="model-option-desc">${m.description}</span></button>`).join("")}
           </div>
-          <p class="field-helper" id="model-description"></p>
         </div>
       </div>
       <div class="field-group">

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -26,11 +26,14 @@ export function computeChunks(
 }
 
 export type SavedState = Required<
-  Omit<RunConfig, "rowRange" | "tools" | "includeGrounding" | "applyMarkdown" | "prefixWithColName">
+  Omit<
+    RunConfig,
+    "rowRange" | "tools" | "includeGrounding" | "applyMarkdown" | "prefixWithColName" | "model"
+  >
 > &
   Pick<
     RunConfig,
-    "rowRange" | "tools" | "includeGrounding" | "applyMarkdown" | "prefixWithColName"
+    "rowRange" | "tools" | "includeGrounding" | "applyMarkdown" | "prefixWithColName" | "model"
   > & {
     toolsExpanded?: boolean;
   };
@@ -216,6 +219,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
       includeGrounding: this.includeGroundingCb?.checked ?? false,
       applyMarkdown: this.applyMarkdownCb?.checked ?? false,
       prefixWithColName: this.prefixWithColNameCb?.checked ?? false,
+      model: undefined,
       toolsExpanded: this.toolsExpanded,
     };
   }

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -1,5 +1,5 @@
 import type { NavigationContext, Panel } from "../types";
-import type { RunConfig, ToolId } from "../../shared/types";
+import type { RunConfig, ToolId, ModelId } from "../../shared/types";
 import { TagList } from "../components/tag-list";
 import { TokenInput } from "../components/token-input";
 import { PromptColList } from "../components/prompt-col-list";
@@ -8,6 +8,7 @@ import { PanelLoader } from "../components/panel-loader";
 import { getSheetHeaders, runBatchAI, getActiveRangeInfo } from "../services";
 import { jobStore } from "../job-store";
 import { TOOL_CATALOG } from "../tools";
+import { MODEL_CATALOG } from "../models";
 
 export const CHUNK_SIZE = 40;
 // Warn before dispatch when the batch exceeds this many rows, regardless of chunk count.
@@ -36,6 +37,7 @@ export type SavedState = Required<
     "rowRange" | "tools" | "includeGrounding" | "applyMarkdown" | "prefixWithColName" | "model"
   > & {
     toolsExpanded?: boolean;
+    modelExpanded?: boolean;
   };
 
 export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState> {
@@ -51,6 +53,8 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
   private nav: NavigationContext | null = null;
   private headersLoaded = false;
   private toolsExpanded = false;
+  private modelListEl: HTMLElement | null = null;
+  private modelExpanded = false;
 
   mount(
     container: HTMLElement,
@@ -74,6 +78,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
           includeGrounding: savedState.includeGrounding,
           applyMarkdown: savedState.applyMarkdown,
           prefixWithColName: savedState.prefixWithColName,
+          model: savedState.model,
         }
       : (params ?? {});
 
@@ -131,6 +136,43 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
     };
     updateToolsSummary();
     container.querySelector("#tools-list")?.addEventListener("click", updateToolsSummary);
+
+    // Model selection
+    const initialModel: ModelId = preset.model ?? "gemini-3.1-flash-lite";
+    this.modelListEl = container.querySelector<HTMLElement>("#model-list");
+    const modelButtons = this.modelListEl?.querySelectorAll<HTMLButtonElement>(".tag");
+
+    const updateModelSummary = (): void => {
+      const entry = MODEL_CATALOG.find((m) => m.id === this.getSelectedModel());
+      const summary = container.querySelector<HTMLElement>("#model-summary");
+      if (summary) summary.textContent = entry?.name ?? "";
+    };
+
+    const updateModelDescription = (): void => {
+      const entry = MODEL_CATALOG.find((m) => m.id === this.getSelectedModel());
+      const desc = container.querySelector<HTMLElement>("#model-description");
+      if (desc) desc.textContent = entry?.description ?? "";
+    };
+
+    modelButtons?.forEach((btn) => {
+      if (btn.getAttribute("data-value") === initialModel) btn.classList.add("selected");
+      btn.addEventListener("click", () => {
+        modelButtons.forEach((b) => b.classList.remove("selected"));
+        btn.classList.add("selected");
+        updateModelSummary();
+        updateModelDescription();
+      });
+    });
+
+    updateModelSummary();
+    updateModelDescription();
+
+    this.modelExpanded = savedState?.modelExpanded ?? false;
+    this.applyModelExpandState(container);
+    container.querySelector("#model-toggle")?.addEventListener("click", () => {
+      this.modelExpanded = !this.modelExpanded;
+      this.applyModelExpandState(container);
+    });
 
     const loader = new PanelLoader(container);
     loader.setState({ status: "loading", message: "Loading columns..." });
@@ -220,6 +262,8 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
       applyMarkdown: this.applyMarkdownCb?.checked ?? false,
       prefixWithColName: this.prefixWithColNameCb?.checked ?? false,
       toolsExpanded: this.toolsExpanded,
+      model: this.getSelectedModel(),
+      modelExpanded: this.modelExpanded,
     };
   }
 
@@ -228,6 +272,18 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
     const toggle = container.querySelector<HTMLButtonElement>("#tools-toggle");
     if (content) content.hidden = !this.toolsExpanded;
     if (toggle) toggle.setAttribute("aria-expanded", String(this.toolsExpanded));
+  }
+
+  private applyModelExpandState(container: HTMLElement): void {
+    const content = container.querySelector<HTMLElement>("#model-content");
+    const toggle = container.querySelector<HTMLButtonElement>("#model-toggle");
+    if (content) content.hidden = !this.modelExpanded;
+    if (toggle) toggle.setAttribute("aria-expanded", String(this.modelExpanded));
+  }
+
+  private getSelectedModel(): ModelId {
+    const selected = this.modelListEl?.querySelector<HTMLButtonElement>(".tag.selected");
+    return (selected?.getAttribute("data-value") as ModelId) ?? "gemini-3.1-flash-lite";
   }
 
   private wireNavButtons(container: HTMLElement): void {
@@ -257,6 +313,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
       includeGrounding: this.includeGroundingCb?.checked,
       applyMarkdown: this.applyMarkdownCb?.checked,
       prefixWithColName: this.prefixWithColNameCb?.checked,
+      model: this.getSelectedModel(),
     };
   }
 
@@ -342,6 +399,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
     const includeGrounding = this.includeGroundingCb?.checked ?? false;
     const applyMarkdown = this.applyMarkdownCb?.checked ?? false;
     const prefixWithColName = this.prefixWithColNameCb?.checked ?? false;
+    const model = this.getSelectedModel();
     return {
       promptCols,
       systemPromptCol,
@@ -351,6 +409,7 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
       includeGrounding: includeGrounding || undefined,
       applyMarkdown: applyMarkdown || undefined,
       prefixWithColName: prefixWithColName || undefined,
+      model,
     };
   }
 
@@ -394,6 +453,20 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
           <input type="checkbox" id="apply-markdown-cb" />
           <span>Apply markdown formatting</span>
         </label>
+      </div>
+      <div class="field-group">
+        <button type="button" id="model-toggle" class="collapsible-header">
+          <span class="collapsible-label">MODEL</span>
+          <span id="model-summary" class="collapsible-summary"></span>
+          <span class="collapsible-chevron">▶</span>
+        </button>
+        <div id="model-content" class="collapsible-content" hidden>
+          <p class="field-helper">Choose the Gemini model for this run. Each model has different strengths.</p>
+          <div id="model-list" class="tag-list">
+            ${MODEL_CATALOG.map((m) => `<button type="button" class="tag" data-value="${m.id}">${m.name}</button>`).join("")}
+          </div>
+          <p class="field-helper" id="model-description"></p>
+        </div>
       </div>
       <div class="field-group">
         <button type="button" id="tools-toggle" class="collapsible-header">

--- a/src/client/sidebar.css
+++ b/src/client/sidebar.css
@@ -287,7 +287,7 @@
         .model-option.selected .model-option-name { color: var(--primary-blue); }
 
         .model-option-desc {
-            font-size: var(--font-size-200);
+            font-size: var(--font-size-100);
             color: var(--text-secondary);
             margin-top: 2px;
             line-height: 1.4;

--- a/src/client/sidebar.css
+++ b/src/client/sidebar.css
@@ -244,6 +244,55 @@
             font-weight: 500;
         }
 
+        .model-option-list {
+            display: flex;
+            flex-direction: column;
+            border: 1px solid var(--border-color);
+            border-radius: 6px;
+            overflow: hidden;
+            margin-top: 4px;
+        }
+
+        .model-option {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            padding: 8px 10px;
+            border: none;
+            border-bottom: 1px solid var(--border-color);
+            background: none;
+            cursor: pointer;
+            text-align: left;
+            font-family: var(--font-family);
+            width: 100%;
+            transition: background 0.1s;
+        }
+
+        .model-option:last-child { border-bottom: none; }
+
+        .model-option:hover { background: #f8f9fa; }
+
+        .model-option.selected {
+            background: rgba(26, 115, 232, 0.06);
+            border-left: 3px solid var(--primary-blue);
+            padding-left: 7px;
+        }
+
+        .model-option-name {
+            font-size: var(--font-size-300);
+            font-weight: 500;
+            color: var(--text-main);
+        }
+
+        .model-option.selected .model-option-name { color: var(--primary-blue); }
+
+        .model-option-desc {
+            font-size: var(--font-size-200);
+            color: var(--text-secondary);
+            margin-top: 2px;
+            line-height: 1.4;
+        }
+
         .select-input {
             width: 100%;
             padding: 7px 8px;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -45,7 +45,7 @@ export interface Job {
  */
 export type RecipeSettings = Pick<
   RunConfig,
-  "tools" | "applyMarkdown" | "includeGrounding" | "prefixWithColName"
+  "tools" | "applyMarkdown" | "includeGrounding" | "prefixWithColName" | "model"
 >;
 
 export interface RecipeInput {

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -53,7 +53,7 @@ export function buildGeminiPayload(req: GeminiRequest): Record<string, unknown> 
  * Call the Gemini generateContent endpoint and return the response as GeminiResponse.
  */
 export function callGeminiAPI(req: GeminiRequest): GeminiResponse {
-  const modelName = req.modelName ?? CONFIG.MODEL_NAME;
+  const modelName = req.modelName ?? CONFIG.DEFAULT_MODEL;
   const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent?key=${req.apiKey}`;
 
   const options: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
@@ -112,7 +112,7 @@ export function callGeminiAPIBatch(reqs: GeminiRequest[]): GeminiResponse[] {
   if (reqs.length === 0) return [];
 
   const requests = reqs.map((req) => {
-    const modelName = req.modelName ?? CONFIG.MODEL_NAME;
+    const modelName = req.modelName ?? CONFIG.DEFAULT_MODEL;
     const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent?key=${req.apiKey}`;
     return {
       url,

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -8,7 +8,7 @@ import type { AppConfig } from "./types";
 
 export const CONFIG: AppConfig = {
   API_KEY_PROPERTY: "GEMINI_API_KEY",
-  MODEL_NAME: "gemini-3.1-flash-lite",
+  DEFAULT_MODEL: "gemini-3.1-flash-lite",
   INLINE_MAX_TOTAL_BYTES: 95 * 1024 * 1024, // 95MB (100MB ceiling × 0.95)
   INLINE_MAX_PDF_BYTES: 47 * 1024 * 1024, // 47MB (50MB ceiling × 0.95)
   INLINE_PREFLIGHT_FACTOR: 4 / 3, // exact base64 expansion ratio

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -514,7 +514,7 @@ export function runBatchAI(config: RunConfig, jobId?: string): void {
       hasFileInputs ? fileUriMap : undefined,
     );
     if (req !== null) {
-      requests.push({ ...req, apiKey });
+      requests.push({ ...req, apiKey, modelName: config.model });
       rowIndices.push(i);
     }
   }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -12,7 +12,7 @@ import type { PromptColumnSpec, ToolId } from "../shared/types";
 
 export interface AppConfig {
   API_KEY_PROPERTY: string;
-  MODEL_NAME: string;
+  DEFAULT_MODEL: string;
   /**
    * Inline data size limits for the Gemini REST API.
    * Source: https://ai.google.dev/gemini-api/docs/file-input-methods#method-comparison
@@ -143,7 +143,7 @@ export interface DriveFileInfo {
 
 export interface GeminiRequest {
   apiKey: string;
-  modelName?: string; // defaults to CONFIG.MODEL_NAME if omitted
+  modelName?: string; // defaults to CONFIG.DEFAULT_MODEL if omitted
   systemPrompt?: string;
   /** Ordered user-turn parts assembled by the caller. Maps 1:1 to contents[0].parts in the REST payload. */
   userParts: GeminiUserPart[];

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -21,7 +21,7 @@ export type ToolId = "google_search" | "url_context" | "code_execution";
  * All model IDs supported by the toolkit.
  * Extend this union when adding a new model option.
  */
-export type ModelId = "gemini-3.1-flash-lite" | "gemini-3.5-flash" | "gemini-3.1-pro-preview";
+export type ModelId = "gemini-3.1-flash-lite" | "gemini-3.1-pro-preview";
 
 // ── Prompt column spec ──────────────────────────────────────────
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -17,6 +17,12 @@
  */
 export type ToolId = "google_search" | "url_context" | "code_execution";
 
+/**
+ * All model IDs supported by the toolkit.
+ * Extend this union when adding a new model option.
+ */
+export type ModelId = "gemini-3.1-flash-lite" | "gemini-3.5-flash" | "gemini-3.1-pro-preview";
+
 // ── Prompt column spec ──────────────────────────────────────────
 
 /**
@@ -50,6 +56,8 @@ export interface RunConfig {
   applyMarkdown?: boolean;
   /** When true, each text prompt part is prefixed with its source column name as "<col>: <value>". */
   prefixWithColName?: boolean;
+  /** Model ID to use for this run. When omitted, defaults to CONFIG.DEFAULT_MODEL. */
+  model?: ModelId;
 }
 
 // ── Recipes ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `ModelId` type to the RPC boundary (`shared/types.ts`) and threads the user's model choice from `RunConfig` through `runBatchAI` to the Gemini API URL — when no model is selected, the existing `CONFIG.DEFAULT_MODEL` fallback (`gemini-3.1-flash-lite`) applies automatically
- Adds a collapsible Model selector to ConfigureAIRunPanel above the Tools section: three chip buttons (Flash Lite, Flash, Pro Preview) with a summary line when collapsed and a flavor-text description that updates on selection; selection persists across back-navigation via `SavedState`
- Renames `CONFIG.MODEL_NAME` to `CONFIG.DEFAULT_MODEL` throughout server code to reflect its new role as a fallback rather than the sole model
- Recipes can pre-set a model via `settings.model` at no extra cost — `"model"` was added to the `RecipeSettings` Pick

## Manual QA

1. Open the Run AI sidebar and confirm a **MODEL** section appears above **TOOLS**
2. Confirm **Gemini 3.1 Flash Lite** is selected by default (chip highlighted, summary shows name)
3. Click **Gemini 3.5 Flash** — confirm the chip becomes selected, summary updates, and the description paragraph changes
4. Click the MODEL header to collapse the section — confirm the selected model name appears as summary text
5. Navigate away (Back) and re-open Run AI — confirm the model selection is restored
6. Set a prompt column and output column, pick **Gemini 3.1 Pro Preview**, run inference — confirm the run completes

> Complete for PRs targeting `main`. Mark N/A with reason for PRs targeting `develop`.

- [ ] Add-on menu appears after opening a Sheet — N/A (targeting develop)
- [ ] Sidebar opens without errors — N/A (targeting develop)
- [ ] Import Drive Links — imports files from a folder — N/A (targeting develop)
- [ ] Extract Text — extracts text from a Doc/PDF/image — N/A (targeting develop)
- [ ] Sample Rows — samples rows reproducibly with a seed — N/A (targeting develop)
- [ ] Run AI — batch inference completes and writes output column — N/A (targeting develop)
- [ ] Tested on a Sheet the tester does not own (shared access) — N/A (targeting develop)

## Security

- [x] Changes Gemini API integration (affects T2, T3, T11, T14)

The model name in the API URL now comes from `RunConfig.model` (user selection) falling back to `CONFIG.DEFAULT_MODEL`. The allowed values are a compile-time closed set (`ModelId` union); no user-supplied string reaches the URL. No new OAuth scopes, no new endpoints, no new data types sent. Threat model reviewed — no update needed.

## Notes

<!-- Anything reviewers or QA testers should know -->
