### PR TITLE
docs: point to AI Studio for Gemini key + spend cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Built with TypeScript, bundled by Rollup, and deployed via clasp.
 - Node.js 22+
 - Apps Script API enabled at [script.google.com/home/usersettings](https://script.google.com/home/usersettings)
 - A Gemini API key — [get one here](https://ai.google.dev/gemini-api/docs/api-key)
+  - Tip: [AI Studio](https://aistudio.google.com/api-keys) makes it easy to mint a key and [set a monthly spend cap](https://aistudio.google.com/spend) to avoid surprise billing
 
 `@google/clasp` is included as a devDependency — no global install needed.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Built with TypeScript, bundled by Rollup, and deployed via clasp.
 - A Google account
 - Node.js 22+
 - Apps Script API enabled at [script.google.com/home/usersettings](https://script.google.com/home/usersettings)
-- A Gemini API key — [get one here](https://ai.google.dev/gemini-api/docs/api-key)
+- [A Gemini API key](https://ai.google.dev/gemini-api/docs/api-key)
   - Tip: [AI Studio](https://aistudio.google.com/api-keys) makes it easy to mint a key and [set a monthly spend cap](https://aistudio.google.com/spend) to avoid surprise billing
 
 `@google/clasp` is included as a devDependency — no global install needed.


### PR DESCRIPTION
## Summary

- Adds a tip under Prerequisites pointing readers to AI Studio for minting a Gemini API key and setting a monthly spend cap
- Addresses AI-90 (Sept 2026 standard-key rejection / cost control) by nudging less-technical users toward cost controls at key-creation time

## Manual QA

N/A — docs-only change targeting `develop`, no code paths affected.

- [ ] Add-on menu appears after opening a Sheet
- [ ] Sidebar opens without errors
- [ ] Import Drive Links — imports files from a folder
- [ ] Extract Text — extracts text from a Doc/PDF/image
- [ ] Sample Rows — samples rows reproducibly with a seed
- [ ] Run AI — batch inference completes and writes output column
- [ ] Tested on a Sheet the tester does not own (shared access)

## Security

- [ ] Adds or changes a data flow (new API call, new Drive/Sheets/Docs operation, new RPC endpoint)
- [ ] Modifies how AI output is written to the spreadsheet (affects T6 — formula injection)
- [ ] Changes `appsscript.json` OAuth scopes (affects T4 variant — scope expansion, T5)
- [ ] Adds or upgrades an npm dependency (affects T10 — build dependency compromise)
- [ ] Changes Gemini API integration (affects T2, T3, T11, T14)
- [x] None of the above — no threat model update needed

## Notes

<!-- Anything reviewers or QA testers should know -->
