### PR TITLE
fix: correct markdown citation injection — block prefixes, multi-line truncation, word boundaries

### DIFF
--- a/__tests__/gemini-grounding.test.ts
+++ b/__tests__/gemini-grounding.test.ts
@@ -202,6 +202,40 @@ describe("injectCitations", () => {
       "* [Candidates are being evaluated.](https://example.com)\nMore details follow.",
     );
   });
+
+  it("snaps startIndex backward to word boundary when citation begins mid-word", () => {
+    const response = makeResponse({
+      text: "Injury: Marcus Semien is out.",
+      groundingMetadata: {
+        groundingChunks: [{ web: { uri: "https://example.com", title: "Source" } }],
+        groundingSupports: [
+          {
+            segment: { startIndex: 10, endIndex: 29, text: "rcus Semien is out." },
+            groundingChunkIndices: [0],
+          },
+        ],
+      },
+    });
+    expect(injectCitations(response)).toBe("Injury: [Marcus Semien is out.](https://example.com)");
+  });
+
+  it("snaps endIndex forward to word boundary when citation ends mid-word", () => {
+    const response = makeResponse({
+      text: "Starting pitcher Clay Holmes. While he pitched well.",
+      groundingMetadata: {
+        groundingChunks: [{ web: { uri: "https://example.com", title: "Source" } }],
+        groundingSupports: [
+          {
+            segment: { startIndex: 0, endIndex: 33, text: "Starting pitcher Clay Holmes. Whi" },
+            groundingChunkIndices: [0],
+          },
+        ],
+      },
+    });
+    expect(injectCitations(response)).toBe(
+      "[Starting pitcher Clay Holmes. While](https://example.com) he pitched well.",
+    );
+  });
 });
 
 // ---- groundingToMarkdown ----

--- a/__tests__/gemini-grounding.test.ts
+++ b/__tests__/gemini-grounding.test.ts
@@ -236,6 +236,80 @@ describe("injectCitations", () => {
       "[Starting pitcher Clay Holmes. While](https://example.com) he pitched well.",
     );
   });
+
+  it("truncates citation at a standalone **bold-heading** line when startIndex is at the opening **", () => {
+    // Gemini uses **Heading** (not ### Heading) for section titles. Citation spans the
+    // heading and into the next paragraph — must truncate at the heading line.
+    // "**Carlos Mendoza Fired**" = 24 chars (indices 0-23); \n at 24.
+    const response = makeResponse({
+      text: "**Carlos Mendoza Fired**\nHe was the Mets manager.",
+      groundingMetadata: {
+        groundingChunks: [{ web: { uri: "https://example.com", title: "Source" } }],
+        groundingSupports: [
+          {
+            segment: {
+              startIndex: 0,
+              endIndex: 45,
+              text: "**Carlos Mendoza Fired**\nHe was the Mets ma",
+            },
+            groundingChunkIndices: [0],
+          },
+        ],
+      },
+    });
+    expect(injectCitations(response)).toBe(
+      "[**Carlos Mendoza Fired**](https://example.com)\nHe was the Mets manager.",
+    );
+  });
+
+  it("snaps backward past ** when startIndex falls inside a bold-heading span", () => {
+    // startIndex=2 lands on 'C' (inside **...**). Backward snap must cross ** delimiters
+    // so the injected link is [**Carlos Mendoza Fired**](url), not **[Carlos...](url).
+    // "**Carlos Mendoza Fired**" = 24 chars; **=0-1, C=2.
+    const response = makeResponse({
+      text: "**Carlos Mendoza Fired**\nHe was the Mets manager.",
+      groundingMetadata: {
+        groundingChunks: [{ web: { uri: "https://example.com", title: "Source" } }],
+        groundingSupports: [
+          {
+            segment: {
+              startIndex: 2,
+              endIndex: 45,
+              text: "Carlos Mendoza Fired**\nHe was the Mets ma",
+            },
+            groundingChunkIndices: [0],
+          },
+        ],
+      },
+    });
+    expect(injectCitations(response)).toBe(
+      "[**Carlos Mendoza Fired**](https://example.com)\nHe was the Mets manager.",
+    );
+  });
+
+  it("handles bold heading inside a numbered item (4. **Heading**)", () => {
+    // startIndex=3 lands on the first * of **Trade Speculation**.
+    // "4. **Trade Speculation**" = 24 chars; 4=0 .=1 ' '=2 *=3 *=4 T=5...n=21 *=22 *=23.
+    const response = makeResponse({
+      text: "4. **Trade Speculation**\nNext paragraph content.",
+      groundingMetadata: {
+        groundingChunks: [{ web: { uri: "https://example.com", title: "Source" } }],
+        groundingSupports: [
+          {
+            segment: {
+              startIndex: 3,
+              endIndex: 40,
+              text: "**Trade Speculation**\nNext paragraph co",
+            },
+            groundingChunkIndices: [0],
+          },
+        ],
+      },
+    });
+    expect(injectCitations(response)).toBe(
+      "4. [**Trade Speculation**](https://example.com)\nNext paragraph content.",
+    );
+  });
 });
 
 // ---- groundingToMarkdown ----

