### PR TITLE
chore: bump version to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gas-project",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gas-project",
-      "version": "8.0.0",
+      "version": "9.0.0",
       "devDependencies": {
         "@google/clasp": "^3.4.1",
         "@rollup/plugin-node-resolve": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gas-project",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "Google Apps Script project with TypeScript, Rollup, and Clasp",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Prepares the sidebar and package.json version for the next release cycle (v9), following release of v8.