### PR TITLE
Sync sidebar and package.json version with the release process

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,6 +16,7 @@ Container-bound Scripts use the **HEAD** by default. Once you've run `npm run de
 feature-branch → develop   (PR + code review)
 develop        → main      (PR containing manual QA instructions = release gate)
 main                       (run ./scripts/release.sh to publish)
+main           → develop   (back-merge PR, opened automatically by release.sh — see below)
 ```
 
 ## Release Process
@@ -30,6 +31,18 @@ main                       (run ./scripts/release.sh to publish)
 This script builds the project, pushes to HEAD, snapshots it as a new immutable version, and repoints the Marketplace deployment. It enforces the `main` branch requirement and will exit with an error if run from any other branch.
 
 > **Note:** `scripts/release.sh` is a human-only operation. It must never be run by automated tooling or CI.
+
+After the release completes, `release.sh` walks through two more steps — a back-merge and a version bump — described below. Both open PRs for you to review and merge; the script never merges anything itself, since `main` and `develop` both require PR review.
+
+## Back-Merge (main → develop)
+
+`release.sh` automatically opens a PR from `main` into `develop` (or reports that there's nothing to sync, if they already match) and pauses, waiting for you to merge it in GitHub before continuing. This exists so the version-bump PR that follows lands as a clean, single-line diff — if the bump were cut from `main` before `develop` had caught up, its PR would also carry forward everything else `main` has that `develop` doesn't yet.
+
+## Version Number
+
+`package.json`'s `version` field (`N.0.0`, where `N` is the release/Apps Script version number) is the single source of truth for the version shown in the sidebar footer. The build injects it into `dist/Sidebar.html` at compile time — nothing else needs to be hand-edited.
+
+Because clasp only assigns a version number *after* a release deploys, the version can't be bumped to `N` until release `N` is already live — bumping then would mean release `N`'s own sidebar still shows `N-1`. Instead, once the back-merge above is done, `release.sh` prompts to bump to `N+1`, giving that bump a full development cycle to land on `develop` before release `N+1` actually ships. If you accept the prompt, it opens a small PR (`chore/bump-version-vN+1`) against `develop` — review and merge it before the next release.
 
 ## Note on Concurrent Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gas-project",
-  "version": "1.0.0",
+  "version": "8.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gas-project",
-      "version": "1.0.0",
+      "version": "8.0.0",
       "devDependencies": {
         "@google/clasp": "^3.4.1",
         "@rollup/plugin-node-resolve": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gas-project",
-  "version": "1.0.0",
+  "version": "8.0.0",
   "description": "Google Apps Script project with TypeScript, Rollup, and Clasp",
   "private": true,
   "type": "module",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,6 +23,16 @@ import { resolve } from "path";
  */
 
 /**
+ * Extracts the major version number from package.json (e.g. "8.0.0" -> "8").
+ * This is the single source of truth for the sidebar's displayed version —
+ * see the {{VERSION}} placeholder in tool-list.ts's footer.
+ */
+function readMajorVersion() {
+  const pkg = JSON.parse(readFileSync(resolve("package.json"), "utf-8"));
+  return pkg.version.split(".")[0];
+}
+
+/**
  * Inline plugin: assembles dist/Sidebar.html from template + compiled JS + CSS.
  */
 function inlineSidebarHtml({ template, css }) {
@@ -31,18 +41,21 @@ function inlineSidebarHtml({ template, css }) {
     buildStart() {
       this.addWatchFile(resolve(css));
       this.addWatchFile(resolve(template));
+      this.addWatchFile(resolve("package.json"));
     },
     generateBundle(_options, bundle) {
       const chunkKey = Object.keys(bundle).find((k) => bundle[k].type === "chunk");
-      const code = chunkKey ? bundle[chunkKey].code : "";
+      const rawCode = chunkKey ? bundle[chunkKey].code : "";
 
       const templateContent = readFileSync(resolve(template), "utf-8");
       const cssContent = readFileSync(resolve(css), "utf-8");
+      const version = readMajorVersion();
 
       // Replacer functions (not plain strings) — String.replace() treats a string
       // replacement's "$" sequences specially ($$, $&, $1, etc.), which would
       // silently corrupt any such sequence occurring in the compiled JS or CSS
       // (e.g. a literal "$" immediately before a template-literal interpolation).
+      const code = rawCode.replace("{{VERSION}}", () => version);
       const assembled = templateContent
         .replace("{{STYLES}}", () => `<style>\n${cssContent}\n</style>`)
         .replace("{{SCRIPTS}}", () => `<script>\n${code}\n</script>`);

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -78,3 +78,42 @@ echo "→ Creating GitHub release..."
 gh release create "$TAG" --generate-notes --title "$TAG"
 
 echo "✓ Released version $VERSION to deployment $DEPLOYMENT_ID (tagged $TAG)"
+
+# Sync main back into develop before bumping the version, so the version-bump
+# PR below stays a clean, single-line diff instead of also carrying forward
+# whatever else has landed only on main. This only opens the PR — merging it
+# still requires human review (main and develop both require it), so we pause
+# here rather than merging it ourselves.
+echo "→ Opening back-merge PR (main → develop) to keep branches in sync..."
+if BACKMERGE_PR_URL=$(gh pr create --base develop --head main \
+  --title "chore: sync main back into develop after v$VERSION" \
+  --body "Back-merges main into develop after releasing v$VERSION, so develop reflects everything that shipped." 2>&1); then
+  echo "✓ Opened back-merge PR: $BACKMERGE_PR_URL"
+  read -p "Merge that PR in GitHub, then press Enter here to continue (or Ctrl+C to stop and handle the version bump manually later)... "
+else
+  echo "  No back-merge needed (main and develop already match): $BACKMERGE_PR_URL"
+fi
+
+# The sidebar footer and package.json version are meant to already read "vN" by
+# the time release N ships — which only works if we bump to N+1 right after
+# release N completes, so the bump has a full development cycle to land before
+# the next release. See docs/releasing.md.
+NEXT_VERSION=$((VERSION + 1))
+read -p "Bump internal version to v$NEXT_VERSION for the next release cycle? (y/N) " BUMP_CONFIRM
+if [ "$BUMP_CONFIRM" = "y" ] || [ "$BUMP_CONFIRM" = "Y" ]; then
+  BUMP_BRANCH="chore/bump-version-v$NEXT_VERSION"
+  echo "→ Bumping version to $NEXT_VERSION.0.0..."
+  git checkout -b "$BUMP_BRANCH"
+  # --no-git-tag-version: npm's default vX.Y.Z tag would collide with this
+  # script's own release tags (e.g. v8).
+  npm version --no-git-tag-version "$NEXT_VERSION.0.0"
+  git add package.json package-lock.json
+  git commit -m "chore: bump version to v$NEXT_VERSION"
+  git push origin "$BUMP_BRANCH"
+  PR_URL=$(gh pr create --base develop --title "chore: bump version to v$NEXT_VERSION" \
+    --body "Prepares the sidebar and package.json version for the next release cycle (v$NEXT_VERSION), following release of v$VERSION.")
+  echo "✓ Opened bump PR: $PR_URL"
+  git checkout main
+else
+  echo "Skipped version bump. Remember to bump package.json to $NEXT_VERSION.0.0 before v$NEXT_VERSION ships."
+fi

--- a/src/client/panels/tool-list.ts
+++ b/src/client/panels/tool-list.ts
@@ -96,7 +96,7 @@ export class ToolListPanel implements Panel {
         </button>
       </div>
       <div class="status-footer">
-        <strong>SSI Toolkit v6</strong>
+        <strong>SSI Toolkit v{{VERSION}}</strong>
       </div>
     `;
   }


