### PR TITLE
Prevent AI runs from processing the header row

### DIFF
--- a/__tests__/row-range.test.ts
+++ b/__tests__/row-range.test.ts
@@ -1,0 +1,19 @@
+import { sanitizeRowRange } from "../src/client/components/row-range";
+
+describe("sanitizeRowRange", () => {
+  it("passes through a valid range unchanged", () => {
+    expect(sanitizeRowRange({ start: 5, end: 10 })).toEqual({ start: 5, end: 10 });
+  });
+
+  it("clamps a start row below 2 up to 2", () => {
+    expect(sanitizeRowRange({ start: 1, end: 10 })).toEqual({ start: 2, end: 10 });
+  });
+
+  it("returns null when the range is only the header row", () => {
+    expect(sanitizeRowRange({ start: 1, end: 1 })).toBeNull();
+  });
+
+  it("returns null when the range is inverted, independent of row 1", () => {
+    expect(sanitizeRowRange({ start: 5, end: 3 })).toBeNull();
+  });
+});

--- a/src/client/components/row-range.ts
+++ b/src/client/components/row-range.ts
@@ -3,6 +3,12 @@ export interface RowRangeValue {
   end: number;
 }
 
+// Never lets a run start on the header row; returns null if nothing valid remains.
+export function sanitizeRowRange(range: RowRangeValue): RowRangeValue | null {
+  const start = Math.max(range.start, 2);
+  return start <= range.end ? { start, end: range.end } : null;
+}
+
 export class RowRange {
   private static instanceCount = 0;
   private readonly container: HTMLElement;
@@ -37,7 +43,10 @@ export class RowRange {
     selRadio.name = groupName;
     selRadio.value = "selection";
     selRadio.checked = !selected;
-    selLabel.append(selRadio, " Use sheet selection");
+    const selHint = document.createElement("span");
+    selHint.className = "optional";
+    selHint.textContent = " (rows currently highlighted on the sheet)";
+    selLabel.append(selRadio, " Use sheet selection", selHint);
 
     const rangeLabel = document.createElement("label");
     const rangeRadio = document.createElement("input");
@@ -45,10 +54,7 @@ export class RowRange {
     rangeRadio.name = groupName;
     rangeRadio.value = "range";
     rangeRadio.checked = !!selected;
-    const rangeHint = document.createElement("span");
-    rangeHint.className = "optional";
-    rangeHint.textContent = " (better for large jobs)";
-    rangeLabel.append(rangeRadio, " Specify range", rangeHint);
+    rangeLabel.append(rangeRadio, " Specify range");
 
     const rangeInputs = document.createElement("div");
     rangeInputs.className = "range-inputs";

--- a/src/client/components/row-range.ts
+++ b/src/client/components/row-range.ts
@@ -43,10 +43,7 @@ export class RowRange {
     selRadio.name = groupName;
     selRadio.value = "selection";
     selRadio.checked = !selected;
-    const selHint = document.createElement("span");
-    selHint.className = "optional";
-    selHint.textContent = " (current selection)";
-    selLabel.append(selRadio, " Use sheet selection", selHint);
+    selLabel.append(selRadio, " Use highlighted rows");
 
     const rangeLabel = document.createElement("label");
     const rangeRadio = document.createElement("input");

--- a/src/client/components/row-range.ts
+++ b/src/client/components/row-range.ts
@@ -45,7 +45,7 @@ export class RowRange {
     selRadio.checked = !selected;
     const selHint = document.createElement("span");
     selHint.className = "optional";
-    selHint.textContent = " (rows currently highlighted on the sheet)";
+    selHint.textContent = " (current selection)";
     selLabel.append(selRadio, " Use sheet selection", selHint);
 
     const rangeLabel = document.createElement("label");

--- a/src/client/panels/configure-ai-run.ts
+++ b/src/client/panels/configure-ai-run.ts
@@ -3,7 +3,7 @@ import type { RunConfig, ToolId, ModelId } from "../../shared/types";
 import { TagList } from "../components/tag-list";
 import { TokenInput } from "../components/token-input";
 import { PromptColList } from "../components/prompt-col-list";
-import { RowRange } from "../components/row-range";
+import { RowRange, sanitizeRowRange, type RowRangeValue } from "../components/row-range";
 import { PanelLoader } from "../components/panel-loader";
 import { getSheetHeaders, runBatchAI, getActiveRangeInfo } from "../services";
 import { jobStore } from "../job-store";
@@ -326,6 +326,16 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
     };
   }
 
+  private resolveRowRange(range: RowRangeValue): RowRangeValue | null {
+    const sanitized = sanitizeRowRange(range);
+    if (!sanitized) {
+      globalThis.alert(
+        "Row 1 is the header row and can't be processed. Please select a data row range.",
+      );
+    }
+    return sanitized;
+  }
+
   private handleRun(_container: HTMLElement): void {
     const config = this.assembleRunConfig();
     if (!config) return;
@@ -363,11 +373,11 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
           jobId,
           "Batch AI Run",
           getActiveRangeInfo().then((rangeInfo) => {
-            if (rangeInfo) {
-              const chunks = computeChunks(rangeInfo, CHUNK_SIZE);
-              return this.runChunks(jobId, config, chunks);
-            }
-            return runBatchAI(config, jobId).then(() => undefined);
+            if (!rangeInfo) return runBatchAI(config, jobId).then(() => undefined);
+            const sanitized = this.resolveRowRange(rangeInfo);
+            if (!sanitized) return;
+            const chunks = computeChunks(sanitized, CHUNK_SIZE);
+            return this.runChunks(jobId, config, chunks);
           }),
         )
         .catch((err: Error) => {
@@ -407,11 +417,12 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
         jobId,
         "Test AI Run",
         resolveRange.then((range) => {
-          if (!range) return undefined;
-          const fullRowCount = range.end - range.start + 1;
-          const cappedEnd = Math.min(range.start + 9, range.end);
+          const sanitized = range ? this.resolveRowRange(range) : null;
+          if (!sanitized) return undefined;
+          const fullRowCount = sanitized.end - sanitized.start + 1;
+          const cappedEnd = Math.min(sanitized.start + 9, sanitized.end);
           return runBatchAI(
-            { ...config, rowRange: { start: range.start, end: cappedEnd } },
+            { ...config, rowRange: { start: sanitized.start, end: cappedEnd } },
             jobId,
           ).then((stats) => (stats ? { stats, fullRowCount } : undefined));
         }),
@@ -506,7 +517,12 @@ export class ConfigureAIRunPanel implements Panel<Partial<RunConfig>, SavedState
       globalThis.alert("Please select an output column.");
       return null;
     }
-    const rowRange = this.rowRangeComp?.getValue();
+    const rawRowRange = this.rowRangeComp?.getValue();
+    let rowRange: RowRangeValue | undefined;
+    if (rawRowRange) {
+      rowRange = this.resolveRowRange(rawRowRange) ?? undefined;
+      if (!rowRange) return null;
+    }
     const tools = (this.toolsList?.getValue() ?? []) as ToolId[];
     const includeGrounding = this.includeGroundingCb?.checked ?? false;
     const applyMarkdown = this.applyMarkdownCb?.checked ?? false;


### PR DESCRIPTION
## Summary

- Reporters occasionally overwrote the header row (row 1) by typing `1` as the start row, or by selecting from row 1 when using "Use sheet selection" — both Run AI and the newly-merged Test button independently resolve a row range and were both exposed.
- Adds `sanitizeRowRange()` (row-range.ts): clamps any resolved range so it never starts on row 1, and rejects a range if nothing valid remains after that clamp (e.g. only the header was selected, or the range was already inverted). Wired into every point that resolves a final row range — the typed-range path (shared by Run and Test via `assembleRunConfig()`), and each button's own "use sheet selection" fallback.
- Clarifies the "Use sheet selection" label (now notes it runs on the rows currently highlighted on the sheet) and removes the "(better for large jobs)" hint on "Specify range", which is no longer accurate now that both paths chunk identically.
- This is a client-side UX guard only, not a server-side security control — deliberately scoped this way since `runBatchAI` input sanitization is being tracked as a separate, broader effort against the threat model.

## Manual QA

1. Open the sidebar → Run AI Inference (Configure AI Run panel).
2. Under "Rows to process," choose **Specify range**, set start row to `1` (any end row), click **Run AI**. Expect: an alert ("Row 1 is the header row and can't be processed...") and no run starts.
3. With the same **Specify range** option, set start row to `1` and end row to `10`, click **Run AI**. Expect: no alert — it silently runs rows 2-10, header row untouched.
4. Switch to **Use sheet selection**. On the sheet, click a single cell in row 1 only (so it's the sole active selection), then click **Run AI**. Expect: the header-row alert, no run starts.
5. On the sheet, drag-select a range that includes row 1 plus data rows (e.g. rows 1-5), then click **Run AI**. Expect: no alert — it silently runs rows 2-5 only.
6. Repeat steps 4 and 5 using the **Test** button instead of Run AI — same expected behavior (alert only when just the header is selected; otherwise silently clamps and runs, capped to 10 rows).
7. Confirm the copy change: "Specify range" no longer shows "(better for large jobs)", and "Use sheet selection" now shows "(rows currently highlighted on the sheet)".

> Complete for PRs targeting `main`. Mark N/A with reason for PRs targeting `develop`.

- [ ] Add-on menu appears after opening a Sheet
- [x] Sidebar opens without errors
- [ ] Import Drive Links — imports files from a folder
- [ ] Extract Text — extracts text from a Doc/PDF/image
- [ ] Sample Rows — samples rows reproducibly with a seed
- [ ] Run AI — batch inference completes and writes output column
- [ ] Tested on a Sheet the tester does not own (shared access)

## Security

- [x] None of the above — no threat model update needed

## Notes

This is a client-side-only guard (UX fix, not a security control). Whether row-1 protection should also be enforced server-side in `runBatchAI` is intentionally left as an open question for the separate, broader `runBatchAI` input-sanitization effort tracked against the threat model.