--- a/__tests__/gemini-grounding.test.ts
+++ b/__tests__/gemini-grounding.test.ts
@@ -158,6 +158,50 @@ describe("injectCitations", () => {
       `[Paris is the capital of France.](${redirectUri})`,
     );
   });
+
+  it("preserves heading prefix outside link and truncates before following paragraph", () => {
+    const response = makeResponse({
+      text: "### Trade Deadline Looming\nBecause the team is struggling heavily.",
+      groundingMetadata: {
+        groundingChunks: [{ web: { uri: "https://example.com", title: "Source" } }],
+        groundingSupports: [
+          {
+            segment: {
+              startIndex: 0,
+              endIndex: 50,
+              text: "### Trade Deadline Looming\nBecause the team is st",
+            },
+            groundingChunkIndices: [0],
+          },
+        ],
+      },
+    });
+    expect(injectCitations(response)).toBe(
+      "### [Trade Deadline Looming](https://example.com)\nBecause the team is struggling heavily.",
+    );
+  });
+
+  it("preserves bullet prefix outside link and truncates before following paragraph", () => {
+    const response = makeResponse({
+      text: "* Candidates are being evaluated.\nMore details follow.",
+      groundingMetadata: {
+        groundingChunks: [{ web: { uri: "https://example.com", title: "Source" } }],
+        groundingSupports: [
+          {
+            segment: {
+              startIndex: 0,
+              endIndex: 48,
+              text: "* Candidates are being evaluated.\nMore details f",
+            },
+            groundingChunkIndices: [0],
+          },
+        ],
+      },
+    });
+    expect(injectCitations(response)).toBe(
+      "* [Candidates are being evaluated.](https://example.com)\nMore details follow.",
+    );
+  });
 });
 
 // ---- groundingToMarkdown ----