### PR DESCRIPTION
## Summary

- Sidebar footer version was a hardcoded string that had drifted from the actual deployed release (showed v6 while Marketplace was on v7); `package.json`'s version is now the single source of truth, injected into the sidebar at build time.
- `release.sh` now opens a `main → develop` back-merge PR after each release, then a version-bump PR that prepares the next release's number ahead of time — so by the time release N ships, its sidebar already reads vN.
- `package.json` bumped to `8.0.0` to reflect the actual current deployment (v7) plus one, per the new "bump ahead" convention.

## Manual QA

1. Run `npm run build` and confirm `dist/Sidebar.html` contains `SSI Toolkit v8` in the footer.
2. Open the add-on sidebar in a test Sheet and confirm the footer shows the correct version.
3. Review `scripts/release.sh`'s new back-merge and version-bump prompts by reading the script (do not run `release.sh` itself — human-only).

> Complete for PRs targeting `main`. Mark N/A with reason for PRs targeting `develop`.

N/A (develop-targeting PR) — no runtime tool behavior changed, only the sidebar footer text and the release script.

- [ ] Add-on menu appears after opening a Sheet
- [ ] Sidebar opens without errors
- [ ] Import Drive Links — imports files from a folder
- [ ] Extract Text — extracts text from a Doc/PDF/image
- [ ] Sample Rows — samples rows reproducibly with a seed
- [ ] Run AI — batch inference completes and writes output column
- [ ] Tested on a Sheet the tester does not own (shared access)

## Security

- [x] None of the above — no threat model update needed

## Notes

`scripts/release.sh` changes are untested by CI (human-only script, consistent with existing convention). Verified locally via `npm run build` and the full
lint/typecheck/format/test suite (920 tests passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)