### PR TITLE
Highlight truncated Extract Text cells

### DIFF
--- a/__tests__/utils-truncation-highlighting.test.ts
+++ b/__tests__/utils-truncation-highlighting.test.ts
@@ -1,0 +1,19 @@
+import { markTruncationHighlight } from "../src/server/utils";
+
+describe("markTruncationHighlight", () => {
+  it("sets a highlight background when the cell is truncated", () => {
+    const cell = { setBackground: jest.fn() };
+
+    markTruncationHighlight(cell as unknown as GoogleAppsScript.Spreadsheet.Range, true);
+
+    expect(cell.setBackground).toHaveBeenCalledWith("#FCE8E6");
+  });
+
+  it("clears the background when the cell is not truncated", () => {
+    const cell = { setBackground: jest.fn() };
+
+    markTruncationHighlight(cell as unknown as GoogleAppsScript.Spreadsheet.Range, false);
+
+    expect(cell.setBackground).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/client/panels/extract-text.ts
+++ b/src/client/panels/extract-text.ts
@@ -157,7 +157,10 @@ export class ExtractTextPanel implements Panel<undefined, SavedState> {
         </div>
         <div class="field-group">
           <span class="field-label">Output Column <span class="required">*</span></span>
-          <p class="field-helper">Truncated at 49,000 characters.</p>
+          <p class="field-helper">
+            Text output truncated at 49,000 characters. Truncated text cells are highlighted and
+            denoted by "... [TRUNCATED]" suffix.
+          </p>
           <div id="output-col" class="tag-list"></div>
         </div>
         <div class="field-group">

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -30,6 +30,7 @@ import {
   getAllFilesRecursive,
   sampleRows,
   truncateText,
+  markTruncationHighlight,
   resolveColumns,
   writeJobProgress,
   writeRunStats,
@@ -188,7 +189,9 @@ export function extractText(config: ExtractTextConfig, jobId?: string): void {
       const fileId = extractId(cellValue);
       const { text, orphanedTempDocName } = extractTextUniversal(fileId);
       if (orphanedTempDocName) orphanedTempDocNames.push(orphanedTempDocName);
-      writeSafeValue(sheet.getRange(rowIdx, outputCol), truncateText(text, 49000));
+      const cell = sheet.getRange(rowIdx, outputCol);
+      writeSafeValue(cell, truncateText(text, 49000));
+      markTruncationHighlight(cell, text.length > 49000);
       SpreadsheetApp.flush();
     }
 

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -99,11 +99,18 @@ export function sampleRows(data: unknown[][], sampleSize: number, seed: number):
 }
 
 /**
+ * Suffix appended by truncateText, and the marker ensureTruncatedCellHighlighting
+ * matches on to highlight incomplete extractions — kept in one place so the two
+ * never drift apart.
+ */
+export const TRUNCATION_SUFFIX = "... [TRUNCATED]";
+
+/**
  * Truncate text to maxLength characters, appending a suffix if truncated.
  */
 export function truncateText(text: string, maxLength: number): string {
   if (text.length <= maxLength) return text;
-  return text.substring(0, maxLength) + "... [TRUNCATED]";
+  return text.substring(0, maxLength) + TRUNCATION_SUFFIX;
 }
 
 /**
@@ -198,6 +205,20 @@ export function markAIOutputRange(
     "Some cells in this column may be AI-generated — exercise good judgement when using",
   );
   sheet.getRange(startRow, colIdx, numRows, 1).setBackground("#FFF8E1");
+}
+
+/**
+ * Highlights a truncated-text cell, or clears the highlight when the cell is
+ * no longer truncated (e.g. a re-extraction that comes back short enough to
+ * fit) so the background never goes stale. Called on every extract-text write,
+ * mirroring markAIOutputRange's direct-write approach rather than a
+ * conditional format rule.
+ */
+export function markTruncationHighlight(
+  cell: GoogleAppsScript.Spreadsheet.Range,
+  truncated: boolean,
+): void {
+  cell.setBackground(truncated ? "#FCE8E6" : null);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Extract Text truncates OCR output at 49,000 characters to fit Sheets' cell limit, but truncated cells were visually indistinguishable from complete ones — there was no way to tell which extractions were incomplete.
- Highlights a cell's background at write time when its extraction was truncated (mirroring the existing `markAIOutputRange` direct-write pattern rather than a conditional format rule), and clears the highlight if a later re-extraction no longer needs truncating.
- Clarifies the Extract Text sidebar's Output Column helper text to explain the highlight and the "... [TRUNCATED]" suffix convention.

## Manual QA

1. Open a sheet with a Drive-link source column pointing to a Doc/PDF/image that will OCR to more than 49,000 characters.
2. Run SSI Tools > Extract Text with that source column and an output column.
3. Confirm the output cell for the large file's row shows text ending in "... [TRUNCATED]" and has a light red background.
4. Confirm a normal (non-truncated) row's output cell has no background highlight.
5. Re-run Extract Text against the same output column after the truncated row's source no longer needs truncating (e.g. point it at a shorter file), and confirm the highlight clears.
6. Open the Extract Text sidebar panel and confirm the Output Column helper text reads the updated explanation.

> Complete for PRs targeting `main`. Mark N/A with reason for PRs targeting `develop`.

- [ ] Add-on menu appears after opening a Sheet
- [ ] Sidebar opens without errors
- [ ] Import Drive Links — imports files from a folder
- [ ] Extract Text — extracts text from a Doc/PDF/image
- [ ] Sample Rows — samples rows reproducibly with a seed
- [ ] Run AI — batch inference completes and writes output column
- [ ] Tested on a Sheet the tester does not own (shared access)

## Security

> Check any that apply to this PR. If any box is checked, review `docs/threat_models/ssi-toolkit-threat-model.md` and update it if the change introduces, removes, or materially changes a threat or data flow.

- [ ] Adds or changes a data flow (new API call, new Drive/Sheets/Docs operation, new RPC endpoint)
- [ ] Modifies how AI output is written to the spreadsheet (affects T6 — formula injection)
- [ ] Changes `appsscript.json` OAuth scopes (affects T4 variant — scope expansion, T5)
- [ ] Adds or upgrades an npm dependency (affects T10 — build dependency compromise)
- [ ] Changes Gemini API integration (affects T2, T3, T11, T14)
- [x] None of the above — no threat model update needed

## Notes

<!-- Anything reviewers or QA testers should know -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