--- a/docs/superpowers/plans/2026-06-29-citation-injection-fix.md
+++ b/docs/superpowers/plans/2026-06-29-citation-injection-fix.md
@@ -1,0 +1,395 @@
+# Citation Injection Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `injectCitations` in `src/server/gemini-grounding.ts` so it always produces structurally valid markdown, eliminating three classes of rendering bugs seen in testing.
+
+**Architecture:** Two targeted changes to `src/server/gemini-grounding.ts`: (1) fix `truncateToFirstBlock` to recognise when a citation starts on a heading or bullet line, and extend the injection loop to skip block-level prefix characters outside the link; (2) add a `snapToWordBoundaries` helper and integrate it into the injection loop so citations never start or end mid-word. `parseMarkdown` and `index.ts` are not touched.
+
+**Tech Stack:** TypeScript, Jest/ts-jest. No new dependencies.
+
+## Global Constraints
+
+- All changes confined to `src/server/gemini-grounding.ts` and `__tests__/gemini-grounding.test.ts`.
+- `parseMarkdown` (`src/server/markdown-to-rich-text.ts`) must not be modified.
+- Run tests with `npx jest __tests__/gemini-grounding.test.ts --no-coverage` after each step; run `npm test` before committing.
+- All 41 existing tests in `__tests__/gemini-grounding.test.ts` must continue to pass after each task.
+
+---
+
+### Task 1: Block-safe injection — truncation fix + prefix skip
+
+Fix two coupled problems in one task so tests reflect the final expected output from the start:
+
+1. `truncateToFirstBlock` runs off the end of a heading/bullet line into the next paragraph because it only checks lines after the first. A citation on `### Trade Deadline Looming\nBecause...` produces `[### Trade Deadline Looming\nBecause...](url)`.
+2. Even when truncation works correctly, block-level prefix characters (`### `, `* `, `- `) end up inside the link. A citation on `### Managerial Search` produces `[### Managerial Search](url)`, making `###` visible literal text in the cell.
+
+After this task a citation that starts on a heading or bullet line will produce e.g. `### [Managerial Search](url)` — prefix preserved outside the link, parser sees a normal heading.
+
+**Files:**
+- Modify: `src/server/gemini-grounding.ts:48-56` (`truncateToFirstBlock`)
+- Modify: `src/server/gemini-grounding.ts:90-100` (injection loop body)
+- Test: `__tests__/gemini-grounding.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new — `injectCitations` signature unchanged
+- Produces: `injectCitations` with correct behaviour for heading/bullet citations; Task 2 builds on this
+
+- [ ] **Step 1: Write the two failing tests**
+
+Add these inside the existing `describe("injectCitations", () => {` block in `__tests__/gemini-grounding.test.ts`:
+
+```typescript
+it("preserves heading prefix outside link and truncates before following paragraph", () => {
+  const response = makeResponse({
+    text: "### Trade Deadline Looming\nBecause the team is struggling heavily.",
+    groundingMetadata: {
+      groundingChunks: [{ web: { uri: "https://example.com", title: "Source" } }],
+      groundingSupports: [
+        {
+          segment: {
+            startIndex: 0,
+            endIndex: 50,
+            text: "### Trade Deadline Looming\nBecause the team is st",
+          },
+          groundingChunkIndices: [0],
+        },
+      ],
+    },
+  });
+  expect(injectCitations(response)).toBe(
+    "### [Trade Deadline Looming](https://example.com)\nBecause the team is struggling heavily."
+  );
+});
+
+it("preserves bullet prefix outside link and truncates before following paragraph", () => {
+  const response = makeResponse({
+    text: "* Candidates are being evaluated.\nMore details follow.",
+    groundingMetadata: {
+      groundingChunks: [{ web: { uri: "https://example.com", title: "Source" } }],
+      groundingSupports: [
+        {
+          segment: {
+            startIndex: 0,
+            endIndex: 48,
+            text: "* Candidates are being evaluated.\nMore details f",
+          },
+          groundingChunkIndices: [0],
+        },
+      ],
+    },
+  });
+  expect(injectCitations(response)).toBe(
+    "* [Candidates are being evaluated.](https://example.com)\nMore details follow."
+  );
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+npx jest __tests__/gemini-grounding.test.ts --no-coverage
+```
+
+Expected: 2 new failures. Current output for the heading test will be something like `[### Trade Deadline Looming\nBecause the team is st](https://example.com)Because the team is struggling heavily.` — the truncation is wrong and the `###` is inside the link.
+
+- [ ] **Step 3: Fix `truncateToFirstBlock`**
+
+Replace lines 48-56 in `src/server/gemini-grounding.ts`:
+
+```typescript
+function truncateToFirstBlock(text: string): string {
+  const lines = text.split("\n");
+  // If the span starts on a heading or bullet line it must not cross into the next line.
+  if (/^(#{1,6} |\* |- )/.test(lines[0])) {
+    return lines[0];
+  }
+  for (let i = 1; i < lines.length; i++) {
+    if (/^(\* |- |#{1,6} |$)/.test(lines[i])) {
+      return lines.slice(0, i).join("\n");
+    }
+  }
+  return text;
+}
+```
+
+- [ ] **Step 4: Update the injection loop to skip block-level prefixes**
+
+Replace lines 90-100 in `src/server/gemini-grounding.ts` (inside the `for` loop, after the `overlaps` check):
+
+```typescript
+    const rawSpan = truncateToFirstBlock(result.slice(startIndex, endIndex));
+    const prefixMatch = rawSpan.match(/^(#{1,6} |\* |- )/);
+    const prefixLength = prefixMatch ? prefixMatch[1].length : 0;
+    const spanText = rawSpan.slice(prefixLength);
+    if (!spanText) continue;
+    result =
+      result.slice(0, startIndex) +
+      rawSpan.slice(0, prefixLength) +
+      `[${spanText}](${url})` +
+      result.slice(startIndex + rawSpan.length);
+```
+
+The full updated `injectCitations` body looks like:
+
+```typescript
+export function injectCitations(
+  response: GeminiResponse,
+  resolvedUris?: Map<string, string>,
+): string {
+  const citations = getCitations(response, resolvedUris).sort(
+    (a, b) => a.startIndex - b.startIndex,
+  );
+  const merged = mergeCitations(citations);
+  if (merged.length === 0) return response.text;
+  const existingLinkSpans = findExistingLinkSpans(response.text);
+  let result = response.text;
+  // Reverse order preserves original indices — forward inserts would shift byte positions of earlier spans.
+  for (let i = merged.length - 1; i >= 0; i--) {
+    const { startIndex, endIndex, url } = merged[i];
+    const overlaps = existingLinkSpans.some(
+      (span) => startIndex < span.end && endIndex > span.start,
+    );
+    if (overlaps) continue;
+    const rawSpan = truncateToFirstBlock(result.slice(startIndex, endIndex));
+    const prefixMatch = rawSpan.match(/^(#{1,6} |\* |- )/);
+    const prefixLength = prefixMatch ? prefixMatch[1].length : 0;
+    const spanText = rawSpan.slice(prefixLength);
+    if (!spanText) continue;
+    result =
+      result.slice(0, startIndex) +
+      rawSpan.slice(0, prefixLength) +
+      `[${spanText}](${url})` +
+      result.slice(startIndex + rawSpan.length);
+  }
+  return result;
+}
+```
+
+- [ ] **Step 5: Run the new tests**
+
+```bash
+npx jest __tests__/gemini-grounding.test.ts --no-coverage
+```
+
+Expected: all 43 tests pass (41 existing + 2 new).
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/server/gemini-grounding.ts __tests__/gemini-grounding.test.ts
+git commit -m "$(cat <<'EOF'
+fix: block-safe citation injection — truncate at heading/bullet line start, skip prefix chars
+
+truncateToFirstBlock now returns early when the span starts on a heading
+or bullet line, preventing citations from spanning into the following
+paragraph. The injection loop strips block-level prefix characters
+(### , * , - ) from the citation content so the parser always sees a
+well-formed heading or bullet with an inline link.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Word-boundary snapping
+
+Gemini's grounding character offsets are not always word-aligned. A `startIndex` that lands mid-word produces a link opening inside a word (`Ma[rcus Semien]`); an `endIndex` that lands mid-word produces a link closing inside a word (`[...Whil]e he gave up`). Both leave visible broken text in the rendered cell.
+
+This task adds a `snapToWordBoundaries` helper and integrates it into the injection loop. The helper expands the content range outward: start snaps backward to the beginning of its containing word; end snaps forward to the end of its containing word. The unified reconstruction replaces the Task 1 reconstruction.
+
+**Files:**
+- Modify: `src/server/gemini-grounding.ts` (new helper + updated injection loop)
+- Test: `__tests__/gemini-grounding.test.ts`
+
+**Interfaces:**
+- Consumes: `truncateToFirstBlock` (Task 1), prefix detection logic (Task 1)
+- Produces: final `injectCitations` with all three fixes applied
+
+- [ ] **Step 1: Write two failing tests**
+
+Character positions verified: `"Injury: Marcus Semien is out."` → `I`=0 … ` `=7 `M`=8 `a`=9 `r`=10; `startIndex: 10` lands on `r` mid-word, snap back finds `M` at 8. `"Starting pitcher Clay Holmes. While he pitched well."` → `W`=30 `h`=31 `i`=32 `l`=33 `e`=34 ` `=35; `endIndex: 33` (exclusive, so last included char is `i` at 32) leaves `le` unlinked, snap forward to 35 includes full `While`.
+
+Add inside the existing `describe("injectCitations", () => {` block in `__tests__/gemini-grounding.test.ts`:
+
+```typescript
+it("snaps startIndex backward to word boundary when citation begins mid-word", () => {
+  const response = makeResponse({
+    text: "Injury: Marcus Semien is out.",
+    groundingMetadata: {
+      groundingChunks: [{ web: { uri: "https://example.com", title: "Source" } }],
+      groundingSupports: [
+        {
+          segment: { startIndex: 10, endIndex: 29, text: "rcus Semien is out." },
+          groundingChunkIndices: [0],
+        },
+      ],
+    },
+  });
+  expect(injectCitations(response)).toBe(
+    "Injury: [Marcus Semien is out.](https://example.com)"
+  );
+});
+
+it("snaps endIndex forward to word boundary when citation ends mid-word", () => {
+  const response = makeResponse({
+    text: "Starting pitcher Clay Holmes. While he pitched well.",
+    groundingMetadata: {
+      groundingChunks: [{ web: { uri: "https://example.com", title: "Source" } }],
+      groundingSupports: [
+        {
+          segment: { startIndex: 0, endIndex: 33, text: "Starting pitcher Clay Holmes. Whi" },
+          groundingChunkIndices: [0],
+        },
+      ],
+    },
+  });
+  expect(injectCitations(response)).toBe(
+    "[Starting pitcher Clay Holmes. While](https://example.com) he pitched well."
+  );
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+npx jest __tests__/gemini-grounding.test.ts --no-coverage
+```
+
+Expected: 2 new failures. The start-snap test will produce `"Injury: Ma[rcus Semien is out.](https://example.com)"` and the end-snap test will produce `"[Starting pitcher Clay Holmes. Whi](https://example.com)le he pitched well."`.
+
+- [ ] **Step 3: Add `snapToWordBoundaries` helper**
+
+Add this function to `src/server/gemini-grounding.ts` immediately after `truncateToFirstBlock` (before `findExistingLinkSpans`):
+
+```typescript
+function snapToWordBoundaries(
+  text: string,
+  start: number,
+  end: number,
+): { start: number; end: number } {
+  let snappedStart = start;
+  while (snappedStart > 0 && /\w/.test(text[snappedStart - 1])) {
+    snappedStart--;
+  }
+  let snappedEnd = end;
+  while (snappedEnd < text.length && /\w/.test(text[snappedEnd])) {
+    snappedEnd++;
+  }
+  return { start: snappedStart, end: snappedEnd };
+}
+```
+
+`\w` matches `[a-zA-Z0-9_]`. Spaces, punctuation, `*`, `#`, and `-` are not matched, so the scan stops at block-prefix boundaries and punctuation. The start scan cannot reach past a block prefix's trailing space.
+
+- [ ] **Step 4: Update the injection loop to use `snapToWordBoundaries`**
+
+Replace the injection loop body (after the `overlaps` check) in `injectCitations` with the following. This replaces the Task 1 reconstruction entirely:
+
+```typescript
+    const rawSpan = truncateToFirstBlock(result.slice(startIndex, endIndex));
+    const prefixMatch = rawSpan.match(/^(#{1,6} |\* |- )/);
+    const prefixLength = prefixMatch ? prefixMatch[1].length : 0;
+    // Snap word boundaries on the content portion only (after block prefix).
+    // snappedStart cannot reach past the prefix's trailing space since \w excludes it.
+    const contentStart = startIndex + prefixLength;
+    const rawContentEnd = startIndex + rawSpan.length;
+    const { start: snappedStart, end: snappedEnd } = snapToWordBoundaries(
+      result,
+      contentStart,
+      rawContentEnd,
+    );
+    const spanText = result.slice(snappedStart, snappedEnd);
+    if (!spanText) continue;
+    // result.slice(0, snappedStart) naturally preserves prefix chars when
+    // snappedStart === contentStart (the common case with a block prefix).
+    result =
+      result.slice(0, snappedStart) +
+      `[${spanText}](${url})` +
+      result.slice(snappedEnd);
+```
+
+The full updated `injectCitations`:
+
+```typescript
+export function injectCitations(
+  response: GeminiResponse,
+  resolvedUris?: Map<string, string>,
+): string {
+  const citations = getCitations(response, resolvedUris).sort(
+    (a, b) => a.startIndex - b.startIndex,
+  );
+  const merged = mergeCitations(citations);
+  if (merged.length === 0) return response.text;
+  const existingLinkSpans = findExistingLinkSpans(response.text);
+  let result = response.text;
+  // Reverse order preserves original indices — forward inserts would shift byte positions of earlier spans.
+  for (let i = merged.length - 1; i >= 0; i--) {
+    const { startIndex, endIndex, url } = merged[i];
+    const overlaps = existingLinkSpans.some(
+      (span) => startIndex < span.end && endIndex > span.start,
+    );
+    if (overlaps) continue;
+    const rawSpan = truncateToFirstBlock(result.slice(startIndex, endIndex));
+    const prefixMatch = rawSpan.match(/^(#{1,6} |\* |- )/);
+    const prefixLength = prefixMatch ? prefixMatch[1].length : 0;
+    const contentStart = startIndex + prefixLength;
+    const rawContentEnd = startIndex + rawSpan.length;
+    const { start: snappedStart, end: snappedEnd } = snapToWordBoundaries(
+      result,
+      contentStart,
+      rawContentEnd,
+    );
+    const spanText = result.slice(snappedStart, snappedEnd);
+    if (!spanText) continue;
+    result =
+      result.slice(0, snappedStart) +
+      `[${spanText}](${url})` +
+      result.slice(snappedEnd);
+  }
+  return result;
+}
+```
+
+- [ ] **Step 5: Run the new tests**
+
+```bash
+npx jest __tests__/gemini-grounding.test.ts --no-coverage
+```
+
+Expected: all 45 tests pass (43 from Task 1 + 2 new).
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/server/gemini-grounding.ts __tests__/gemini-grounding.test.ts
+git commit -m "$(cat <<'EOF'
+fix: snap citation boundaries to word edges to prevent mid-word link splits
+
+Adds snapToWordBoundaries helper that expands citation start backward and
+end forward to the nearest word boundary. Integrates with the unified
+injection loop reconstruction so block-prefix preservation and word-
+boundary snapping compose cleanly.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-06-29-citation-injection-fix-design.md
+++ b/docs/superpowers/specs/2026-06-29-citation-injection-fix-design.md
@@ -1,0 +1,99 @@
+# Citation Injection Fix Design
+
+**Date:** 2026-06-29
+**Status:** Approved
+
+## Problem
+
+`injectCitations` wraps Gemini grounding citation ranges as `[text](url)` inline links using raw character offsets. Because it operates on the raw markdown text, it can produce structurally invalid markdown in three ways:
+
+**Bug 1 — Multi-line spanning.** `truncateToFirstBlock` only truncates when the *next* line starts a new block construct. It doesn't detect that the *current* line is already a heading or bullet, which should itself be a hard boundary. A citation starting on `### Trade Deadline Looming` runs unchecked into the following paragraph, producing `[### Trade Deadline Looming\nBecause the team...](url)` — a link that spans a block boundary.
+
+**Bug 2 — Block-prefix wrapping.** When a citation's `startIndex` falls at the start of a heading or bullet line, the block prefix characters (`### `, `* `, `- `) get wrapped inside the link: `[### Managerial Search](url)`. That line now starts with `[`, not `#`, so `groupBlocks` can't detect it as a heading — the `###` appears as visible literal text in the cell.
+
+**Bug 3 — Mid-word splits.** Gemini's character offsets are not word-aligned. A `startIndex` landing mid-word produces `Ma[rcus Semien...](url)` (broken link opening mid-word); an `endIndex` landing mid-word produces `...Whil](url)e he gave up` (broken link closing mid-word, stranding the remainder as plain text).
+
+All three produce visible markdown syntax characters in the rendered cell.
+
+## Approach
+
+`parseMarkdown` stays completely untouched. The fix is to make `injectCitations` produce valid markdown in all cases — three targeted changes, all confined to `src/server/gemini-grounding.ts`.
+
+## Fix 1 — `truncateToFirstBlock`: detect heading/bullet start
+
+Add a check at the top of the function: if `lines[0]` itself matches a heading or bullet prefix, return only `lines[0]`. A citation that starts on a block-level line must not cross into the next line, regardless of what follows.
+
+```
+before: only checks lines[1..n] for block-opening markers
+after:  also returns lines[0] immediately if it is a heading or bullet
+```
+
+This covers the `[Trade Deadline Looming\n...](url)` case: the heading line is returned immediately, truncating the span before the paragraph text.
+
+## Fix 2 — `injectCitations`: block-prefix skip
+
+After calling `truncateToFirstBlock`, detect if the span text begins with a block-level prefix (`#{1,6} `, `* `, `- `). If so, advance the injection start point past the prefix and preserve the prefix characters outside the link.
+
+A citation on `### Managerial Search` produces:
+```
+### [Managerial Search](url)
+```
+instead of:
+```
+[### Managerial Search](url)
+```
+
+The parser's `groupBlocks` sees `### ` at the line start, detects the heading correctly, and processes `[Managerial Search](url)` as inline link content.
+
+## Fix 3 — `injectCitations`: word-boundary snapping
+
+After the prefix skip, add a `snapToWordBoundaries` helper that adjusts the content span:
+
+- **Start:** scan backward from the content start (i.e. `startIndex + prefixLength`, after Fix 2 has removed any block prefix from consideration) while the preceding character is a word character (`\w`). This expands to include the full starting word — `rcus Semien...` becomes `Marcus Semien...`. The scan stops at non-`\w` characters (spaces, `*`, `#`) so it cannot reach backward past a block prefix.
+- **End:** scan forward from `endIndex` while the current character is a word character. This expands to include the full ending word — `Whil` becomes `While`.
+
+Snapping expands rather than contracts so that the linked text is always a grammatically complete token. The expansion is safe to apply after reverse-order processing because we're only extending into territory that wasn't covered by the citation, never into adjacent citations that were already processed.
+
+## Composed injection loop
+
+The three fixes apply in order within the existing reverse-iteration loop:
+
+1. Get raw span: `truncateToFirstBlock(result.slice(startIndex, endIndex))` — **Fix 1** is now reliable
+2. Detect and measure block prefix in raw span — **Fix 2**
+3. Apply `snapToWordBoundaries` to the content portion (after prefix) — **Fix 3**
+4. Reconstruct: `prefix + [snappedContent](url)` replaces only the content range in `result`
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `src/server/gemini-grounding.ts` | Fix `truncateToFirstBlock`; add `snapToWordBoundaries` helper; update injection loop |
+| `src/server/markdown-to-rich-text.ts` | None |
+| `src/server/index.ts` | None |
+
+## Tests
+
+New test cases for `injectCitations` in `__tests__/gemini-grounding.test.ts`:
+
+- Citation whose segment starts at a heading line — result is `### [content](url)`, not `[### content](url)`
+- Citation whose segment starts at a bullet line — result is `* [content](url)`, not `[* content](url)`
+- Citation spanning a heading and the following paragraph — truncated to the heading line only
+- Citation whose `startIndex` is mid-word — result starts at the word boundary
+- Citation whose `endIndex` is mid-word — result ends at the word boundary
+- Citation whose segment starts mid-word AND at a block prefix (combined case)
+
+New test case for `truncateToFirstBlock` (or moved to its own `describe` block):
+
+- Input starts with a heading line followed by a paragraph — returns only the heading line
+- Input starts with a bullet line followed by a paragraph — returns only the bullet line
+- Existing behaviour unchanged: plain paragraph truncates at a blank line or heading that follows
+
+## Out of scope
+
+**Citations landing inside inline formatting delimiters.** A citation whose `startIndex` falls between `**` and the bold text (e.g. offset 2 of `**Kodai Senga:**`) would still produce `**[Kodai Senga:**...](url)` with visible `**`. This requires the open-delimiter character (`*`, `~`) to be included in the word-boundary scan, or a separate delimiter-alignment pass. Not yet observed in testing; deferred.
+
+**Parse-first approach.** An alternative design would apply citation URLs after parsing, treating them as data rather than injecting them as markdown syntax. This eliminates the entire class of pre-parse injection bugs and maps cleanly to the Interactions API's `annotations[]` format (see issue #119). It is the right long-term architecture but requires threading a `segmentOffset` parameter through the recursive inline processor. Deferred in favour of the targeted fix; the Interactions API migration is the natural moment to revisit.
+
+## Future: Interactions API migration
+
+The Interactions API returns citations as `annotations[]` co-located with `content[].text` (see issue #119). The normalization point — converting API-specific citation format to `{startIndex, endIndex, url}[]` — is currently inside `injectCitations`. When migrating, that normalization becomes a new adapter (`extractCitations` or equivalent) that produces the same shape, and the rest of `injectCitations` (including these three fixes) remains unchanged.

--- a/src/server/gemini-grounding.ts
+++ b/src/server/gemini-grounding.ts
@@ -47,12 +47,13 @@ function mergeCitations(
 // block boundaries — groupBlocks() splits on these lines before inline parsing runs.
 function truncateToFirstBlock(text: string): string {
   const lines = text.split("\n");
-  // If the span starts on a heading or bullet line it must not cross into the next line.
-  if (/^(#{1,6} |\* |- )/.test(lines[0])) {
+  // Treat heading, bullet, and standalone bold-heading lines as block boundaries.
+  // A line starting or ending with ** is Gemini's section-heading style (**Title**).
+  if (/^(#{1,6} |\* |- |\*\*)/.test(lines[0]) || lines[0].endsWith("**")) {
     return lines[0];
   }
   for (let i = 1; i < lines.length; i++) {
-    if (/^(\* |- |#{1,6} |$)/.test(lines[i])) {
+    if (/^(\* |- |#{1,6} |$|\*\*)/.test(lines[i]) || lines[i].endsWith("**")) {
       return lines.slice(0, i).join("\n");
     }
   }
@@ -65,7 +66,9 @@ function snapToWordBoundaries(
   end: number,
 ): { start: number; end: number } {
   let snappedStart = start;
-  while (snappedStart > 0 && /\w/.test(text[snappedStart - 1])) {
+  // Also cross * and ~ so a citation starting inside **bold** or ~~strikethrough~~ snaps
+  // back past the opening delimiter rather than leaving it stranded outside the link.
+  while (snappedStart > 0 && /[\w*~]/.test(text[snappedStart - 1])) {
     snappedStart--;
   }
   let snappedEnd = end;

--- a/src/server/gemini-grounding.ts
+++ b/src/server/gemini-grounding.ts
@@ -47,6 +47,10 @@ function mergeCitations(
 // block boundaries — groupBlocks() splits on these lines before inline parsing runs.
 function truncateToFirstBlock(text: string): string {
   const lines = text.split("\n");
+  // If the span starts on a heading or bullet line it must not cross into the next line.
+  if (/^(#{1,6} |\* |- )/.test(lines[0])) {
+    return lines[0];
+  }
   for (let i = 1; i < lines.length; i++) {
     if (/^(\* |- |#{1,6} |$)/.test(lines[i])) {
       return lines.slice(0, i).join("\n");
@@ -93,11 +97,16 @@ export function injectCitations(
       (span) => startIndex < span.end && endIndex > span.start,
     );
     if (overlaps) continue;
-    const spanText = truncateToFirstBlock(result.slice(startIndex, endIndex));
+    const rawSpan = truncateToFirstBlock(result.slice(startIndex, endIndex));
+    const prefixMatch = rawSpan.match(/^(#{1,6} |\* |- )/);
+    const prefixLength = prefixMatch ? prefixMatch[1].length : 0;
+    const spanText = rawSpan.slice(prefixLength);
+    if (!spanText) continue;
     result =
       result.slice(0, startIndex) +
+      rawSpan.slice(0, prefixLength) +
       `[${spanText}](${url})` +
-      result.slice(startIndex + spanText.length);
+      result.slice(startIndex + rawSpan.length);
   }
   return result;
 }

--- a/src/server/gemini-grounding.ts
+++ b/src/server/gemini-grounding.ts
@@ -59,6 +59,22 @@ function truncateToFirstBlock(text: string): string {
   return text;
 }
 
+function snapToWordBoundaries(
+  text: string,
+  start: number,
+  end: number,
+): { start: number; end: number } {
+  let snappedStart = start;
+  while (snappedStart > 0 && /\w/.test(text[snappedStart - 1])) {
+    snappedStart--;
+  }
+  let snappedEnd = end;
+  while (snappedEnd < text.length && /\w/.test(text[snappedEnd])) {
+    snappedEnd++;
+  }
+  return { start: snappedStart, end: snappedEnd };
+}
+
 function findExistingLinkSpans(text: string): Array<{ start: number; end: number }> {
   const spans: Array<{ start: number; end: number }> = [];
   const linkRegex = /\[([^\]]*)\]\(([^)]*)\)/g;
@@ -100,13 +116,20 @@ export function injectCitations(
     const rawSpan = truncateToFirstBlock(result.slice(startIndex, endIndex));
     const prefixMatch = rawSpan.match(/^(#{1,6} |\* |- )/);
     const prefixLength = prefixMatch ? prefixMatch[1].length : 0;
-    const spanText = rawSpan.slice(prefixLength);
+    // Snap word boundaries on the content portion only (after block prefix).
+    // snappedStart cannot reach past the prefix's trailing space since \w excludes it.
+    const contentStart = startIndex + prefixLength;
+    const rawContentEnd = startIndex + rawSpan.length;
+    const { start: snappedStart, end: snappedEnd } = snapToWordBoundaries(
+      result,
+      contentStart,
+      rawContentEnd,
+    );
+    const spanText = result.slice(snappedStart, snappedEnd);
     if (!spanText) continue;
-    result =
-      result.slice(0, startIndex) +
-      rawSpan.slice(0, prefixLength) +
-      `[${spanText}](${url})` +
-      result.slice(startIndex + rawSpan.length);
+    // result.slice(0, snappedStart) naturally preserves prefix chars when
+    // snappedStart === contentStart (the common case with a block prefix).
+    result = result.slice(0, snappedStart) + `[${spanText}](${url})` + result.slice(snappedEnd);
   }
   return result;
 }


### PR DESCRIPTION
## Summary

- Fixes three classes of markdown rendering bugs in `injectCitations` (`src/server/gemini-grounding.ts`) where citations were injected as character-offset ranges before `parseMarkdown` ran, producing structurally invalid markdown
- Block-level prefix characters (`### `, `* `, `- `) are now preserved outside the link so the parser still sees a valid heading or bullet
- Citations starting on a heading or bullet line no longer span into the following paragraph
- Gemini's non-word-aligned character offsets are now snapped to word boundaries so links never open or close mid-word

## Manual QA

1. Open a Sheet with Run AI grounding enabled (Google Search tool)
2. Run a batch AI inference that returns a response with grounding citations
3. Verify cells with heading lines show `### Heading` rendered as bold (not `[### Heading]` with visible `###`)
4. Verify cells with multi-line responses show citation links confined to a single block (not spanning a heading into the next paragraph)
5. Verify citation link text starts and ends at word boundaries (no partial words like `rcus Semien` or `Whil`)

> N/A for regression checklist items — this PR targets `develop`

- [ ] Add-on menu appears after opening a Sheet — N/A (targets develop)
- [ ] Sidebar opens without errors — N/A (targets develop)
- [ ] Import Drive Links — imports files from a folder — N/A (targets develop)
- [ ] Extract Text — extracts text from a Doc/PDF/image — N/A (targets develop)
- [ ] Sample Rows — samples rows reproducibly with a seed — N/A (targets develop)
- [ ] Run AI — batch inference completes and writes output column — N/A (targets develop)
- [ ] Tested on a Sheet the tester does not own (shared access) — N/A (targets develop)

## Security

- [x] None of the above — no threat model update needed

## Notes

<\!-- Anything reviewers or QA testers should know -->
